### PR TITLE
Duplicated name from 'AGM-114 Hellfire Missile EMP'

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/Parts/hellfireMissile/hellfire_emp.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/hellfireMissile/hellfire_emp.cfg
@@ -5,7 +5,7 @@ PART
 	// 
 
 	// --- general parameters ---
-	name = HellfireEMP
+	name = HellfireEMPII
 	module = Part
 	author = BahamutoD
 


### PR DESCRIPTION
I was parsing my ConfigCache and got a duplicate key exception building a dictionary. Considering I doubt it is intended, I'm proposing a quick fix.
If it is intended, is it possible to disable the .cfg file so the part is not loaded?