### PR TITLE
Weapon groups reset and remove deprecated features

### DIFF
--- a/BDArmory.Core/BDArmorySettings.cs
+++ b/BDArmory.Core/BDArmorySettings.cs
@@ -9,7 +9,6 @@ namespace BDArmory.Core
         [BDAPersistantSettingsField] public static bool BULLET_HITS = true;
         [BDAPersistantSettingsField] public static bool BULLET_DECALS = true;
         [BDAPersistantSettingsField] public static int MAX_NUM_BULLET_DECALS = 200;
-        [BDAPersistantSettingsField] public static float PHYSICS_RANGE = 0;                 //TODO: remove all references to this so it can be deprecated!
         [BDAPersistantSettingsField] public static bool EJECT_SHELLS = true;
         [BDAPersistantSettingsField] public static bool SHELL_COLLISIONS = true;
         [BDAPersistantSettingsField] public static bool INFINITE_AMMO = false;

--- a/BDArmory.Core/BDArmorySettings.cs
+++ b/BDArmory.Core/BDArmorySettings.cs
@@ -21,7 +21,6 @@ namespace BDArmory.Core
         [BDAPersistantSettingsField] public static bool BOMB_CLEARANCE_CHECK = true;
         [BDAPersistantSettingsField] public static float MAX_BULLET_RANGE = 8000f;               //TODO: remove all references to this so it can be deprecated! all ranges should be supplied in part config!
         [BDAPersistantSettingsField] public static float TRIGGER_HOLD_TIME = 0.3f;
-        [BDAPersistantSettingsField] public static bool ALLOW_LEGACY_TARGETING = true;           //TODO: remove all references to this so it can be deprecated! legacy targeting should not be support anymore in future versions.
         [BDAPersistantSettingsField] public static float TARGET_CAM_RESOLUTION = 1024f;
         [BDAPersistantSettingsField] public static bool BW_TARGET_CAM = true;
         [BDAPersistantSettingsField] public static float SMOKE_DEFLECTION_FACTOR = 10f;

--- a/BDArmory/Misc/WMTurretGroup.cs
+++ b/BDArmory/Misc/WMTurretGroup.cs
@@ -26,7 +26,7 @@ namespace BDArmory.Misc
             while (weapon.MoveNext())
             {
                 if (weapon.Current == null) continue;
-                weapon.Current.legacyTargetVessel = targetVessel;
+                weapon.Current.visualTargetVessel = targetVessel;
                 weapon.Current.autoFireTimer = Time.time;
                 weapon.Current.autoFireLength = burstLength;
             }
@@ -40,7 +40,7 @@ namespace BDArmory.Misc
             {
                 if (weapon.Current == null) continue;
                 weapon.Current.autoFire = false;
-                weapon.Current.legacyTargetVessel = null;
+                weapon.Current.visualTargetVessel = null;
             }
             weapon.Dispose();
         }

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -418,7 +418,7 @@ namespace BDArmory.Modules
             while (weapon.MoveNext())
             {
                 if (weapon.Current == null) continue;
-                weapon.Current.legacyTargetVessel = null;
+                weapon.Current.visualTargetVessel = null;
                 weapon.Current.autoFire = false;
                 weapon.Current.aiControlled = false;
             }
@@ -3832,7 +3832,7 @@ namespace BDArmory.Modules
                     if (weapon.Current == null) continue;
 					if (weapon.Current.GetShortName() != selectedWeapon.GetShortName()) continue;
 					weapon.Current.autoFire = false;
-                    weapon.Current.legacyTargetVessel = null;
+                    weapon.Current.visualTargetVessel = null;
                 }
                 weapon.Dispose();
             }
@@ -4136,7 +4136,7 @@ namespace BDArmory.Modules
                 {
                     if (weapon.Current == null) continue;
 					if (weapon.Current.GetShortName() != selectedWeapon.GetShortName()) continue;
-					weapon.Current.legacyTargetVessel = guardTarget;
+					weapon.Current.visualTargetVessel = guardTarget;
                     weapon.Current.autoFireTimer = Time.time;
                     //weapon.Current.autoFireLength = 3 * targetScanInterval / 4;
                     weapon.Current.autoFireLength = (fireBurstLength < 0.5) ? targetScanInterval / 2 : fireBurstLength;

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -923,11 +923,6 @@ namespace BDArmory.Modules
                 targetScanTimer = -100;
             }
 
-            if (vessel.isActiveVessel)
-            {
-                TargetAcquire();
-            }
-
             BombAimer();
         }
 
@@ -942,12 +937,7 @@ namespace BDArmory.Modules
 
         void ClampVisualRange()
         {
-            if (!BDArmorySettings.ALLOW_LEGACY_TARGETING)
-            {
-                guardRange = Mathf.Clamp(guardRange, 0, BDArmorySettings.MAX_GUARD_VISUAL_RANGE);
-            }
-
-            //UpdateMaxGuardRange();
+            guardRange = Mathf.Clamp(guardRange, 0, BDArmorySettings.MAX_GUARD_VISUAL_RANGE);
         }
 
         void OnGUI()
@@ -957,7 +947,7 @@ namespace BDArmory.Modules
             {
                 if (BDArmorySettings.DRAW_DEBUG_LINES)
                 {
-                    if (guardMode && !BDArmorySettings.ALLOW_LEGACY_TARGETING)
+                    if (guardMode)
                     {
                         BDGUIUtils.DrawLineBetweenWorldPositions(part.transform.position,
                             part.transform.position + (debugGuardViewDirection * 25), 2, Color.yellow);
@@ -1138,7 +1128,7 @@ namespace BDArmory.Modules
 
         IEnumerator GuardTurretRoutine()
         {
-            if (gameObject.activeInHierarchy && !BDArmorySettings.ALLOW_LEGACY_TARGETING)
+            if (gameObject.activeInHierarchy)
             //target is out of visual range, try using sensors
             {
                 if (guardTarget.LandedOrSplashed)
@@ -1233,28 +1223,7 @@ namespace BDArmory.Modules
             {
                 guardFiringMissile = true;
 
-
-                if (BDArmorySettings.ALLOW_LEGACY_TARGETING)
-                {
-                    //TODO BDModularGuidance Legacy and turret implementation
-                    if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                    {
-                        Debug.Log("[BDArmory]: Firing on target: " + guardTarget.GetName() + ", (legacy targeting)");
-                    }
-                    if (ml is MissileLauncher && ((MissileLauncher)ml).missileTurret)
-                    {
-                        ((MissileLauncher)ml).missileTurret.PrepMissileForFire(((MissileLauncher)ml));
-                        ((MissileLauncher)ml).FireMissileOnTarget(guardTarget);
-                        ((MissileLauncher)ml).missileTurret.UpdateMissileChildren();
-                    }
-                    else
-                    {
-                        ((MissileLauncher)ml).FireMissileOnTarget(guardTarget);
-                    }
-                    //StartCoroutine(MissileAwayRoutine(ml));
-                    UpdateList();
-                }
-                else if (ml.TargetingMode == MissileBase.TargetingModes.Radar && vesselRadarData)
+                if (ml.TargetingMode == MissileBase.TargetingModes.Radar && vesselRadarData)
                 {
                     float attemptLockTime = Time.time;
                     while ((!vesselRadarData.locked || (vesselRadarData.lockedTargetData.vessel != guardTarget)) && Time.time - attemptLockTime < 2)
@@ -3060,17 +3029,14 @@ namespace BDArmory.Modules
                 {
                     targetsTried.Add(potentialTarget);
                     SetTarget(potentialTarget);
-                    if (!BDArmorySettings.ALLOW_LEGACY_TARGETING)
+                    if (CrossCheckWithRWR(potentialTarget) && TryPickAntiRad(potentialTarget))
                     {
-                        if (CrossCheckWithRWR(potentialTarget) && TryPickAntiRad(potentialTarget))
+                        if (BDArmorySettings.DRAW_DEBUG_LABELS)
                         {
-                            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                            {
-                                Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging the least engaged radar target with " +
-                                          selectedWeapon.GetShortName());
-                            }
-                            return;
+                            Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging the least engaged radar target with " +
+                                        selectedWeapon.GetShortName());
                         }
+                        return;
                     }
                     if (SmartPickWeapon_EngagementEnvelope(potentialTarget))
                     {
@@ -3089,17 +3055,14 @@ namespace BDArmory.Modules
                 {
                     targetsTried.Add(potentialTarget);
                     SetTarget(potentialTarget);
-                    if (!BDArmorySettings.ALLOW_LEGACY_TARGETING)
+                    if (CrossCheckWithRWR(potentialTarget) && TryPickAntiRad(potentialTarget))
                     {
-                        if (CrossCheckWithRWR(potentialTarget) && TryPickAntiRad(potentialTarget))
+                        if (BDArmorySettings.DRAW_DEBUG_LABELS)
                         {
-                            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                            {
-                                Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging the closest radar target with " +
-                                          selectedWeapon.GetShortName());
-                            }
-                            return;
+                            Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging the closest radar target with " +
+                                        selectedWeapon.GetShortName());
                         }
+                        return;
                     }
                     if (SmartPickWeapon_EngagementEnvelope(potentialTarget))
                     {
@@ -3685,47 +3648,6 @@ namespace BDArmory.Modules
             return false;
         }
 
-
-        void ScanAllTargets()
-        {
-            //get a target.
-            //float angle = 0;
-            List<Vessel>.Enumerator v = FlightGlobals.Vessels.GetEnumerator();
-            while (v.MoveNext())
-            {
-                if (v.Current == null) continue;
-                if (!v.Current.loaded) continue;
-                float distance = (transform.position - v.Current.transform.position).sqrMagnitude;
-                if (!(distance < guardRange*guardRange) || !CanSeeTarget(v.Current)) continue;
-                float angle = Vector3.Angle(-transform.forward, v.Current.transform.position - transform.position);
-                if (!(angle < guardAngle / 2)) continue;
-                List<MissileBase>.Enumerator missile = v.Current.FindPartModulesImplementing<MissileBase>().GetEnumerator();
-                while (missile.MoveNext())
-                {
-                    if (missile.Current == null) continue;
-                    if (!missile.Current.HasFired || missile.Current.Team == team) continue;
-                    BDATargetManager.ReportVessel(v.Current, this);
-                    if (!isFlaring && missile.Current.TargetingMode == MissileBase.TargetingModes.Heat && Vector3.Angle(missile.Current.GetForwardTransform(), transform.position - missile.Current.transform.position) < 20)
-                    {
-                        StartCoroutine(FlareRoutine(targetScanInterval * 0.75f));
-                    }
-                    break;
-                }
-                missile.Dispose();
-
-                List<MissileFire>.Enumerator mF = v.Current.FindPartModulesImplementing<MissileFire>().GetEnumerator();
-                while (mF.MoveNext())
-                {
-                    if (mF.Current == null) continue;
-                    if (mF.Current.team == team || !mF.Current.vessel.IsControllable || !mF.Current.vessel.isCommandable) continue;
-                    BDATargetManager.ReportVessel(v.Current, this);
-                    break;
-                }
-                mF.Dispose();
-            }
-            v.Dispose();
-        }
-
         void SearchForRadarSource()
         {
             antiRadTargetAcquired = false;
@@ -3839,15 +3761,7 @@ namespace BDArmory.Modules
             }
             else if (ml.TargetingMode == MissileBase.TargetingModes.Gps)
             {
-                if (BDArmorySettings.ALLOW_LEGACY_TARGETING)
-                {
-                    if (vessel.targetObject != null && vessel.targetObject.GetVessel() != null)
-                    {
-                        ml.TargetAcquired = true;
-                        ml.legacyTargetVessel = vessel.targetObject.GetVessel();
-                    }
-                }
-                else if (designatedGPSCoords != Vector3d.zero)
+                if (designatedGPSCoords != Vector3d.zero)
                 {
                     ml.targetGPSCoords = designatedGPSCoords;
                     ml.TargetAcquired = true;
@@ -3875,47 +3789,6 @@ namespace BDArmory.Modules
             }
         }
 
-        public void TargetAcquire()
-        {
-            if (!isArmed || !BDArmorySettings.ALLOW_LEGACY_TARGETING) return;
-            Vessel acquiredTarget = null;
-            float smallestAngle = 8;
-
-            if (Time.time - targetListTimer > 1)
-            {
-                loadedVessels.Clear();
-                List<Vessel>.Enumerator v = FlightGlobals.Vessels.GetEnumerator();
-                while (v.MoveNext())
-                {
-                    if (v.Current == null) continue;
-                    float viewAngle = Vector3.Angle(-transform.forward, v.Current.transform.position - transform.position);
-                    if (!v.Current.loaded || !(viewAngle < smallestAngle)) continue;
-                    if (!v.Current.vesselName.Contains("(fired)")) loadedVessels.Add(v.Current);
-                }
-                v.Dispose();
-            }
-
-            List<Vessel>.Enumerator vl = loadedVessels.GetEnumerator();
-            while (vl.MoveNext())
-            {
-                if (vl.Current == null) continue;
-                float viewAngle = Vector3.Angle(-transform.forward, vl.Current.transform.position - transform.position);
-                //if(vl.Current!= vessel && vl.Current.loaded) Debug.Log ("view angle: " + viewAngle);
-                if (vl.Current == vessel || !vl.Current.loaded || !(viewAngle < smallestAngle) ||
-                    !CanSeeTarget(vl.Current)) continue;
-                acquiredTarget = vl.Current;
-                smallestAngle = viewAngle;
-            }
-            vl.Dispose();
-
-            if (acquiredTarget == null || acquiredTarget == (Vessel) FlightGlobals.fetch.VesselTarget) return;
-            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-            {
-                Debug.Log("[BDArmory]: found target! : " + acquiredTarget.name);
-            }
-            FlightGlobals.fetch.SetVesselTarget(acquiredTarget);
-        }
-
         #endregion
 
         #region Guard
@@ -3930,10 +3803,7 @@ namespace BDArmory.Modules
             if (!gameObject.activeInHierarchy) return;
             if (BDArmorySettings.PEACE_MODE) return;
 
-            if (!BDArmorySettings.ALLOW_LEGACY_TARGETING)
-            {
-                UpdateGuardViewScan();
-            }
+            UpdateGuardViewScan();
 
             //setting turrets to guard mode
             if (selectedWeapon != null && selectedWeapon.GetWeaponClass() == WeaponClasses.Gun)
@@ -3954,16 +3824,7 @@ namespace BDArmory.Modules
                 weapon.Dispose();
             }
 
-            if (guardTarget)
-            {
-                //release target if out of range
-                if (BDArmorySettings.ALLOW_LEGACY_TARGETING &&
-                    (guardTarget.transform.position - transform.position).sqrMagnitude > guardRange*guardRange)
-                {
-                    SetTarget(null);
-                }
-            }
-            else if (selectedWeapon != null && selectedWeapon.GetWeaponClass() == WeaponClasses.Gun)
+            if (!guardTarget && selectedWeapon != null && selectedWeapon.GetWeaponClass() == WeaponClasses.Gun)
             {
                 List<ModuleWeapon>.Enumerator weapon = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
                 while (weapon.MoveNext())
@@ -3997,10 +3858,6 @@ namespace BDArmory.Modules
                 if (!guardFiringMissile)
                 {
                     SetTarget(null);
-                    if (BDArmorySettings.ALLOW_LEGACY_TARGETING)
-                    {
-                        ScanAllTargets();
-                    }
 
                     SmartFindTarget();
 
@@ -4037,8 +3894,7 @@ namespace BDArmory.Modules
 
                             if (missilesAway < maxMissilesOnTarget)
                             {
-                                if (!guardFiringMissile && launchAuthorized &&
-                                    (pilotAuthorized || !BDArmorySettings.ALLOW_LEGACY_TARGETING))
+                                if (!guardFiringMissile && launchAuthorized)
                                 {
                                     StartCoroutine(GuardMissileRoutine());
                                 }
@@ -4300,14 +4156,7 @@ namespace BDArmory.Modules
             UI_FloatRange rangeEditor = (UI_FloatRange)Fields["guardRange"].uiControlEditor;
             if (BDArmorySettings.PHYSICS_RANGE != 0)
             {
-                if (BDArmorySettings.ALLOW_LEGACY_TARGETING)
-                {
-                    rangeEditor.maxValue = BDArmorySettings.PHYSICS_RANGE;
-                }
-                else
-                {
-                    rangeEditor.maxValue = BDArmorySettings.MAX_GUARD_VISUAL_RANGE;
-                }
+                rangeEditor.maxValue = BDArmorySettings.MAX_GUARD_VISUAL_RANGE;
             }
             else
             {

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -4154,14 +4154,7 @@ namespace BDArmory.Modules
         public void UpdateMaxGuardRange()
         {
             UI_FloatRange rangeEditor = (UI_FloatRange)Fields["guardRange"].uiControlEditor;
-            if (BDArmorySettings.PHYSICS_RANGE != 0)
-            {
-                rangeEditor.maxValue = BDArmorySettings.MAX_GUARD_VISUAL_RANGE;
-            }
-            else
-            {
-                rangeEditor.maxValue = 5000;
-            }
+            rangeEditor.maxValue = BDArmorySettings.MAX_GUARD_VISUAL_RANGE;
         }
 
 
@@ -4538,7 +4531,7 @@ namespace BDArmory.Modules
 
         bool AltitudeTrigger()
         {
-            float maxAlt = Mathf.Clamp(BDArmorySettings.PHYSICS_RANGE * 0.75f, 2250, 10000);
+            const float maxAlt = 10000;
             double asl = vessel.mainBody.GetAltitude(vessel.CoM);
             double radarAlt = asl - vessel.terrainAltitude;
 

--- a/BDArmory/Modules/MissileLauncher.cs
+++ b/BDArmory/Modules/MissileLauncher.cs
@@ -705,26 +705,6 @@ namespace BDArmory.Modules
 		    TargetPosition = transform.position + (transform.forward * 5000); //set initial target position so if no target update, missileBase will count a miss if it nears this point or is flying post-thrust
 		    startDirection = transform.forward;
 
-		    if(BDArmorySettings.ALLOW_LEGACY_TARGETING)
-		    {
-		        if(vessel.targetObject!=null && vessel.targetObject.GetVessel()!=null)
-		        {
-		            legacyTargetVessel = vessel.targetObject.GetVessel();
-		            List<MissileFire>.Enumerator mf = legacyTargetVessel.FindPartModulesImplementing<MissileFire>().GetEnumerator();
-		            while(mf.MoveNext())
-		            {
-		                if (mf.Current == null) continue;
-		                TargetMf = mf.Current;
-		                break;
-		            }
-                    mf.Dispose();
-
-		            if(TargetingMode == TargetingModes.Heat)
-		            {
-		                heatTarget = new TargetSignatureData(legacyTargetVessel, 9999);
-		            }
-		        }
-		    }
 		    SetLaserTargeting();
 		    SetAntiRadTargeting();
 
@@ -919,11 +899,6 @@ namespace BDArmory.Modules
 		{
 			if(guidanceActive)
 			{
-				if(BDArmorySettings.ALLOW_LEGACY_TARGETING && legacyTargetVessel)
-				{
-					UpdateLegacyTarget();
-				}
-
 				if(TargetingMode == TargetingModes.Heat)
 				{
 					UpdateHeatTarget();
@@ -1697,41 +1672,6 @@ namespace BDArmory.Modules
 		{
             DoAero(CalculateAGMBallisticGuidance(this,TargetPosition));
         }
-
-		void UpdateLegacyTarget()
-		{
-			if(legacyTargetVessel)
-			{
-				maxOffBoresight = 90;
-				
-				if(TargetingMode == TargetingModes.Radar)
-				{
-                    //activeRadarRange = 40000;
-                    activeRadarRange = BDArmorySettings.MAX_ACTIVE_RADAR_RANGE;
-
-                    TargetAcquired = true;
-					radarTarget = new TargetSignatureData(legacyTargetVessel, 500);
-					return;
-				}
-				else if(TargetingMode == TargetingModes.Heat)
-				{
-					TargetAcquired = true;
-					heatTarget = new TargetSignatureData(legacyTargetVessel, 500);
-					return;
-				}
-
-				if(TargetingMode != TargetingModes.Gps || TargetAcquired)
-				{
-					TargetAcquired = true;
-					TargetPosition = legacyTargetVessel.CoM + (legacyTargetVessel.Velocity() * Time.fixedDeltaTime);
-					targetGPSCoords = VectorUtils.WorldPositionToGeoCoords(TargetPosition, vessel.mainBody);
-					TargetVelocity = legacyTargetVessel.Velocity();
-					TargetAcceleration = legacyTargetVessel.acceleration;
-					lastLaserPoint = TargetPosition;
-					lockFailTimer = 0;
-				}
-			}
-		}
 	
 		public override void Detonate()
 		{

--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -1239,10 +1239,6 @@ namespace BDArmory.Modules
 
         private bool FireLaser()
         {
-            float maxDistance = BDArmorySettings.PHYSICS_RANGE;
-            if (BDArmorySettings.PHYSICS_RANGE == 0)
-                maxDistance = 2500;
-
             float chargeAmount = requestResourceAmount * TimeWarp.fixedDeltaTime;
 
             if (!pointingAtSelf && !Misc.Misc.CheckMouseIsOnGui() && WMgrAuthorized() && !isOverheated &&
@@ -1278,7 +1274,7 @@ namespace BDArmory.Modules
                     lr.SetPosition(0, Vector3.zero);
                     RaycastHit hit;                    
                     
-                    if (Physics.Raycast(ray, out hit, maxDistance, 9076737))
+                    if (Physics.Raycast(ray, out hit, maxTargetingRange, 9076737))
                     {
                         lr.useWorldSpace = true;
                         laserPoint = hit.point + targetVelocity * Time.fixedDeltaTime;
@@ -1309,7 +1305,7 @@ namespace BDArmory.Modules
                     }
                     else
                     {
-                        laserPoint = lr.transform.InverseTransformPoint((targetDirectionLR * maxDistance) + tf.position);
+                        laserPoint = lr.transform.InverseTransformPoint((targetDirectionLR * maxTargetingRange) + tf.position);
                         lr.SetPosition(1, laserPoint);
                     }
                 }

--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -29,6 +29,7 @@ namespace BDArmory.Modules
         bool finalFire;
 
         public int rippleIndex = 0;
+        public string OriginalShortName { get; private set; }
 
         // WeaponTypes.Cannon is deprecated.  identical behavior is achieved with WeaponType.Ballistic and bulletInfo.explosive = true.
         public enum WeaponTypes
@@ -543,6 +544,7 @@ namespace BDArmory.Modules
 			{
 				shortName = part.partInfo.title;
 			}
+            OriginalShortName = shortName;
 			WeaponName = shortName;
 			IEnumerator<KSPParticleEmitter> emitter = part.FindModelComponents<KSPParticleEmitter>().AsEnumerable().GetEnumerator();
             while (emitter.MoveNext())
@@ -2525,7 +2527,7 @@ namespace BDArmory.Modules
 
 			if (GUILayout.Button("Save & Close"))
 			{
-                string newName = string.IsNullOrEmpty(txtName.Trim()) ? txtName.Trim() : WPNmodule.part.partInfo.title;
+                string newName = string.IsNullOrEmpty(txtName.Trim()) ? WPNmodule.OriginalShortName : txtName.Trim();
 
                 WPNmodule.WeaponName = newName;
 				WPNmodule.shortName = newName;  

--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -2064,24 +2064,11 @@ namespace BDArmory.Modules
             bool atprWasAcquired = atprAcquired;
             atprAcquired = false;
 
-            //targetVessel = null;
-            if (BDArmorySettings.ALLOW_LEGACY_TARGETING)
-            {
-                if (!aiControlled)
-                {
-                    if (vessel.targetObject != null && vessel.targetObject.GetVessel() != null)
-                    {
-                        legacyTargetVessel = vessel.targetObject.GetVessel();
-                    }
-                }
-            }
-
             if (weaponManager)
             {
                 //legacy or visual range guard targeting
                 if (aiControlled && weaponManager && legacyTargetVessel &&
-                    (BDArmorySettings.ALLOW_LEGACY_TARGETING ||
-                     (legacyTargetVessel.transform.position - transform.position).sqrMagnitude < weaponManager.guardRange*weaponManager.guardRange))
+                    (legacyTargetVessel.transform.position - transform.position).sqrMagnitude < weaponManager.guardRange*weaponManager.guardRange)
                 {
                     targetPosition = legacyTargetVessel.CoM;
                     targetVelocity = legacyTargetVessel.rb_velocity;

--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -2529,8 +2529,10 @@ namespace BDArmory.Modules
 
 			if (GUILayout.Button("Save & Close"))
 			{
-				WPNmodule.WeaponName = txtName;
-				WPNmodule.shortName = txtName;  
+                string newName = string.IsNullOrEmpty(txtName.Trim()) ? txtName.Trim() : WPNmodule.part.partInfo.title;
+
+                WPNmodule.WeaponName = newName;
+				WPNmodule.shortName = newName;  
 				instance.WPNmodule.HideUI();
 			}
 

--- a/BDArmory/Modules/RadarWarningReceiver.cs
+++ b/BDArmory/Modules/RadarWarningReceiver.cs
@@ -254,7 +254,7 @@ namespace BDArmory.Modules
                 }
                 else if (type == RWRThreatTypes.MissileLock)
                 {
-                    if (!BDArmorySettings.ALLOW_LEGACY_TARGETING && weaponManager && weaponManager.guardMode)
+                    if (weaponManager && weaponManager.guardMode)
                     {
                         weaponManager.FireChaff();
                         // TODO: if torpedo inbound, also fire accoustic decoys (not yet implemented...)

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -843,10 +843,10 @@ namespace BDArmory.Radar
         /// Scans for targets in direction with field of view.
         /// (Visual Target acquisition)
         /// </summary>
-        public static Vector3 GuardScanInDirection(MissileFire myWpnManager, float directionAngle, Transform referenceTransform, float fov, out ViewScanResults results, float maxDistance)
+        public static ViewScanResults GuardScanInDirection(MissileFire myWpnManager, Transform referenceTransform, float fov, float maxDistance)
 		{
 			fov *= 1.1f;
-            results = new ViewScanResults
+            var results = new ViewScanResults
             {
                 foundMissile = false,
                 foundHeatMissile = false,
@@ -860,14 +860,14 @@ namespace BDArmory.Radar
 
             if (!myWpnManager || !referenceTransform)
 			{
-				return Vector3.zero;
+				return results;
 			}
 
 			Vector3 position = referenceTransform.position;
 			//Vector3d geoPos = VectorUtils.WorldPositionToGeoCoords(position, FlightGlobals.currentMainBody);
 			Vector3 forwardVector = referenceTransform.forward;
 			Vector3 upVector = referenceTransform.up;
-			Vector3 lookDirection = Quaternion.AngleAxis(directionAngle, upVector) * forwardVector;
+			Vector3 lookDirection = forwardVector;
 
 
             List<Vessel>.Enumerator loadedvessels = BDATargetManager.LoadedVessels.GetEnumerator();
@@ -962,7 +962,7 @@ namespace BDArmory.Radar
 			}
 
             loadedvessels.Dispose();
-            return lookDirection;
+            return results;
 		}
 
 

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -892,8 +892,7 @@ namespace BDArmory.UI
                     }
                     guardLines += 1.25f;
 
-                    string scanLabel = BDArmorySettings.ALLOW_LEGACY_TARGETING ? "Scan Interval" : "Firing Interval";
-                    GUI.Label(new Rect(leftIndent, (guardLines*entryHeight), 85, entryHeight), scanLabel, leftLabel);
+                    GUI.Label(new Rect(leftIndent, (guardLines*entryHeight), 85, entryHeight), "Firing Interval", leftLabel);
                     ActiveWeaponManager.targetScanInterval =
                         GUI.HorizontalSlider(
                             new Rect(leftIndent + (90), (guardLines*entryHeight), contentWidth - 90 - 38, entryHeight),
@@ -929,16 +928,12 @@ namespace BDArmory.UI
                         ActiveWeaponManager.guardAngle.ToString(), leftLabel);
                     guardLines++;
 
-                    string rangeLabel = BDArmorySettings.ALLOW_LEGACY_TARGETING ? "Guard Range" : "Visual Range";
-                    GUI.Label(new Rect(leftIndent, (guardLines*entryHeight), 85, entryHeight), rangeLabel, leftLabel);
+                    GUI.Label(new Rect(leftIndent, (guardLines*entryHeight), 85, entryHeight), "Visual Range", leftLabel);
                     float guardRange = ActiveWeaponManager.guardRange;
-                    float maxVisRange = BDArmorySettings. ALLOW_LEGACY_TARGETING
-                        ? Mathf.Clamp(BDArmorySettings.PHYSICS_RANGE, 2500, 100000)
-                        : BDArmorySettings.MAX_GUARD_VISUAL_RANGE;
                     guardRange =
                         GUI.HorizontalSlider(
                             new Rect(leftIndent + 90, (guardLines*entryHeight), contentWidth - 90 - 38, entryHeight),
-                            guardRange, 100, maxVisRange);
+                            guardRange, 100, BDArmorySettings.MAX_GUARD_VISUAL_RANGE);
                     guardRange = guardRange/100;
                     guardRange = Mathf.Round(guardRange);
                     ActiveWeaponManager.guardRange = guardRange*100;
@@ -1376,7 +1371,6 @@ namespace BDArmory.UI
             BDArmorySettings.REMOTE_SHOOTING = GUI.Toggle(SLeftRect(line), BDArmorySettings.REMOTE_SHOOTING, "Remote Firing");
             BDArmorySettings.BOMB_CLEARANCE_CHECK = GUI.Toggle(SRightRect(line), BDArmorySettings.BOMB_CLEARANCE_CHECK, "Clearance Check");
             line++;
-            BDArmorySettings.ALLOW_LEGACY_TARGETING = GUI.Toggle(SLeftRect(line), BDArmorySettings.ALLOW_LEGACY_TARGETING, "Legacy Targeting");
             BDArmorySettings.SHELL_COLLISIONS = GUI.Toggle(SRightRect(line), BDArmorySettings.SHELL_COLLISIONS, "Shell Collisions");
             line++;
             BDArmorySettings.BULLET_DECALS = GUI.Toggle(SLeftRect(line), BDArmorySettings.BULLET_DECALS, "Bullet Hole Decals");


### PR DESCRIPTION
- Entering a blank weapon group will now nicely reset the weapon name to the original one.
- Legacy targeting is gone.
- Guard mode "scanning" is gone, now it checks the whole view angle cone at once.
- BDA "Physics range" is gone.