### PR TITLE
Normal distribution

### DIFF
--- a/BDArmory.Core/Extension/PartExtensions.cs
+++ b/BDArmory.Core/Extension/PartExtensions.cs
@@ -300,7 +300,6 @@ namespace BDArmory.Core.Extension
 
         public static Vector3 GetSize(this Part part)
         {
-            var tweakScaleModule = part.Modules["TweakScale"];
 
             var size =  part.GetComponentInChildren<MeshFilter>().mesh.bounds.size;
             
@@ -310,8 +309,9 @@ namespace BDArmory.Core.Extension
             }
 
             float scaleMultiplier = 1f;
-            if (tweakScaleModule != null)
+            if (part.Modules.Contains("TweakScale"))
             {
+                var tweakScaleModule = part.Modules["TweakScale"];
                 scaleMultiplier = tweakScaleModule.Fields["currentScale"].GetValue<float>(tweakScaleModule) /
                                   tweakScaleModule.Fields["defaultScale"].GetValue<float>(tweakScaleModule);
             }

--- a/BDArmory/Misc/VectorUtils.cs
+++ b/BDArmory/Misc/VectorUtils.cs
@@ -5,6 +5,8 @@ namespace BDArmory.Misc
 {
 	public static class VectorUtils
 	{
+        private static System.Random RandomGen = new System.Random();
+
 		/// <param name="referenceRight">Right compared to fromDirection, make sure it's not orthogonal to toDirection, or you'll get unstable signs</param>
 		public static float SignedAngle(Vector3 fromDirection, Vector3 toDirection, Vector3 referenceRight)
 		{
@@ -89,27 +91,17 @@ namespace BDArmory.Misc
         }
 
         /// <returns>Random float distributed with an approximated standard normal distribution</returns>
-        /// <see>https://www.johndcook.com/blog/csharp_phi/</see>
+        /// <see>https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform</see>
         /// <remarks>Note a standard normal variable is technically unbounded</remarks>
         public static float Gaussian()
         {
-            const float a1 = 0.254829592f;
-            const float a2 = -0.284496736f;
-            const float a3 = 1.421413741f;
-            const float a4 = -1.453152027f;
-            const float a5 = 1.061405429f;
-            const float p = 0.3275911f;
-            const float invsqrt2 = 0.70710678118654752440084436210485f;
-
-            float x = UnityEngine.Random.Range(-invsqrt2, invsqrt2);
-            int sign = Math.Sign(x);
-            x = Mathf.Abs(x);
-
-            // A&S formula 7.1.26
-            float t = 1f / (1f + p * x);
-            float y = 1f - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * Mathf.Exp(-x * x);
-
-            return 0.5f * (1f + sign * y);
+            // Technically this will raise an exception if the first random produces a zero
+            try {
+                return Mathf.Sqrt(-2 * Mathf.Log(UnityEngine.Random.value)) * Mathf.Cos(Mathf.PI * UnityEngine.Random.value);
+            }
+            catch (Exception) { // I have no idea what exception Mathf.Log raises when it gets a zero
+                return 0;
+            }
         }
 
 		/// <summary>

--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -248,7 +248,7 @@ namespace BDArmory.Modules
         [KSPField]
         public float roundsPerMinute = 850; //rate of fire
         [KSPField]
-        public float maxDeviation = 1; //inaccuracy standard deviation in degrees
+        public float maxDeviation = 1; //inaccuracy two standard deviations in degrees (two because backwards compatibility :)
         [KSPField]
         public float maxEffectiveDistance = 2500; //used by AI to select appropriate weapon
         [KSPField]
@@ -1072,7 +1072,7 @@ namespace BDArmory.Modules
                         timeFired = Time.time;
                         
                         Vector3 firedVelocity =
-                            VectorUtils.GaussianDirectionDeviation(fireTransform.forward, maxDeviation) * bulletVelocity;
+                            VectorUtils.GaussianDirectionDeviation(fireTransform.forward, maxDeviation / 2) * bulletVelocity;
 
                         firedBullet.transform.position += (part.rb.velocity + Krakensbane.GetFrameVelocityV3f()) * Time.fixedDeltaTime;
                         pBullet.currentVelocity = (part.rb.velocity + Krakensbane.GetFrameVelocityV3f()) + firedVelocity; // use the real velocity, w/o offloading

--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -932,6 +932,7 @@ namespace BDArmory.Modules
             {
                 bool effectsShot = false;
                 //Transform[] fireTransforms = part.FindModelTransforms("fireTransform");
+                for (float iTime = Mathf.Min(Time.time - timeFired - timeGap, TimeWarp.fixedDeltaTime); iTime >= 0; iTime -= timeGap)
                 for (int i = 0; i < fireTransforms.Length; i++)
                 {
                     //if ((BDArmorySettings.INFINITE_AMMO || part.RequestResource(ammoName, requestResourceAmount) > 0))
@@ -1065,17 +1066,18 @@ namespace BDArmory.Modules
 
                         pBullet.ballisticCoefficient = bulletBallisticCoefficient;
 
-                        pBullet.flightTimeElapsed = 0;
+                        pBullet.flightTimeElapsed = iTime;
                         // measure bullet lifetime in time rather than in distance, because distances get very relative in orbit
                         pBullet.timeToLiveUntil = Mathf.Max(maxTargetingRange, maxEffectiveDistance) / bulletVelocity * 1.1f + Time.time;
 
-                        timeFired = Time.time;
+                        timeFired = Time.time - iTime;
                         
                         Vector3 firedVelocity =
                             VectorUtils.GaussianDirectionDeviation(fireTransform.forward, maxDeviation / 2) * bulletVelocity;
 
-                        firedBullet.transform.position += (part.rb.velocity + Krakensbane.GetFrameVelocityV3f()) * Time.fixedDeltaTime;
                         pBullet.currentVelocity = (part.rb.velocity + Krakensbane.GetFrameVelocityV3f()) + firedVelocity; // use the real velocity, w/o offloading
+                        firedBullet.transform.position += (part.rb.velocity + Krakensbane.GetFrameVelocityV3f()) * Time.fixedDeltaTime 
+                                                            + pBullet.currentVelocity * iTime;
 
                         pBullet.sourceVessel = vessel;
                         pBullet.bulletTexturePath = bulletTexturePath;
@@ -2287,7 +2289,7 @@ namespace BDArmory.Modules
             }
             else
             {
-                output.AppendLine($"Rounds Per Minute: {roundsPerMinute}");
+                output.AppendLine($"Rounds Per Minute: {roundsPerMinute * (fireTransforms?.Length ?? 1)}");
                 output.AppendLine($"Ammunition: {ammoName}");
                 output.AppendLine($"Bullet type: {bulletType}");
                 output.AppendLine($"Bullet mass: {Math.Round(binfo.bulletMass,2)} kg");


### PR DESCRIPTION
- Use the correct formula for calculating normal distribution #571
- `maxDeviation` is now actually two standard deviations, which seems to be in line with previous bullet spread
- Fixed a check for Tweakscale throwing errors like crazy when no Tweakscale is present.
- Multiple the config rpm by number of fire transforms for info display #524 
- Weapons may fire multiple times per update #524