### PR TITLE
Fix for #305 - drag estimations

### DIFF
--- a/BDArmory/Control/BDAirspeedControl.cs
+++ b/BDArmory/Control/BDAirspeedControl.cs
@@ -192,8 +192,7 @@ namespace BDArmory.Control
         float GravAccel()
         {
             Vector3 geeVector = FlightGlobals.getGeeForceAtPosition(vessel.CoM);
-            float gravAccel = geeVector.magnitude * Mathf.Cos(Mathf.Deg2Rad * Vector3.Angle(FlightGlobals.getUpAxis(), vessel.velocityD));
-
+            float gravAccel = geeVector.magnitude * Mathf.Cos(Mathf.Deg2Rad * Vector3.Angle(-geeVector, vessel.velocityD));
             return gravAccel;
         }
 

--- a/BDArmory/Control/BDAirspeedControl.cs
+++ b/BDArmory/Control/BDAirspeedControl.cs
@@ -144,10 +144,10 @@ namespace BDArmory.Control
 
 
             //estimate drag
-            float estimatedCurrentAccel = finalThrust/vesselMass;
-            float actualCurrentAccel = Vector3.Project(vessel.acceleration, vessel.ReferenceTransform.up).magnitude*
-                                       Mathf.Sign(Vector3.Dot(vessel.acceleration, -vessel.ReferenceTransform.up));
-            float accelError = (actualCurrentAccel - estimatedCurrentAccel)/2;
+            float estimatedCurrentAccel = finalThrust / vesselMass - GravAccel();
+            Vector3 vesselAccelProjected = Vector3.Project(vessel.acceleration_immediate, vessel.velocityD.normalized);
+            float actualCurrentAccel = vesselAccelProjected.magnitude * Mathf.Sign(Vector3.Dot(vesselAccelProjected, vessel.velocityD.normalized));
+            float accelError = (actualCurrentAccel - estimatedCurrentAccel); // /2 -- why divide by 2 here?
             dragAccel = accelError;
 
             possibleAccel += accel;
@@ -192,8 +192,7 @@ namespace BDArmory.Control
         float GravAccel()
         {
             Vector3 geeVector = FlightGlobals.getGeeForceAtPosition(vessel.CoM);
-            float gravAccel = Vector3.Project(geeVector, vessel.ReferenceTransform.up).magnitude;
-            gravAccel *= Mathf.Sign(Vector3.Dot(vessel.ReferenceTransform.up, geeVector));
+            float gravAccel = geeVector.magnitude * Mathf.Cos(Mathf.Deg2Rad * Vector3.Angle(FlightGlobals.getUpAxis(), vessel.velocityD));
 
             return gravAccel;
         }


### PR DESCRIPTION
Little fix for drag estimation - current results in rolling off the throttle in a climb even when below target speed.

* Used vessel.VelocityD instead of the craft transform; while this normally makes things more accurate I'm a little concerned about what will happen if the craft's velocity vector is way off it's nose, say for post-stall supermaneuverable craft. I don't have any to test with. Hopefully that is the right velocity vector too... docs are thin on the ground there. Reason is simply to cope with angle of attack.
* Used scalar projection in GravAccel() just to make it a bit simpler
* Estimated drag now takes current gravity drag into account - this fixes backing off throttle in a climb.
* Using vessel.acceleration_immediate to avoid transient changes resulting in unwanted throttle changes - vessel.acceleration is averaged in some way and is a bit slow for aerobatic aircraft.

End result is that craft climb on full throttle when they want & I believe some more rare conditions are also fixed.