### PR TITLE
Correct version and compatibility metadata

### DIFF
--- a/BahaTurret/Distribution/GameData/BDArmory/BDArmory.version
+++ b/BahaTurret/Distribution/GameData/BDArmory/BDArmory.version
@@ -13,24 +13,24 @@
         "MAJOR":0,
         "MINOR":2,
         "PATCH":0,
-        "BUILD":0
+        "BUILD":99
     },
     "KSP_VERSION":
     {
         "MAJOR":1,
         "MINOR":2,
-        "PATCH":2
+        "PATCH":9
     },
     "KSP_VERSION_MIN":
     {
         "MAJOR":1,
         "MINOR":2,
-        "PATCH":0
+        "PATCH":9
     },
     "KSP_VERSION_MAX":
     {
         "MAJOR":1,
         "MINOR":2,
-        "PATCH":2
+        "PATCH":9
     }
 }

--- a/BahaTurret/Properties/AssemblyInfo.cs
+++ b/BahaTurret/Properties/AssemblyInfo.cs
@@ -18,8 +18,8 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("0.2.0.0")]
-[assembly: AssemblyFileVersion("0.2.0.0")]
+[assembly: AssemblyVersion("0.2.0.99")]
+[assembly: AssemblyFileVersion("0.2.0.99")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.


### PR DESCRIPTION
Sorry folks, I realise this probably isn't the best destination branch, but you didn't seem to have one for the 1.2.9 prereleases.

Current prereleases intended for KSP 1.2.9 include an AVC `.version` file that declares them as compatible with KSP 1.2.2. They also use exactly the same version as the stable KSP 1.2.2 release. These two facts will cause tools that rely on the .version file, such as AVC and the CKAN indexer, to give misleading and probably catastrophic results.

Pull request just updates the `.version` file to accurately reflect KSP compatibility, as well as bumps the build in the version number to indicate that it is actually a different build.