### PR TITLE
Infinite ammo for rockets

### DIFF
--- a/BDArmory/MissileFire.cs
+++ b/BDArmory/MissileFire.cs
@@ -2574,7 +2574,8 @@ namespace BDArmory
                         while (r.MoveNext())
                         {
                             if (r.Current == null) continue;
-                            if (r.Current.resourceName != rl.rocketType || !(r.Current.amount > 0)) continue;
+                            if ((r.Current.resourceName != rl.rocketType || !(r.Current.amount > 0)) 
+                                && !BDArmorySettings.INFINITE_AMMO) continue;
                             hasRocket = true;
                             break;
                         }
@@ -2610,7 +2611,7 @@ namespace BDArmory
                         while (r.MoveNext())
                         {
                             if (r.Current == null) continue;
-                            if (r.Current.amount > 0) hasRocket = true;
+                            if (r.Current.amount > 0 || BDArmorySettings.INFINITE_AMMO) hasRocket = true;
                             else orl.Current.drawAimer = false;
                         }
                         r.Dispose();

--- a/BDArmory/MissileFire.cs
+++ b/BDArmory/MissileFire.cs
@@ -2112,7 +2112,8 @@ namespace BDArmory
 
                 //dont add empty rocket pods
                 if (weapon.Current.GetWeaponClass() == WeaponClasses.Rocket &&
-                    weapon.Current.GetPart().FindModuleImplementing<RocketLauncher>().GetRocketResource().amount < 1)
+                    weapon.Current.GetPart().FindModuleImplementing<RocketLauncher>().GetRocketResource().amount < 1
+                    && !BDArmorySettings.INFINITE_AMMO)
                 {
                     continue;
                 }

--- a/BDArmory/RocketLauncher.cs
+++ b/BDArmory/RocketLauncher.cs
@@ -548,6 +548,9 @@ namespace BDArmory
 
             int rocketsLeft = (int)Math.Floor(rocketResource.amount);
 
+            if (BDArmorySettings.INFINITE_AMMO && rocketsLeft < 1)
+                rocketsLeft = 1;
+
             if (rocketsLeft >= 1)
             {
                 Transform currentRocketTfm = rockets[rocketsLeft - 1];
@@ -580,7 +583,8 @@ namespace BDArmory
                 rocket.parentRB = part.rb;
 
                 sfAudioSource.PlayOneShot(GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/launch"));
-                rocketResource.amount--;
+                if (!BDArmorySettings.INFINITE_AMMO)
+                    rocketResource.amount--;
 
                 lastRocketsLeft = rocketResource.amount;
             }

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1361,7 +1361,7 @@ namespace BDArmory.UI
                 return;
             }
             BDArmorySettings.INSTAKILL = GUI.Toggle(SLeftRect(line), BDArmorySettings.INSTAKILL, "Instakill");
-            BDArmorySettings.INFINITE_AMMO = GUI.Toggle(SRightRect(line), BDArmorySettings.INFINITE_AMMO, "Infinte Ammo");
+            BDArmorySettings.INFINITE_AMMO = GUI.Toggle(SRightRect(line), BDArmorySettings.INFINITE_AMMO, "Infinite Ammo");
             line++;
             BDArmorySettings.BULLET_HITS = GUI.Toggle(SLeftRect(line), BDArmorySettings.BULLET_HITS, "Bullet Hits");
             BDArmorySettings.EJECT_SHELLS = GUI.Toggle(SRightRect(line), BDArmorySettings.EJECT_SHELLS, "Eject Shells");


### PR DESCRIPTION
Make rocket pods and turrets obey `INFINITE_AMMO` setting.

When it's on, rockets are no longer used up, and empty rocket pods can be fired.
Empty rocket pods will also appear in the weapon list on list update, but toggling `INFINITE_AMMO` does not force an update.

related to #533 