### PR TITLE
Fixing nullrefs

### DIFF
--- a/BDArmory/ModuleWeapon.cs
+++ b/BDArmory/ModuleWeapon.cs
@@ -1814,7 +1814,8 @@ namespace BDArmory
                 {
                     heatGauge = InitHeatGauge();
                 }
-                heatGauge.SetValue(heat, maxHeat / 3, maxHeat);
+
+                heatGauge?.SetValue(heat, maxHeat / 3, maxHeat);    //null check
             }
             else if (heatGauge != null && heat < maxHeat / 4)
             {
@@ -1975,12 +1976,15 @@ namespace BDArmory
         {
             ProtoStageIconInfo v = part.stackIcon.DisplayInfo();
 
-            v.SetMsgBgColor(XKCDColors.DarkRed);
-            v.SetMsgTextColor(XKCDColors.Orange);
-            v.SetMessage("Overheat");
-            v.SetProgressBarBgColor(XKCDColors.DarkRed);
-            v.SetProgressBarColor(XKCDColors.Orange);
-
+            // fix nullref if no stackicon exists
+            if (v != null)
+            {
+                v.SetMsgBgColor(XKCDColors.DarkRed);
+                v.SetMsgTextColor(XKCDColors.Orange);
+                v.SetMessage("Overheat");
+                v.SetProgressBarBgColor(XKCDColors.DarkRed);
+                v.SetProgressBarColor(XKCDColors.Orange);
+            }
             return v;
         }
 

--- a/BDArmory/TargetSignatureData.cs
+++ b/BDArmory/TargetSignatureData.cs
@@ -46,6 +46,13 @@ namespace BDArmory
 			signalStrength = _signalStrength;
 
 			targetInfo = v.gameObject.GetComponent<TargetInfo> ();
+
+            // vessel never been picked up on radar before: create new targetinfo record
+            if (targetInfo is null)
+            {
+                targetInfo = v.gameObject.AddComponent<TargetInfo>();
+            }
+
 			team = BDArmorySettings.BDATeams.None;
 
 			if(targetInfo)


### PR DESCRIPTION
1. fix nullrefs when switching to terminal radar guidance
2. fix nullrefs with weapons without staging icons overheating
