### PR TITLE
Radar/Chaff balancing updates

### DIFF
--- a/BDArmory/Parts/ModuleECMJammer.cs
+++ b/BDArmory/Parts/ModuleECMJammer.cs
@@ -125,6 +125,7 @@ namespace BDArmory.Parts
 
         void EnsureVesselJammer()
         {
+            /*
             if (vesselJammer == null)
             {
                 return;
@@ -137,6 +138,7 @@ namespace BDArmory.Parts
             {
                 return;
             }
+            */
 
             if (!vesselJammer || vesselJammer.vessel != vessel)
             {

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -533,6 +533,14 @@ namespace BDArmory.Radar
                 if (loadedvessels.Current == null) continue;
                 if (!loadedvessels.Current.loaded) continue;
 
+                // IFF code check to prevent friendly lock-on (neutral vessel without a weaponmanager WILL be lockable!)
+                MissileFire wm = loadedvessels.Current.FindPartModuleImplementing<MissileFire>();
+                if (wm != null)
+                {
+                    if (missile.Team == wm.team)
+                        continue;
+                }                
+
                 // ignore self, ignore behind ray
                 Vector3 vectorToTarget = (loadedvessels.Current.transform.position - ray.origin);
                 if (((vectorToTarget).sqrMagnitude < RADAR_IGNORE_DISTANCE_SQR) ||

--- a/BDArmory/TargetSignatureData.cs
+++ b/BDArmory/TargetSignatureData.cs
@@ -162,11 +162,14 @@ namespace BDArmory
 
                 if (vessel != null)
                 {
+                    // chaff check
                     decoyFactor = (1f - RadarUtils.GetVesselChaffFactor(vessel));
+
                     if (decoyFactor > 0f)
                     {
-                        decoyFactor *= UnityEngine.Random.Range(10f, 100f);
-                        posDistortion = Vector3.Cross(UnityEngine.Random.insideUnitSphere, vessel.transform.up) * decoyFactor;      //cross product: if deflection direction directly forward or aft, effect is smaller than if deflection laterally
+                        // with ecm on better chaff effectiveness due to higher modifiedSignature
+                        // higher speed -> missile decoyed further "behind" where the chaff drops (also means that for head-on engagements chaff is most like less effective!)
+                        posDistortion = (vessel.GetSrfVelocity() * -1f * Mathf.Clamp(decoyFactor * decoyFactor, 0f, 0.5f)) + (UnityEngine.Random.insideUnitSphere * UnityEngine.Random.Range(targetInfo.radarModifiedSignature, targetInfo.radarModifiedSignature * targetInfo.radarModifiedSignature) * decoyFactor);
                     }
                 }
 


### PR DESCRIPTION
1. IFF check to prevent friendly radar lock
2. Attempt at chaff rebalance (tricky, maybe chaff is a bit too effective now... only tests will show)
3. fix ecm jammer nullref
