### PR TITLE
KSP 1.4 changes to avoid compilation & runtime errors

### DIFF
--- a/BDArmory/FX/BDAParticleSelfDestruct.cs
+++ b/BDArmory/FX/BDAParticleSelfDestruct.cs
@@ -17,7 +17,7 @@ namespace BDArmory.FX
 
         void Start()
         {
-            if (pEmitter.pe.particleCount == 0)
+            if (pEmitter.ps.particleCount == 0)
             {
                 Destroy(gameObject);
             }

--- a/BDArmory/Radar/ModuleRadar.cs
+++ b/BDArmory/Radar/ModuleRadar.cs
@@ -151,7 +151,7 @@ namespace BDArmory.Radar
         #region Part members
         //locks
         [KSPField(isPersistant = false, guiActive = true, guiActiveEditor = false, guiName = "Current Locks")]
-        private int currLocks;
+        public int currLocks;
         public bool locked
         {
             get { return currLocks > 0; }
@@ -185,7 +185,7 @@ namespace BDArmory.Radar
         {
             get { return radarDetectionCurve.minTime; }
         }
-        [KSPField(isPersistant = false, guiActive = true, guiActiveEditor = true, guiName = "Detection Range")]
+        //[KSPField(isPersistant = false, guiActive = true, guiActiveEditor = true, guiName = "Detection Range")]
         public float radarMaxDistanceDetect
         {
             get { return radarDetectionCurve.maxTime; }
@@ -194,7 +194,7 @@ namespace BDArmory.Radar
         {
             get { return radarLockTrackCurve.minTime; }
         }
-        [KSPField(isPersistant = false, guiActive = true, guiActiveEditor = true, guiName = "Locking Range")]
+        //[KSPField(isPersistant = false, guiActive = true, guiActiveEditor = true, guiName = "Locking Range")]
         public float radarMaxDistanceLockTrack
         {
             get { return radarLockTrackCurve.maxTime; }
@@ -355,7 +355,7 @@ namespace BDArmory.Radar
                 }
             }
         }
-      
+
 
         public override void OnStart(StartState state)
         {


### PR DESCRIPTION
Note: this makes BDA dev branch TECHNICALLY compatible with KSP 1.4 as of avoiding compilation and runtime exceptions.

Most likely still needs work to make it BEHAVE correctly with 1.4, especially regarding:
- radar rcs shader seems to be affected
- potentially particle emitters need to be checked for correct function
