### PR TITLE
Fix for ripple fire

### DIFF
--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -2305,6 +2305,7 @@ namespace BDArmory.Modules
                     if (weapCnt.Current == null) continue;
                     if (selectedWeapon.GetShortName() != weapCnt.Current.GetShortName()) continue;
                     weaponRpm = weapCnt.Current.roundsPerMinute;
+		    rippleWeapons.Add(weapCnt.Current);
                     counter += weaponRpm; // grab sum of weapons rpm
 				}
                 weapCnt.Dispose();

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -2311,8 +2311,7 @@ namespace BDArmory.Modules
 
                 gunRippleRpm = counter;
 				//number of seconds between each gun firing; will reduce with increasing RPM or number of guns
-				float timeDelayPerGun = 60f / (weaponRpm * counter);
-
+				float timeDelayPerGun = 60f / gunRippleRpm; // rpm*counter will return the square of rpm now
 				// Now lets act on the filtered list.
 				List<ModuleWeapon>.Enumerator weapon = rippleWeapons.GetEnumerator();
                 while (weapon.MoveNext())


### PR DESCRIPTION
My initial change to permit accurate weapon group weapon rpm count forgot to also change the timeDelayPerGun calc, resulting in the time delay now grabbing the square of total rpm, which causes Barrage to be essentially identical to Salvo, rather than correctly ripple firing linked weapons if Barrage mode is selected.
