### PR TITLE
Missile cost rebalance

### DIFF
--- a/BahaTurret/Distribution/GameData/BDArmory/Parts/agm-86Cruise/agm86.cfg
+++ b/BahaTurret/Distribution/GameData/BDArmory/Parts/agm-86Cruise/agm86.cfg
@@ -22,7 +22,7 @@ node_stack_top = 0.0, 0.25582, 0, 0, 1, 0, 0
 // --- editor parameters ---
 TechRequired = precisionEngineering
 entryCost = 2100
-cost = 950
+cost = 2400
 category = none
 subcategory = 0
 title = AGM-86C Cruise Missile

--- a/BahaTurret/Distribution/GameData/BDArmory/Parts/aim-120/amraam.cfg
+++ b/BahaTurret/Distribution/GameData/BDArmory/Parts/aim-120/amraam.cfg
@@ -22,7 +22,7 @@ PART
 	// --- editor parameters ---
 	TechRequired = precisionEngineering
 	entryCost = 2100
-	cost = 950
+	cost = 2000
 	category = none
 	subcategory = 0
 	title = AIM-120 AMRAAM Missile

--- a/BahaTurret/Distribution/GameData/BDArmory/Parts/clusterBomb/clusterBomb.cfg
+++ b/BahaTurret/Distribution/GameData/BDArmory/Parts/clusterBomb/clusterBomb.cfg
@@ -21,7 +21,7 @@ node_stack_top = 0.0, 0.25, 0, 0, 1, 0, 0
 // --- editor parameters ---
 TechRequired = precisionEngineering
 entryCost = 2100
-cost = 950
+cost = 150
 category = none
 subcategory = 0
 title = CBU-87 Cluster Bomb

--- a/BahaTurret/Distribution/GameData/BDArmory/Parts/harm/harm.cfg
+++ b/BahaTurret/Distribution/GameData/BDArmory/Parts/harm/harm.cfg
@@ -21,7 +21,7 @@ PART
 	// --- editor parameters ---
 	TechRequired = precisionEngineering
 	entryCost = 2100
-	cost = 950
+	cost = 568
 	category = none
 	subcategory = 0
 	title = AGM-88 HARM Missile

--- a/BahaTurret/Distribution/GameData/BDArmory/Parts/hekv1/hekv1.cfg
+++ b/BahaTurret/Distribution/GameData/BDArmory/Parts/hekv1/hekv1.cfg
@@ -21,7 +21,7 @@ node_stack_top = 0.0, 0.1232686, 0.0, 0, 1, 0, 0
 // --- editor parameters ---
 TechRequired = precisionEngineering
 entryCost = 2100
-cost = 950
+cost = 4000
 category = none
 subcategory = 0
 title = HE-KV-1 Missile (BROKEN)

--- a/BahaTurret/Distribution/GameData/BDArmory/Parts/hellfireMissile/hellfireMissile.cfg
+++ b/BahaTurret/Distribution/GameData/BDArmory/Parts/hellfireMissile/hellfireMissile.cfg
@@ -21,7 +21,7 @@ PART
 	// --- editor parameters ---
 	TechRequired = precisionEngineering
 	entryCost = 2100
-	cost = 650
+	cost = 220
 	category = none
 	subcategory = 0
 	title = AGM-114 Hellfire Missile

--- a/BahaTurret/Distribution/GameData/BDArmory/Parts/jdamMk83/jdam.cfg
+++ b/BahaTurret/Distribution/GameData/BDArmory/Parts/jdamMk83/jdam.cfg
@@ -21,7 +21,7 @@ node_stack_top = 0.0, 0.1779008, 0.2834791, 0, 1, 0, 0
 // --- editor parameters ---
 TechRequired = precisionEngineering
 entryCost = 2100
-cost = 950
+cost = 200
 category = none
 subcategory = 0
 title = Mk83 JDAM Bomb

--- a/BahaTurret/Distribution/GameData/BDArmory/Parts/maverick/maverickMissile.cfg
+++ b/BahaTurret/Distribution/GameData/BDArmory/Parts/maverick/maverickMissile.cfg
@@ -21,7 +21,7 @@ PART
 	// --- editor parameters ---
 	TechRequired = precisionEngineering
 	entryCost = 2100
-	cost = 650
+	cost = 400
 	category = none
 	subcategory = 0
 	title = AGM-65 Maverick Missile

--- a/BahaTurret/Distribution/GameData/BDArmory/Parts/mk82Bomb/mk82Bomb.cfg
+++ b/BahaTurret/Distribution/GameData/BDArmory/Parts/mk82Bomb/mk82Bomb.cfg
@@ -21,7 +21,7 @@ node_stack_top = 0.0, 0.1365, 0.15, 0, 1, 0, 0
 // --- editor parameters ---
 TechRequired = precisionEngineering
 entryCost = 2100
-cost = 950
+cost = 50
 category = none
 subcategory = 0
 title = Mk82 Bomb

--- a/BahaTurret/Distribution/GameData/BDArmory/Parts/mk82BombBrake/mk82BombBrake.cfg
+++ b/BahaTurret/Distribution/GameData/BDArmory/Parts/mk82BombBrake/mk82BombBrake.cfg
@@ -21,7 +21,7 @@ node_stack_top = 0.0, 0.1365, 0.15, 0, 1, 0, 0
 // --- editor parameters ---
 TechRequired = precisionEngineering
 entryCost = 2100
-cost = 950
+cost = 75
 category = none
 subcategory = 0
 title = Mk82 SnakeEye Bomb

--- a/BahaTurret/Distribution/GameData/BDArmory/Parts/pac-3/pac3.cfg
+++ b/BahaTurret/Distribution/GameData/BDArmory/Parts/pac-3/pac3.cfg
@@ -22,7 +22,7 @@ PART
 	// --- editor parameters ---
 	TechRequired = precisionEngineering
 	entryCost = 2100
-	cost = 950
+	cost = 4000
 	category = none
 	subcategory = 0
 	title = PAC-3 Intercept Missile

--- a/BahaTurret/Distribution/GameData/BDArmory/Parts/rbs-15/rbs15.cfg
+++ b/BahaTurret/Distribution/GameData/BDArmory/Parts/rbs-15/rbs15.cfg
@@ -21,7 +21,7 @@ PART
 	// --- editor parameters ---
 	TechRequired = precisionEngineering
 	entryCost = 2100
-	cost = 950
+	cost = 2000
 	category = none
 	subcategory = 0
 	title = RBS-15 Cruise Missile

--- a/BahaTurret/Distribution/GameData/BDArmory/Parts/sidewinder/sidewinder.cfg
+++ b/BahaTurret/Distribution/GameData/BDArmory/Parts/sidewinder/sidewinder.cfg
@@ -21,7 +21,7 @@ PART
 	// --- editor parameters ---
 	TechRequired = precisionEngineering
 	entryCost = 2100
-	cost = 950
+	cost = 1200
 	category = none
 	subcategory = 0
 	title = AIM-9 Sidewinder Missile

--- a/BahaTurret/Distribution/GameData/BDArmory/Parts/towMissile/towMissile.cfg
+++ b/BahaTurret/Distribution/GameData/BDArmory/Parts/towMissile/towMissile.cfg
@@ -21,7 +21,7 @@ PART
 	// --- editor parameters ---
 	TechRequired = precisionEngineering
 	entryCost = 2100
-	cost = 950
+	cost = 120
 	category = none
 	subcategory = 0
 	title = BGM-71 Tow Missile


### PR DESCRIPTION
I am not experienced with modding, but cost values were really weird so I decided to change them in case somebody wants to make a career-mode war DMP server :D 
They are, in general, 1/500 of the real cost values in present-day US dollars. However, many of them have different values for various gameplay reasons. I didn't want a very hardcore approach, so the missiles don't cost more than aircraft, but I think that at least for air-air missiles, the cost should encourage people to use guns whenever missiles are not needed, at least on career war servers ;)
Do you agree with my values, or should I change something?
