### PR TITLE
Vulcan mass changes

### DIFF
--- a/BahaTurret/Distribution/GameData/BDArmory/Parts/20mmVulcan/vulcanTurret.cfg
+++ b/BahaTurret/Distribution/GameData/BDArmory/Parts/20mmVulcan/vulcanTurret.cfg
@@ -31,7 +31,7 @@ PART
 	attachRules = 0,1,0,0,1
 
 	// --- standard part parameters ---
-	mass = 0.4
+	mass = 0.2
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2

--- a/BahaTurret/Distribution/GameData/BDArmory/Parts/hiddenVulcan/hiddenVulcan.cfg
+++ b/BahaTurret/Distribution/GameData/BDArmory/Parts/hiddenVulcan/hiddenVulcan.cfg
@@ -31,7 +31,7 @@ description = A 6 barrel 20x102mm rotary cannon.
 attachRules = 0,1,0,0,1
 
 // --- standard part parameters ---
-mass = 0.3
+mass = 0.1
 dragModelType = default
 maximum_drag = 0.2
 minimum_drag = 0.2


### PR DESCRIPTION
Fixed Vulcan mass change from 0.3 to 0.1, turret Vulcan mass change from 0.4 to 0.2. Both used to be unrealistically high, moreover, the CoM shift when mounting Vulcan on the front of a plane could seriously impact maneuverability or even flyability, this way it's much less problematic.

BTW the turret vulcan is heavier than normal cuz the turret rotation mechanism and such stuff has to add some mass to the gun, also cuz balance.