### PR TITLE
Feature proposal: firing burst length for guard mode

### DIFF
--- a/BahaTurret/MissileFire.cs
+++ b/BahaTurret/MissileFire.cs
@@ -391,6 +391,11 @@ namespace BahaTurret
          UI_FloatRange(minValue = 1f, maxValue = 60f, stepIncrement = 1f, scene = UI_Scene.All)] public float
             targetScanInterval = 3;
 
+        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Firing Burst Length"),
+         UI_FloatRange(minValue = 0f, maxValue = 60f, stepIncrement = 0.5f, scene = UI_Scene.All)]
+        public float
+            fireBurstLength = 0;
+
         [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Field of View"),
          UI_FloatRange(minValue = 10f, maxValue = 360f, stepIncrement = 10f, scene = UI_Scene.All)] public float
             guardAngle = 360;
@@ -2719,7 +2724,8 @@ namespace BahaTurret
                         }
                         weapon.legacyGuardTarget = guardTarget;
                         weapon.autoFireStartTime = Time.time;
-                        weapon.autoFireDuration = targetScanInterval/2;
+                        //weapon.autoFireDuration = targetScanInterval / 2;
+                        weapon.autoFireDuration = (fireBurstLength < 1) ? targetScanInterval / 2 : fireBurstLength;
                         weapon.autoRippleRate = rippleFire ? rippleRPM : 0;
                     }
                 }
@@ -2732,7 +2738,8 @@ namespace BahaTurret
                     {
                         weapon.legacyTargetVessel = guardTarget;
                         weapon.autoFireTimer = Time.time;
-                        weapon.autoFireLength = 3*targetScanInterval/4;
+                        //weapon.autoFireLength = 3 * targetScanInterval / 4;
+                        weapon.autoFireLength = (fireBurstLength < 1) ? targetScanInterval / 2 : fireBurstLength;
                     }
                 }
             }

--- a/BahaTurret/ModuleWeapon.cs
+++ b/BahaTurret/ModuleWeapon.cs
@@ -1043,6 +1043,7 @@ namespace BahaTurret
                         pBullet.mass = bulletMass;
                         pBullet.ballisticCoefficient = bulletBallisticCoefficient;
                         pBullet.flightTimeElapsed = 0;
+                        pBullet.maxDistance = Mathf.Max(maxTargetingRange, maxEffectiveDistance);
 
                         timeFired = Time.time;
 

--- a/BahaTurret/PooledBullet.cs
+++ b/BahaTurret/PooledBullet.cs
@@ -73,7 +73,7 @@ namespace BahaTurret
         Vector3 sourceOriginalV;
         bool hasBounced = false;
 
-        float maxDistance;
+        public float maxDistance;
 
         //bool isUnderwater = false;
 
@@ -97,7 +97,9 @@ namespace BahaTurret
             startPosition = transform.position;
             collisionEnabled = false;
 
-            maxDistance = Mathf.Clamp(BDArmorySettings.PHYSICS_RANGE, 2500, BDArmorySettings.MAX_BULLET_RANGE);
+            //maxDistance = Mathf.Clamp(BDArmorySettings.PHYSICS_RANGE, 2500, BDArmorySettings.MAX_BULLET_RANGE);
+            //maxDistance set to gun's weapons range by ModuleWeapon!
+
             if (!wasInitiated)
             {
                 //projectileColor.a = projectileColor.a/2;

--- a/BahaTurret/UI/BDArmorySettings.cs
+++ b/BahaTurret/UI/BDArmorySettings.cs
@@ -955,6 +955,17 @@ namespace BahaTurret
                         ActiveWeaponManager.targetScanInterval.ToString(), leftLabel);
                     guardLines++;
 
+                    string burstLabel = "Burst Length";
+                    GUI.Label(new Rect(leftIndent, (guardLines * entryHeight), 85, entryHeight), burstLabel, leftLabel);
+                    ActiveWeaponManager.fireBurstLength =
+                        GUI.HorizontalSlider(
+                            new Rect(leftIndent + (90), (guardLines * entryHeight), contentWidth - 90 - 38, entryHeight),
+                            ActiveWeaponManager.fireBurstLength, 0, 60);
+                    ActiveWeaponManager.fireBurstLength = Mathf.Round(ActiveWeaponManager.fireBurstLength*2)/2;
+                    GUI.Label(new Rect(leftIndent + (contentWidth - 35), (guardLines * entryHeight), 35, entryHeight),
+                        ActiveWeaponManager.fireBurstLength.ToString(), leftLabel);
+                    guardLines++;
+
                     GUI.Label(new Rect(leftIndent, (guardLines*entryHeight), 85, entryHeight), "Field of View",
                         leftLabel);
                     float guardAngle = ActiveWeaponManager.guardAngle;


### PR DESCRIPTION
Dear BDAc team,

I'd like to propose the following change to the guard mode firing: add guard mode burst length (to complement fire interval).

Rationale:
Right now we can set the firing interval for guard mode. 
However, when set to N seconds, in the coding that means the selected guns will fire for 3/4 * N seconds.

I'd like to setup guards with different patterns, such as:
1) LONG FIRING .... SHORT PAUSE    [current behaviour]
2) FIRE .. PAUSE .. FIRE .. PAUSE
3) SHORT BURST .... LONG PAUSE

With the additional parameter "burst length", in combination with the existing firing interval, this can be achieved.
