### PR TITLE
Fix #481 modules appearing in weapon manager module list twice

### DIFF
--- a/BDArmory/MissileFire.cs
+++ b/BDArmory/MissileFire.cs
@@ -2856,6 +2856,8 @@ namespace BDArmory
 
         void RefreshModules()
         {
+            radars = vessel.FindPartModulesImplementing<ModuleRadar>();
+
             List<ModuleRadar>.Enumerator rad = radars.GetEnumerator();
             while (rad.MoveNext())
             {
@@ -2864,20 +2866,6 @@ namespace BDArmory
                 if (rad.Current.radarEnabled) rad.Current.EnableRadar();
             }
             rad.Dispose();
-
-            radars = vessel.FindPartModulesImplementing<ModuleRadar>();
-
-            List<ModuleRadar>.Enumerator nRad = radars.GetEnumerator();
-            while (nRad.MoveNext())
-            {
-                if (nRad.Current == null) continue;
-                nRad.Current.EnsureVesselRadarData();
-                if (nRad.Current.radarEnabled)
-                {
-                    nRad.Current.EnableRadar();
-                }
-            }
-            nRad.Dispose();
 
             jammers = vessel.FindPartModulesImplementing<ModuleECMJammer>();
             targetingPods = vessel.FindPartModulesImplementing<ModuleTargetingCamera>();

--- a/BDArmory/Parts/ModuleECMJammer.cs
+++ b/BDArmory/Parts/ModuleECMJammer.cs
@@ -71,13 +71,6 @@ namespace BDArmory.Parts
             base.OnStart(state);
             if (!HighLogic.LoadedSceneIsFlight) return;
             part.force_activate();
-            List<MissileFire>.Enumerator wm = vessel.FindPartModulesImplementing<MissileFire>().GetEnumerator();
-            while (wm.MoveNext())
-            {
-                if (wm.Current == null) continue;
-                wm.Current.jammers.Add(this);
-            }
-            wm.Dispose();
 
             GameEvents.onVesselCreate.Add(OnVesselCreate);
         }

--- a/BDArmory/Radar/ModuleRadar.cs
+++ b/BDArmory/Radar/ModuleRadar.cs
@@ -406,14 +406,6 @@ namespace BDArmory.Radar
                     break;
                 }
                 turr.Dispose();
-                
-                List<MissileFire>.Enumerator wm = vessel.FindPartModulesImplementing<MissileFire>().GetEnumerator();
-                while (wm.MoveNext())
-                {
-                    if (wm.Current == null) continue;
-                    wm.Current.radars.Add(this);
-                }
-                wm.Dispose();
 
                 //GameEvents.onVesselGoOnRails.Add(OnGoOnRails);    //not needed
                 EnsureVesselRadarData();


### PR DESCRIPTION
At some point I made MissileFire refresh modules on start ( https://github.com/PapaJoesSoup/BDArmory/blame/dev/BDArmory/MissileFire.cs#L749 ). 

Since previously it didn't do that, modules were adding themselves to the MissileFire lists on load, which resulted in them appearing in the module list twice. :)