### PR TITLE
Update BDArmory.version

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/BDArmory.version
+++ b/BDArmory/Distribution/GameData/BDArmory/BDArmory.version
@@ -1,7 +1,7 @@
 ﻿{
     "NAME":"BDArmory",
     "URL":"https://github.com/PapaJoesSoup/BDArmory/raw/master/BahaTurret/Distribution/GameData/BDArmory/BDArmory.version",
-    "DOWNLOAD":"https://github.com/PapaJoesSoup/BDArmory/releases/tag/v0.2.2.0,
+    "DOWNLOAD":"https://github.com/PapaJoesSoup/BDArmory/releases/tag/v0.2.2.0",
     "GITHUB":
     {
         "USERNAME":"PapaJoesSoup",


### PR DESCRIPTION
Missing quotation mark is preventing the last two versions of BDArmory being listed on CKAN. Also, this still says v0.2.2.0, even though v0.3.0.0 is the latest release.