### PR TITLE
Fix for KSP 1.3.1

### DIFF
--- a/BDArmory/Misc/BDAEditorCategory.cs
+++ b/BDArmory/Misc/BDAEditorCategory.cs
@@ -29,8 +29,8 @@ namespace BDArmory.Misc
 			Texture2D iconTex = GameDatabase.Instance.GetTexture("BDArmory/Textures/icon", false);
 
 			RUI.Icons.Selectable.Icon icon = new RUI.Icons.Selectable.Icon("BDArmory", iconTex, iconTex, false);
-		    
-            PartCategorizer.Category filter = PartCategorizer.Instance.filters.Find(f => f.button.categoryName == "Filter by function");
+
+            PartCategorizer.Category filter = PartCategorizer.Instance.filters.Find(f => f.button.categorydisplayName == "#autoLOC_453547");
 
 	        PartCategorizer.AddCustomSubcategoryFilter(filter, customCategoryName, customDisplayCategoryName, icon,
 	            p => availableParts.Contains(p));


### PR DESCRIPTION
This will fix the BDArmory tab not showing on KSP 1.3.1