### PR TITLE
Guard mode torpedo fix

### DIFF
--- a/BDArmory/Modules/MissileBase.cs
+++ b/BDArmory/Modules/MissileBase.cs
@@ -721,7 +721,7 @@ namespace BDArmory.Modules
         {
             return (ti.isMissile && engageMissile) ||
                     (!ti.isMissile && ti.isFlying && engageAir) ||
-                    ((ti.isLanded || ti.isSplashed) && engageGround) ||
+                    ((ti.isLandedOrSurfaceSplashed || ti.isSplashed) && engageGround) ||
                     (ti.isUnderwater && engageSLW);
         }
 

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -3345,7 +3345,7 @@ namespace BDArmory.Modules
                 item.Dispose();
             }
 
-            else if (target.isLanded)
+            else if (target.isLandedOrSurfaceSplashed)
             {
                 // iterate over weaponTypesGround and pick suitable one based on engagementRange (and dynamic launch zone for missiles)
                 // Prioritize by:
@@ -3372,6 +3372,17 @@ namespace BDArmory.Modules
                         targetWeapon = item.Current;
                         if (distance > gunRange)
                             break;  //definitely use missiles
+                    }
+
+                    // TargetInfo.isLanded includes splashed but not underwater, for whatever reasons.
+                    // If target is splashed, and we have torpedoes, use torpedoes, because, obviously,
+                    // torpedoes are the best kind of sausage for splashed targets, 
+                    // almost as good as STS missiles, which we don't have.
+                    if (candidateClass == WeaponClasses.SLW && target.isSplashed)
+                    {
+                        targetWeapon = item.Current;
+                        if (distance > gunRange)
+                            break;
                     }
 
                     if (candidateClass == WeaponClasses.Bomb)
@@ -3423,26 +3434,7 @@ namespace BDArmory.Modules
                     targetWeapon = item.Current;
                     targetWeaponImpact = candidateImpact;
                 }
-
             }
-                //if we have a torpedo use it
-            else if (target.isSplashed)
-            { 
-                List<IBDWeapon>.Enumerator item = weaponTypesSLW.GetEnumerator();
-                while (item.MoveNext())
-                {
-                    if (item.Current == null) continue;
-                    if (CheckEngagementEnvelope(item.Current, distance))
-                    {
-                        if (item.Current.GetMissileType().ToLower() == "torpedo")
-                        {
-                            targetWeapon = item.Current;
-                            break;
-                        }
-                    }
-                }
-                item.Dispose();
-            }              
             else if (target.isUnderwater)
             {
                 // iterate over weaponTypesSLW (Ship Launched Weapons) and pick suitable one based on engagementRange

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -3589,6 +3589,23 @@ namespace BDArmory.Modules
                     break;
 
                 case WeaponClasses.SLW:
+                    // Enable sonar, or radar, if no sonar is found.
+                    if (((MissileBase)weaponCandidate).TargetingMode == MissileBase.TargetingModes.Radar)
+                    {
+                        ModuleRadar foundRadar = null;
+                        using (List<ModuleRadar>.Enumerator rd = radars.GetEnumerator())
+                            while (rd.MoveNext())
+                            {
+                                if (rd.Current == null || !rd.Current.canLock) continue;
+                                if (!foundRadar || rd.Current.rwrType == RadarWarningReceiver.RWRThreatTypes.Sonar)
+                                {
+                                    foundRadar = rd.Current;
+                                    if (rd.Current.rwrType == RadarWarningReceiver.RWRThreatTypes.Sonar)
+                                        break;
+                                }
+                            }
+                        foundRadar.EnableRadar();
+                    }
                     return true;                    
 
                 default:

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -426,7 +426,7 @@ namespace BDArmory.Radar
             float groundClutterMutiplier = Mathf.Lerp(1, radar.radarGroundClutterFactor, (lookDownAngle / 90));
 
             //additional ground clutter factor when target is landed/splashed:
-            if (ti.isLanded || ti.isSplashed)
+            if (ti.isLandedOrSurfaceSplashed || ti.isSplashed)
                 groundClutterMutiplier *= radar.radarGroundClutterFactor;
 
             return groundClutterMutiplier;

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -24,7 +24,7 @@ namespace BDArmory.Targeting
         public bool alreadyScheduledRCSUpdate = false;
 
 
-        public bool isLanded
+        public bool isLandedOrSurfaceSplashed
 		{
 			get
 			{

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -806,7 +806,7 @@ namespace BDArmory.UI
             List<TargetInfo>.Enumerator target = TargetDatabase[team].GetEnumerator();
             while (target.MoveNext())
             {
-                if (target.Current == null || !target.Current.Vessel || target.Current.isLanded || target.Current.isMissile || !target.Current.isThreat) continue;
+                if (target.Current == null || !target.Current.Vessel || target.Current.isLandedOrSurfaceSplashed || target.Current.isMissile || !target.Current.isThreat) continue;
                 Vector3 targetRelPos = target.Current.Vessel.vesselTransform.position - mf.vessel.vesselTransform.position;
 
                 float distance, dot;


### PR DESCRIPTION
AI can now blow itself up with torpedoes like a boss, that is, this should fix AI weapon selection for splashed targets to include torpedoes.

Also renamed TargetInfo.isLanded to what it actually is.