### PR TITLE
Explosion force fix and minor edit to damage transfer to stop things from spontaneously exploding when something like spaced armor is struck

### DIFF
--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -111,7 +111,7 @@ namespace BDArmory.FX
         }
 
         public static float ExplosionHeatMultiplier = 4200;
-        public static float ExplosionImpulseMultiplier = 1.5f;
+        public static float ExplosionImpulseMultiplier = 0.1f; //adjust as necessary to increase/decrease the force of HE weapons
 
 		public static void DoExplosionRay(Ray ray, float power, float heat, float maxDistance, ref List<Part> ignoreParts, ref List<DestructibleBuilding> ignoreBldgs, Vessel sourceVessel = null)
 		{

--- a/BDArmory/PooledBullet.cs
+++ b/BDArmory/PooledBullet.cs
@@ -365,7 +365,7 @@ namespace BDArmory
 
                             float overKillHeatDamage = (float) (hitPart.temperature - hitPart.maxTemp);
 
-                            if (overKillHeatDamage > 0)
+                            if ((overKillHeatDamage > 100 && hitPart.mass < 0.01) || overKillHeatDamage > 90000)    //only kicks in if damage overheat is excessive (insanely powerful weapon hits tank), or if the hit part is very very lightweight to prevent exploiting or using weak trash as throw-away armor.
                             //if the part is destroyed by overheating, we want to add the remaining heat to attached parts.  This prevents using tiny parts as armor
                             {
                                 overKillHeatDamage *= hitPart.crashTolerance; //reset to raw damage


### PR DESCRIPTION
Explosion force fix (no more 30mm gauss cannon knocking 100t tanks around like golf balls) and minor edit to damage transfer to stop things from spontaneously exploding when something like spaced armor is struck