### PR TITLE
Feature: Multiple teams

### DIFF
--- a/BDArmory/BDArmory.csproj
+++ b/BDArmory/BDArmory.csproj
@@ -61,9 +61,6 @@
     <Reference Include="KSPAssets">
       <HintPath>..\..\_LocalDev\KSPRefs\KSPAssets.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.12.0.1\lib\net35\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="UnityEngine">
@@ -429,7 +426,6 @@
     <None Include="Distribution\GameData\BDArmory\Sounds\TorpPropFX.ogg" />
     <None Include="Distribution\GameData\BDArmory\Sounds\warning.ogg" />
     <None Include="Distribution\GameData\BDArmory\Sounds\windloop.ogg" />
-    <None Include="packages.config" />
     <None Include="Shaders\rcsShader.shader" />
     <None Include="Shaders\rcsShader.shader" />
   </ItemGroup>

--- a/BDArmory/BDArmory.csproj
+++ b/BDArmory/BDArmory.csproj
@@ -72,6 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Misc\BDTeam.cs" />
+    <Compile Include="UI\BDTeamSelector.cs" />
     <Compile Include="Modules\ModuleAmmoSwitch.cs" />
     <Compile Include="Misc\BDAcTools.cs" />
     <Compile Include="Control\AIUtils.cs" />

--- a/BDArmory/BDArmory.csproj
+++ b/BDArmory/BDArmory.csproj
@@ -61,6 +61,9 @@
     <Reference Include="KSPAssets">
       <HintPath>..\..\_LocalDev\KSPRefs\KSPAssets.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.12.0.1\lib\net35\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="UnityEngine">
@@ -71,6 +74,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Misc\BDTeam.cs" />
     <Compile Include="Modules\ModuleAmmoSwitch.cs" />
     <Compile Include="Misc\BDAcTools.cs" />
     <Compile Include="Control\AIUtils.cs" />
@@ -425,6 +429,7 @@
     <None Include="Distribution\GameData\BDArmory\Sounds\TorpPropFX.ogg" />
     <None Include="Distribution\GameData\BDArmory\Sounds\warning.ogg" />
     <None Include="Distribution\GameData\BDArmory\Sounds\windloop.ogg" />
+    <None Include="packages.config" />
     <None Include="Shaders\rcsShader.shader" />
     <None Include="Shaders\rcsShader.shader" />
   </ItemGroup>

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -168,8 +168,12 @@ namespace BDArmory.Control
 
                         using (var otherLeader = leaders.GetEnumerator())
                             while (otherLeader.MoveNext())
+                            {
+                                if (leader.Current == otherLeader.Current)
+                                    continue;
                                 if ((leader.Current.transform.position - otherLeader.Current.transform.position).sqrMagnitude < sqrDistance)
                                     waiting = true;
+                            }
 
                         using (var pilot = pilots[leader.Current.weaponManager.Team].GetEnumerator())
                             while (pilot.MoveNext())

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -53,7 +53,7 @@ namespace BDArmory.Control
         {
             if (!competitionStarting)
             {
-                competitionRoutine = StartCoroutine(DogfightCompetitionModeRoutine(distance/2));
+                competitionRoutine = StartCoroutine(DogfightCompetitionModeRoutine(distance));
             }
         }
 
@@ -71,38 +71,33 @@ namespace BDArmory.Control
         {
             competitionStarting = true;
             competitionStatus = "Competition: Pilots are taking off.";
-            Dictionary<BDArmorySetup.BDATeams, List<IBDAIControl>> pilots =
-                new Dictionary<BDArmorySetup.BDATeams, List<IBDAIControl>>();
-            pilots.Add(BDArmorySetup.BDATeams.A, new List<IBDAIControl>());
-            pilots.Add(BDArmorySetup.BDATeams.B, new List<IBDAIControl>());
-            List<Vessel>.Enumerator loadedVessels = BDATargetManager.LoadedVessels.GetEnumerator();
-            while (loadedVessels.MoveNext())
-            {
-                if (loadedVessels.Current == null) continue;
-                if (!loadedVessels.Current.loaded) continue;
-                IBDAIControl pilot = null;
-                IEnumerator<IBDAIControl> ePilots = loadedVessels.Current.FindPartModulesImplementing<IBDAIControl>().AsEnumerable().GetEnumerator();
-                while (ePilots.MoveNext())
+            var pilots = new Dictionary<BDTeam, List<IBDAIControl>>();
+            using (var loadedVessels = BDATargetManager.LoadedVessels.GetEnumerator())
+                while (loadedVessels.MoveNext())
                 {
-                    pilot = ePilots.Current;
-                    break;
-                }
-                ePilots.Dispose();
-                if (pilot == null || !pilot.weaponManager) continue;
+                    if (loadedVessels.Current == null || !loadedVessels.Current.loaded)
+                        continue;
+                    IBDAIControl pilot = loadedVessels.Current.FindPartModuleImplementing<IBDAIControl>();
+                    if (pilot == null || !pilot.weaponManager || pilot.weaponManager.Team.Neutral)
+                        continue;
 
-                pilots[BDATargetManager.BoolToTeam(pilot.weaponManager.team)].Add(pilot);
-                pilot.CommandTakeOff();
-                if (pilot.weaponManager.guardMode)
-                {
-                    pilot.weaponManager.ToggleGuardMode();
+                    if (!pilots.TryGetValue(pilot.weaponManager.Team, out List<IBDAIControl> teamPilots))
+                    {
+                        teamPilots = new List<IBDAIControl>();
+                        pilots.Add(pilot.weaponManager.Team, teamPilots);
+                    }
+                    teamPilots.Add(pilot);
+                    pilot.CommandTakeOff();
+                    if (pilot.weaponManager.guardMode)
+                    {
+                        pilot.weaponManager.ToggleGuardMode();
+                    }
                 }
-            }
-            loadedVessels.Dispose();
             
             //clear target database so pilots don't attack yet
             BDATargetManager.ClearDatabase();
 
-            if (pilots[BDArmorySetup.BDATeams.A].Count == 0 || pilots[BDArmorySetup.BDATeams.B].Count == 0)
+            if (pilots.Count < 2)
             {
                 Debug.Log("[BDArmory]: Unable to start competition mode - one or more teams is empty");
                 competitionStatus = "Competition: Failed!  One or more teams is empty.";
@@ -111,112 +106,103 @@ namespace BDArmory.Control
                 yield break;
             }
 
-            IBDAIControl aLeader = pilots[BDArmorySetup.BDATeams.A][0];
-            IBDAIControl bLeader = pilots[BDArmorySetup.BDATeams.B][0];
-
-            aLeader.weaponManager.wingCommander.CommandAllFollow();
-            bLeader.weaponManager.wingCommander.CommandAllFollow();
-
+            var leaders = new List<IBDAIControl>();
+            using (var pilotList = pilots.GetEnumerator())
+                while (pilotList.MoveNext())
+                {
+                    leaders.Add(pilotList.Current.Value[0]);
+                    pilotList.Current.Value[0].weaponManager.wingCommander.CommandAllFollow();
+                }
 
             //wait till the leaders are ready to engage (airborne for PilotAI)
-            while (aLeader != null && bLeader != null && (!aLeader.CanEngage() || !bLeader.CanEngage()))
+            bool ready = false;
+            while (!ready)
             {
-                yield return null;
+                ready = true;
+                using (var leader = leaders.GetEnumerator())
+                    while(leader.MoveNext())
+                        if (leader.Current != null && !leader.Current.CanEngage())
+                        {
+                            ready = false;
+                            yield return null;
+                            break;
+                        }
             }
 
-            if (aLeader == null || bLeader == null)
-            {
-                StopCompetition();
-            }
+            using (var leader = leaders.GetEnumerator())
+                while (leader.MoveNext())
+                    if (leader.Current == null)
+                        StopCompetition();
 
             competitionStatus = "Competition: Sending pilots to start position.";
-            Vector3 aDirection =
-                Vector3.ProjectOnPlane(aLeader.vessel.CoM - bLeader.vessel.CoM, aLeader.vessel.upAxis).normalized;
-            Vector3 bDirection =
-                Vector3.ProjectOnPlane(bLeader.vessel.CoM - aLeader.vessel.CoM, bLeader.vessel.upAxis).normalized;
+            Vector3 center = Vector3.zero;
+            using (var leader = leaders.GetEnumerator())
+                while (leader.MoveNext())
+                    center += leader.Current.vessel.CoM;
+            center /= leaders.Count;
+            Vector3 startDirection = Vector3.ProjectOnPlane(leaders[0].vessel.CoM - center, VectorUtils.GetUpDirection(center)).normalized;
+            startDirection *= (distance * leaders.Count / 4) + 1250f;
+            Quaternion directionStep = Quaternion.AngleAxis(360f / leaders.Count, VectorUtils.GetUpDirection(center));
 
-            Vector3 center = (aLeader.vessel.CoM + bLeader.vessel.CoM)/2f;
-            Vector3 aDestination = center + (aDirection*(distance + 1250f));
-            Vector3 bDestination = center + (bDirection*(distance + 1250f));
-            aDestination = VectorUtils.WorldPositionToGeoCoords(aDestination, FlightGlobals.currentMainBody);
-            bDestination = VectorUtils.WorldPositionToGeoCoords(bDestination, FlightGlobals.currentMainBody);
-
-            aLeader.CommandFlyTo(aDestination);
-            bLeader.CommandFlyTo(bDestination);
+            for(var i = 0; i < leaders.Count; ++i)
+            {
+                leaders[i].CommandFlyTo(VectorUtils.WorldPositionToGeoCoords(startDirection, FlightGlobals.currentMainBody));
+                startDirection = directionStep * startDirection;
+            }
 
             Vector3 centerGPS = VectorUtils.WorldPositionToGeoCoords(center, FlightGlobals.currentMainBody);
 
             //wait till everyone is in position
+            competitionStatus = "Competition: Waiting for teams to get in position.";
             bool waiting = true;
+            var sqrDistance = distance * distance;
             while (waiting)
             {
                 waiting = false;
 
-                if (aLeader == null || bLeader == null)
-                {
-                    StopCompetition();
-                }
-
-                if (Vector3.Distance(aLeader.transform.position, bLeader.transform.position) < distance*1.95f)
-                {
-                    waiting = true;
-                }
-                else
-                {
-                    Dictionary<BDArmorySetup.BDATeams, List<IBDAIControl>>.KeyCollection.Enumerator keys = pilots.Keys.GetEnumerator();
-                    while (keys.MoveNext())
+                using (var leader = leaders.GetEnumerator())
+                    while (leader.MoveNext())
                     {
-                        List<IBDAIControl>.Enumerator ePilots = pilots[keys.Current].GetEnumerator();
-                        while (ePilots.MoveNext())
-                        {
-                            if (ePilots.Current == null) continue;
-                            if (ePilots.Current.currentCommand != PilotCommands.Follow ||
-                                !(Vector3.ProjectOnPlane(
-                                    ePilots.Current.vessel.CoM - ePilots.Current.commandLeader.vessel.CoM,
-                                    VectorUtils.GetUpDirection(ePilots.Current.commandLeader.vessel.transform.position)
-                                    ).sqrMagnitude > 1000f*1000f)) continue;
-                            competitionStatus = "Competition: Waiting for teams to get in position.";
-                            waiting = true;
-                        }
-                        ePilots.Dispose();
+                        if (leader.Current == null)
+                            StopCompetition();
+
+                        using (var otherLeader = leaders.GetEnumerator())
+                            while (otherLeader.MoveNext())
+                                if ((leader.Current.transform.position - otherLeader.Current.transform.position).sqrMagnitude < sqrDistance)
+                                    waiting = true;
+
+                        using (var pilot = pilots[leader.Current.weaponManager.Team].GetEnumerator())
+                            while (pilot.MoveNext())
+                                if (pilot.Current != null
+                                        && pilot.Current.currentCommand == PilotCommands.Follow
+                                        && (pilot.Current.vessel.CoM - pilot.Current.commandLeader.vessel.CoM).sqrMagnitude > 1000f * 1000f)
+                                    waiting = true;
+
+                        if (waiting) break;
                     }
-                    keys.Dispose();
-                }
 
                 yield return null;
             }
 
             //start the match
-            Dictionary<BDArmorySetup.BDATeams, List<IBDAIControl>>.KeyCollection.Enumerator pKeys = pilots.Keys.GetEnumerator();
-            while (pKeys.MoveNext())
-            {
-                List<IBDAIControl>.Enumerator pPilots = pilots[pKeys.Current].GetEnumerator();
-                while (pPilots.MoveNext())
-                {
-                    if (pPilots.Current == null) continue;
+            using (var teamPilots = pilots.GetEnumerator())
+                while (teamPilots.MoveNext())
+                    using (var pilot = teamPilots.Current.Value.GetEnumerator())
+                        while (pilot.MoveNext())
+                        {
+                            if (pilot.Current == null) continue;
 
-                    //enable guard mode
-                    if (!pPilots.Current.weaponManager.guardMode)
-                    {
-                      pPilots.Current.weaponManager.ToggleGuardMode();
-                    }
+                            if (!pilot.Current.weaponManager.guardMode)
+                                pilot.Current.weaponManager.ToggleGuardMode();
 
-                    //report all vessels
-                    if (BDATargetManager.BoolToTeam(pPilots.Current.weaponManager.team) == BDArmorySetup.BDATeams.B)
-                    {
-                        BDATargetManager.ReportVessel(pPilots.Current.vessel, aLeader.weaponManager);
-                    }
-                    else
-                    {
-                        BDATargetManager.ReportVessel(pPilots.Current.vessel, bLeader.weaponManager);
-                    }
+                            using (var leader = leaders.GetEnumerator())
+                                while (leader.MoveNext())
+                                    BDATargetManager.ReportVessel(pilot.Current.vessel, leader.Current.weaponManager);
 
-                    //release command
-                    pPilots.Current.ReleaseCommand();
-                    pPilots.Current.CommandAttack(centerGPS);
-                }
-            }
-            pKeys.Dispose();
+                            pilot.Current.ReleaseCommand();
+                            pilot.Current.CommandAttack(centerGPS);
+                        }
+            
             competitionStatus = "Competition starting!  Good luck!";
             yield return new WaitForSeconds(2);
             competitionStarting = false;

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,4 +1,22 @@
-﻿v1.2.4
+﻿v1.3.0
+* NEW FEATURES:
+	* Multiple teams are now supported by BDA.
+		* Probably breaks ALL the existing addons.
+			The new property is `Team` instead of `team`.
+			Review all existing references and check whether the check is for the same/different team (`==`/`!=`) or enemy/ally (use `isEnemy` and `isAlly`).
+			`TargetDatabase` and `GPSTargets` have gone private and are not guaranteed to contain all the teams anyway. 
+			Use `TargetList` and `GPSTargetList` instead.
+		* Will lose existing saved GPS targets.
+
+* ENHANCEMENTS:
+* FIXES
+	* AI pilot should now use torpedoes.
+	* Weapons will revert to default weapon group on blank weapon group entry.
+	* Missiles fired from turrets will obey drop time and decouple direction.
+	* Updated ballistics calculation acceleration extrapolation
+		(guard mode should hit bobbing ships more accurately).
+
+v1.2.4
 * NEW FEATURES:
 	* Weapons groups - different weapons firing in parallel(thanks to @SuicidalInsanity)
 * ENHANCEMENTS:

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -7,8 +7,9 @@
 			`TargetDatabase` and `GPSTargets` have gone private and are not guaranteed to contain all the teams anyway. 
 			Use `TargetList` and `GPSTargetList` instead.
 		* Will lose existing saved GPS targets.
-
+		* Right-click the team button to customize the teams in-game.
 * ENHANCEMENTS:
+	* Recompiled for KSP 1.6.1 
 * FIXES
 	* AI pilot should now use torpedoes.
 	* Weapons will revert to default weapon group on blank weapon group entry.

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -3,7 +3,7 @@
 	* Multiple teams are now supported by BDA.
 		* Probably breaks ALL the existing addons.
 			The new property is `Team` instead of `team`.
-			Review all existing references and check whether the check is for the same/different team (`==`/`!=`) or enemy/ally (use `isEnemy` and `isAlly`).
+			Review all existing references and check whether the check is for the same/different team (`==`/`!=`) or enemy/ally (use `IsEnemy` and `IsFriendly`).
 			`TargetDatabase` and `GPSTargets` have gone private and are not guaranteed to contain all the teams anyway. 
 			Use `TargetList` and `GPSTargetList` instead.
 		* Will lose existing saved GPS targets.

--- a/BDArmory/Misc/BDTeam.cs
+++ b/BDArmory/Misc/BDTeam.cs
@@ -54,9 +54,11 @@ namespace BDArmory.Misc
                 return BDTeam.Get("B");
             try
             {
-                BDTeam team = UnityEngine.JsonUtility.FromJson<BDTeam>(teamString);
+                BDTeam team = UnityEngine.JsonUtility.FromJson<BDTeam>(Misc.JsonDecompat(teamString));
                 if (!BDArmorySetup.Instance.Teams.ContainsKey(team.Name))
+                {
                     BDArmorySetup.Instance.Teams.Add(team.Name, team);
+                }
                 return BDArmorySetup.Instance.Teams[team.Name];
             }
             catch
@@ -67,7 +69,7 @@ namespace BDArmory.Misc
 
         public string Serialize()
         {
-            return UnityEngine.JsonUtility.ToJson(this);
+            return Misc.JsonCompat(UnityEngine.JsonUtility.ToJson(this));
         }
 
         public override int GetHashCode() => Name.GetHashCode();

--- a/BDArmory/Misc/BDTeam.cs
+++ b/BDArmory/Misc/BDTeam.cs
@@ -1,23 +1,25 @@
 ﻿using BDArmory.UI;
 using System;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace BDArmory.Misc
 {
     [Serializable]
     public class BDTeam
     {
-        public readonly string Name;
+        // No warranty is provided for changing the Name, but this makes serialization easier. :)
+        public string Name;
 
         public bool Neutral;
 
-        public HashSet<string> Allies;
+        public List<string> Allies = new List<string>();
 
-        public BDTeam(string name, HashSet<string> allies = null, bool neutral = false)
+        public BDTeam(string name, List<string> allies = null, bool neutral = false)
         {
             Name = name;
             Neutral = neutral;
-            Allies = allies ?? new HashSet<string>();
+            Allies = allies ?? new List<string>();
         }
 
         public static BDTeam Get(string name)

--- a/BDArmory/Misc/BDTeam.cs
+++ b/BDArmory/Misc/BDTeam.cs
@@ -1,0 +1,61 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace BDArmory.Misc
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    public class BDTeam
+    {
+        [JsonProperty]
+        public readonly string Name;
+
+        [JsonProperty]
+        public bool Neutral;
+
+        [JsonProperty]
+        public readonly List<string> Friends;
+
+        public BDTeam(string name, List<string> friends = null, bool neutral = false)
+        {
+            Name = name;
+            Friends = friends ?? new List<string>();
+            Neutral = neutral;
+        }
+
+        public bool IsEnemy(BDTeam other)
+        {
+            if (Neutral || other is null || other.Neutral || other.Name == Name || Friends.Contains(other.Name))
+                return false;
+            return true;
+        }
+
+        public override string ToString() => JsonConvert.SerializeObject(this);
+
+        public static BDTeam FromString(string teamString)
+        {
+            // Backward compatibility
+            if (string.IsNullOrEmpty(teamString) || teamString == "False")
+                return new BDTeam("A");
+            else if (teamString == "True")
+                return new BDTeam("B");
+            try
+            {
+                return JsonConvert.DeserializeObject<BDTeam>(teamString);
+            }
+            catch
+            {
+                return new BDTeam("A");
+            }
+        }
+
+        public override int GetHashCode() => Name.GetHashCode();
+
+        public bool Equals(BDTeam other) => Name == other?.Name;
+
+        public override bool Equals(object obj) => Equals(obj as BDTeam);
+
+        public static bool operator ==(BDTeam left, BDTeam right) => object.Equals(left, right);
+
+        public static bool operator !=(BDTeam left, BDTeam right) => !object.Equals(left, right);
+    }
+}

--- a/BDArmory/Misc/BDTeam.cs
+++ b/BDArmory/Misc/BDTeam.cs
@@ -8,19 +8,19 @@ namespace BDArmory.Misc
     public class BDTeam
     {
         [JsonProperty]
-        public string Name;
+        public readonly string Name;
 
         [JsonProperty]
         public bool Neutral;
 
         [JsonProperty]
-        public List<string> Allies;
+        public HashSet<string> Allies;
 
-        public BDTeam(string name, List<string> allies = null, bool neutral = false)
+        public BDTeam(string name, HashSet<string> allies = null, bool neutral = false)
         {
             Name = name;
             Neutral = neutral;
-            Allies = allies ?? new List<string>();
+            Allies = allies ?? new HashSet<string>();
         }
 
         public static BDTeam Get(string name)
@@ -32,11 +32,16 @@ namespace BDArmory.Misc
 
         public bool IsEnemy(BDTeam other)
         {
-            if (other == null)
-                return true;
-            if (Neutral || other.Neutral || other.Name == Name || Allies.Contains(other.Name))
+            if (Neutral || other == null || other.Neutral || other.Name == Name || Allies.Contains(other.Name))
                 return false;
             return true;
+        }
+
+        public bool IsFriendly(BDTeam other)
+        {
+            if (other == null)
+                return false;
+            return !IsEnemy(other);
         }
 
         public override string ToString() => Name;

--- a/BDArmory/Misc/BDTeam.cs
+++ b/BDArmory/Misc/BDTeam.cs
@@ -1,19 +1,16 @@
 ﻿using BDArmory.UI;
-using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace BDArmory.Misc
 {
-    [JsonObject(MemberSerialization.OptIn)]
+    [Serializable]
     public class BDTeam
     {
-        [JsonProperty]
         public readonly string Name;
 
-        [JsonProperty]
         public bool Neutral;
 
-        [JsonProperty]
         public HashSet<string> Allies;
 
         public BDTeam(string name, HashSet<string> allies = null, bool neutral = false)
@@ -55,7 +52,7 @@ namespace BDArmory.Misc
                 return BDTeam.Get("B");
             try
             {
-                BDTeam team = JsonConvert.DeserializeObject<BDTeam>(teamString);
+                BDTeam team = UnityEngine.JsonUtility.FromJson<BDTeam>(teamString);
                 if (!BDArmorySetup.Instance.Teams.ContainsKey(team.Name))
                     BDArmorySetup.Instance.Teams.Add(team.Name, team);
                 return BDArmorySetup.Instance.Teams[team.Name];
@@ -68,7 +65,7 @@ namespace BDArmory.Misc
 
         public string Serialize()
         {
-            return JsonConvert.SerializeObject(this);
+            return UnityEngine.JsonUtility.ToJson(this);
         }
 
         public override int GetHashCode() => Name.GetHashCode();

--- a/BDArmory/Misc/Misc.cs
+++ b/BDArmory/Misc/Misc.cs
@@ -331,5 +331,15 @@ namespace BDArmory.Misc
             FieldInfo field = typeof(GameSettings).GetField(groupName);
             return (KeyBinding) field.GetValue(null);
         }
+
+        public static string JsonCompat(string json)
+        {
+            return json.Replace('{', '<').Replace('}', '>');
+        }
+
+        public static string JsonDecompat(string json)
+        {
+            return json.Replace('<', '{').Replace('>', '}');
+        }
     }
 }

--- a/BDArmory/Modules/BDGenericAIBase.cs
+++ b/BDArmory/Modules/BDGenericAIBase.cs
@@ -182,7 +182,7 @@ namespace BDArmory.Modules
 				part.OnJustAboutToBeDestroyed += DeactivatePilot;
 				vessel.OnJustAboutToBeDestroyed += DeactivatePilot;
                 GameEvents.onVesselWasModified.Add(onVesselWasModified);
-				MissileFire.OnToggleTeam += OnToggleTeam;
+				MissileFire.OnChangeTeam += OnToggleTeam;
 
                 activeVessel = vessel;
 				UpdateWeaponManager();
@@ -198,7 +198,7 @@ namespace BDArmory.Modules
 
 		protected virtual void OnDestroy()
 		{
-			MissileFire.OnToggleTeam -= OnToggleTeam;
+			MissileFire.OnChangeTeam -= OnToggleTeam;
 		}
 
 		protected virtual void OnGUI()

--- a/BDArmory/Modules/BDGenericAIBase.cs
+++ b/BDArmory/Modules/BDGenericAIBase.cs
@@ -210,7 +210,7 @@ namespace BDArmory.Modules
 			}
 		}
 
-		protected virtual void OnToggleTeam(MissileFire mf, BDArmorySetup.BDATeams team)
+		protected virtual void OnToggleTeam(MissileFire mf, BDTeam team)
 		{
 			if (mf.vessel == vessel || (commandLeader && commandLeader.vessel == mf.vessel))
 			{
@@ -291,7 +291,7 @@ namespace BDArmory.Modules
 		{
 			if (weaponManager != null && !weaponManager.guardMode)
 			{
-				if (vessel.targetObject?.GetVessel()?.FindPartModuleImplementing<MissileFire>()?.team == !weaponManager.team)
+				if (weaponManager.Team.IsEnemy(vessel.targetObject?.GetVessel()?.FindPartModuleImplementing<MissileFire>()?.Team))
 					targetVessel = (Vessel)vessel.targetObject;
 			}
 		}

--- a/BDArmory/Modules/BDModularGuidance.cs
+++ b/BDArmory/Modules/BDModularGuidance.cs
@@ -846,7 +846,7 @@ namespace BDArmory.Modules
                 while (wpm.MoveNext())
                 {
                     if (wpm.Current == null) continue;
-                    Team = wpm.Current.team;
+                    Team = wpm.Current.Team;
                     break;
                 }
                 wpm.Dispose();

--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -982,11 +982,7 @@ namespace BDArmory.Modules
 				if (weaponManager.TargetOverride)
 				{
 					extending = false;
-					weaponManager.ForceWideViewScan();
 				}
-				else
-					weaponManager.ForceWideViewScan();
-
 
 				float extendDistance = Mathf.Clamp(weaponManager.guardRange-1800, 2500, 4000);
 

--- a/BDArmory/Modules/MissileBase.cs
+++ b/BDArmory/Modules/MissileBase.cs
@@ -148,7 +148,7 @@ namespace BDArmory.Modules
 
         public bool HasFired { get; set; } = false;
 
-        public bool Team { get; set; }
+        public BDTeam Team { get; set; }
 
         public bool HasMissed { get; set; } = false;
 
@@ -287,7 +287,7 @@ namespace BDArmory.Modules
         protected void AddTargetInfoToVessel()
         {
             TargetInfo info = vessel.gameObject.AddComponent<TargetInfo>();
-            info.team = BDATargetManager.BoolToTeam(Team);
+            info.Team = Team;
             info.isMissile = true;
             info.MissileBaseModule = this;
         }

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -673,7 +673,7 @@ namespace BDArmory.Modules
             heatTarget = TargetSignatureData.noTarget;
         }
 
-        public override void OnStart(StartState state)
+        public void Start()
         {
             team_loaded = true;
             Team = BDTeam.Deserialize(team);

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -465,17 +465,14 @@ namespace BDArmory.Modules
         {
             get
             {
-                BDTeam value;
-                if (BDArmorySetup.Instance.BDTeams.TryGetValue(teamString, out value))
-                    return value;
-                return new BDTeam(teamString);
+                return BDTeam.Get(teamString);
             }
             set
             {
+                if (!BDArmorySetup.Instance.Teams.ContainsKey(value.Name))
+                    BDArmorySetup.Instance.Teams.Add(value.Name, value);
                 teamString = value.Name;
-                if (!BDArmorySetup.Instance.BDTeams.ContainsKey(teamString))
-                    BDArmorySetup.Instance.BDTeams.Add(value.Name, value);
-                team = BDArmorySetup.Instance.BDTeams[value.Name].ToString();
+                team = value.Serialize();
             }
         }
         
@@ -502,12 +499,12 @@ namespace BDArmory.Modules
         public void NextTeam()
         {
             var teamList = new List<string> { "A", "B" };
-            using (var teams = BDArmorySetup.Instance.BDTeams.GetEnumerator())
+            using (var teams = BDArmorySetup.Instance.Teams.GetEnumerator())
                 while (teams.MoveNext())
                     if (!teamList.Contains(teams.Current.Key) && !teams.Current.Value.Neutral)
                         teamList.Add(teams.Current.Key);
             teamList.Sort();
-            Team = BDArmorySetup.Instance.BDTeams[teamList[(teamList.IndexOf(Team.Name) + 1) % teamList.Count]];
+            Team = BDArmorySetup.Instance.Teams[teamList[(teamList.IndexOf(Team.Name) + 1) % teamList.Count]];
 
             if (HighLogic.LoadedSceneIsFlight || HighLogic.LoadedSceneIsEditor)
             {
@@ -666,7 +663,7 @@ namespace BDArmory.Modules
 
         public override void OnAwake()
         {
-            Team = BDTeam.FromString(team);
+            Team = BDTeam.Deserialize(team);
 
             clickSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/click");
             warningSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/warning");

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -502,7 +502,7 @@ namespace BDArmory.Modules
                     if (!teamList.Contains(teams.Current.Key) && !teams.Current.Value.Neutral)
                         teamList.Add(teams.Current.Key);
             teamList.Sort();
-            Team = BDArmorySetup.Instance.Teams[teamList[(teamList.IndexOf(Team.Name) + 1) % teamList.Count]];
+            Team = BDTeam.Get(teamList[(teamList.IndexOf(Team.Name) + 1) % teamList.Count]);
 
             if (HighLogic.LoadedSceneIsFlight || HighLogic.LoadedSceneIsEditor)
             {

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -461,16 +461,37 @@ namespace BDArmory.Modules
 		}
 		
 		
-		[KSPField(guiActive = true, guiActiveEditor = true, guiName = "Team")]
-		public string teamString = "A";
 		void UpdateTeamString()
 		{
 			teamString = Enum.GetName(typeof(BDArmorySetup.BDATeams), BDATargetManager.BoolToTeam(team));
 		}
 		
 		
+        public BDTeam Team
+        {
+            get
+            {
+                BDTeam value;
+                if (BDArmorySetup.Instance.BDTeams.TryGetValue(teamString, out value))
+                    return value;
+                return new BDTeam(teamString);
+            }
+            set
+            {
+                teamString = value.Name;
+                if (!BDArmorySetup.Instance.BDTeams.ContainsKey(teamString))
+                    BDArmorySetup.Instance.BDTeams.Add(value.Name, value);
+                team = BDArmorySetup.Instance.BDTeams[value.Name].ToString();
+            }
+        }
+        
+        // Team name
+		[KSPField(guiActive = true, guiActiveEditor = true, guiName = "Team")]
+		public string teamString = "A";
+        
+        // Serialized team
 		[KSPField(isPersistant = true)]
-        public bool team = false;
+        public string team;
 
 
         [KSPAction("Toggle Team")]
@@ -644,6 +665,8 @@ namespace BDArmory.Modules
 
         public override void OnAwake()
         {
+            Team = BDTeam.FromString(team);
+
             clickSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/click");
             warningSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/warning");
             armOnSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/armOn");

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -467,6 +467,7 @@ namespace BDArmory.Modules
             }
             set
             {
+                if (!team_loaded) return;
                 if (!BDArmorySetup.Instance.Teams.ContainsKey(value.Name))
                     BDArmorySetup.Instance.Teams.Add(value.Name, value);
                 teamString = value.Name;
@@ -476,11 +477,12 @@ namespace BDArmory.Modules
         
         // Team name
 		[KSPField(guiActive = true, guiActiveEditor = true, guiName = "Team")]
-		public string teamString = "A";
+		public string teamString = "Neutral";
         
         // Serialized team
 		[KSPField(isPersistant = true)]
         public string team;
+        private bool team_loaded = false;
 
 
         [KSPAction("Next Team")]
@@ -661,8 +663,6 @@ namespace BDArmory.Modules
 
         public override void OnAwake()
         {
-            Team = BDTeam.Deserialize(team);
-
             clickSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/click");
             warningSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/warning");
             armOnSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/armOn");
@@ -675,6 +675,9 @@ namespace BDArmory.Modules
 
         public override void OnStart(StartState state)
         {
+            team_loaded = true;
+            Team = BDTeam.Deserialize(team);
+
             UpdateMaxGuardRange();
 
             startTime = Time.time;

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -1463,7 +1463,7 @@ namespace BDArmory.Modules
                 //check database for target first
                 float twoxsqrRad = 4f * radius * radius;
                 bool foundTargetInDatabase = false;
-                List<GPSTargetInfo>.Enumerator gps = BDATargetManager.GPSTargets[BDATargetManager.BoolToTeam(team)].GetEnumerator();
+                List<GPSTargetInfo>.Enumerator gps = BDATargetManager.GPSTargetList(Team).GetEnumerator();
                 while (gps.MoveNext())
                 {
                     if (!((gps.Current.worldPos - guardTarget.CoM).sqrMagnitude < twoxsqrRad)) continue;

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -3597,7 +3597,7 @@ namespace BDArmory.Modules
             // but to prevent AI from stopping an engagement just because a target dropped behind a small hill 5 seconds ago, clamp the timeout to 30 seconds
             // i.e. let's have at least some object permanence :)
             // (Ideally, I'd love to have "stale targets", where AI would attack the last known position, but that's a feature for the future)
-            if (Time.time - target.detectedTime < Mathf.Max(targetScanInterval, 30))
+            if (target.detectedTime.TryGetValue(Team, out float detectedTime) && Time.time - detectedTime < Mathf.Max(targetScanInterval, 30))
                 return true;
 
             // can we get a visual sight of the target?
@@ -4008,8 +4008,8 @@ namespace BDArmory.Modules
                     TargetInfo nearbyThreat = BDATargetManager.GetTargetFromWeaponManager(results.threatWeaponManager);
 
                     if (nearbyThreat?.weaponManager != null && nearbyFriendly?.weaponManager != null)
-                        if (nearbyThreat.weaponManager.team != team &&
-                            nearbyFriendly.weaponManager.team == team)
+                        if (Team.IsEnemy(nearbyThreat.weaponManager.Team) &&
+                            nearbyFriendly.weaponManager.Team == Team)
                         //turns out that there's no check for AI on the same team going after each other due to this.  Who knew?
                         {
                             if (nearbyThreat == currentTarget && nearbyFriendly.weaponManager.currentTarget != null)

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -519,7 +519,7 @@ namespace BDArmory.Modules
                 {
                     if (vessel.gameObject.GetComponent<TargetInfo>())
                     {
-                        vessel.gameObject.GetComponent<TargetInfo>().RemoveFromDatabases();
+                        BDATargetManager.RemoveTarget(vessel.gameObject.GetComponent<TargetInfo>());
                         Destroy(vessel.gameObject.GetComponent<TargetInfo>());
                     }
                     OnChangeTeam?.Invoke(this, Team);

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -344,8 +344,6 @@ namespace BDArmory.Modules
         public bool underFire;
         Coroutine ufRoutine;
 
-        bool focusingOnTarget;
-        float focusingOnTargetTimer;
         public Vector3 incomingThreatPosition;
         public Vessel incomingThreatVessel;
 
@@ -4036,12 +4034,6 @@ namespace BDArmory.Modules
                 }
                 ufRoutine = StartCoroutine(UnderFireRoutine());
             }
-        }
-
-        public void ForceWideViewScan()
-        {
-            focusingOnTarget = false;
-            focusingOnTargetTimer = 1;
         }
 
         public void ForceScan()

--- a/BDArmory/Modules/MissileLauncher.cs
+++ b/BDArmory/Modules/MissileLauncher.cs
@@ -693,7 +693,7 @@ namespace BDArmory.Modules
 		    while(wpm.MoveNext())
 		    {
 		        if (wpm.Current == null) continue;
-		        Team = wpm.Current.team;	
+		        Team = wpm.Current.Team;	
 		        break;
 		    }
 		    wpm.Dispose();

--- a/BDArmory/Modules/ModuleTargetingCamera.cs
+++ b/BDArmory/Modules/ModuleTargetingCamera.cs
@@ -1148,7 +1148,7 @@ namespace BDArmory.Modules
 		{
 			if(groundStabilized && weaponManager)
 			{
-				BDATargetManager.GPSTargets[BDATargetManager.BoolToTeam(weaponManager.team)].Add(new GPSTargetInfo(bodyRelativeGTP, "Target"));
+				BDATargetManager.GPSTargets[weaponManager.team.Name].Add(new GPSTargetInfo(bodyRelativeGTP, "Target"));
 			}
 		}
 

--- a/BDArmory/Modules/ModuleTargetingCamera.cs
+++ b/BDArmory/Modules/ModuleTargetingCamera.cs
@@ -1148,7 +1148,7 @@ namespace BDArmory.Modules
 		{
 			if(groundStabilized && weaponManager)
 			{
-				BDATargetManager.GPSTargets[weaponManager.team.Name].Add(new GPSTargetInfo(bodyRelativeGTP, "Target"));
+				BDATargetManager.GPSTargetList(weaponManager.Team).Add(new GPSTargetInfo(bodyRelativeGTP, "Target"));
 			}
 		}
 

--- a/BDArmory/Modules/ModuleTargetingCamera.cs
+++ b/BDArmory/Modules/ModuleTargetingCamera.cs
@@ -1149,7 +1149,8 @@ namespace BDArmory.Modules
 			if(groundStabilized && weaponManager)
 			{
 				BDATargetManager.GPSTargetList(weaponManager.Team).Add(new GPSTargetInfo(bodyRelativeGTP, "Target"));
-			}
+                BDATargetManager.Instance.SaveGPSTargets();
+            }
 		}
 
 		void SlaveTurrets()

--- a/BDArmory/Modules/ModuleWingCommander.cs
+++ b/BDArmory/Modules/ModuleWingCommander.cs
@@ -74,7 +74,7 @@ namespace BDArmory.Modules
                 GameEvents.onVesselLoaded.Add(OnVesselLoad);
                 GameEvents.onVesselDestroy.Add(OnVesselLoad);
                 GameEvents.onVesselGoOnRails.Add(OnVesselLoad);
-                MissileFire.OnToggleTeam += OnToggleTeam;
+                MissileFire.OnChangeTeam += OnToggleTeam;
 
                 screenMessage = new ScreenMessage("", 2, ScreenMessageStyle.LOWER_CENTER);
             }
@@ -108,7 +108,7 @@ namespace BDArmory.Modules
                 GameEvents.onVesselLoaded.Remove(OnVesselLoad);
                 GameEvents.onVesselDestroy.Remove(OnVesselLoad);
                 GameEvents.onVesselGoOnRails.Remove(OnVesselLoad);
-                MissileFire.OnToggleTeam -= OnToggleTeam;
+                MissileFire.OnChangeTeam -= OnToggleTeam;
             }
         }
 

--- a/BDArmory/Modules/ModuleWingCommander.cs
+++ b/BDArmory/Modules/ModuleWingCommander.cs
@@ -80,7 +80,7 @@ namespace BDArmory.Modules
             }
         }
 
-        void OnToggleTeam(MissileFire mf, BDArmorySetup.BDATeams team)
+        void OnToggleTeam(MissileFire mf, BDTeam team)
         {
             RefreshFriendlies();
             RefreshWingmen();
@@ -151,7 +151,7 @@ namespace BDArmory.Modules
                 }
                 ws.Dispose();
 
-                if (!wm || wm.team != weaponManager.team) continue;
+                if (!wm || wm.Team != weaponManager.Team) continue;
                 friendlies.Add(pilot);
             }
             vs.Dispose();
@@ -176,7 +176,7 @@ namespace BDArmory.Modules
                 focusIndexes.Clear();
                 return;
             }
-            wingmen.RemoveAll(w => w == null || (w.weaponManager && w.weaponManager.team != weaponManager.team));
+            wingmen.RemoveAll(w => w == null || (w.weaponManager && w.weaponManager.Team != weaponManager.Team));
 
             List<int> uniqueIndexes = new List<int>();
             List<int>.Enumerator fIndexes = focusIndexes.GetEnumerator();

--- a/BDArmory/Parts/GPSTargetInfo.cs
+++ b/BDArmory/Parts/GPSTargetInfo.cs
@@ -1,17 +1,16 @@
-﻿using Newtonsoft.Json;
+﻿using System;
 using BDArmory.Misc;
 
 namespace BDArmory.Parts
 {
-    [JsonObject(MemberSerialization.OptIn)]
+    [Serializable]
     public struct GPSTargetInfo
     {
-        [JsonProperty]
         public Vector3d gpsCoordinates;
 
-        [JsonProperty]
         public string name;
 
+        [NonSerialized]
         public Vessel gpsVessel;
 
         public Vector3d worldPos

--- a/BDArmory/Parts/GPSTargetInfo.cs
+++ b/BDArmory/Parts/GPSTargetInfo.cs
@@ -1,11 +1,17 @@
-﻿using BDArmory.Misc;
+﻿using Newtonsoft.Json;
+using BDArmory.Misc;
 
 namespace BDArmory.Parts
 {
+    [JsonObject(MemberSerialization.OptIn)]
     public struct GPSTargetInfo
     {
+        [JsonProperty]
         public Vector3d gpsCoordinates;
+
+        [JsonProperty]
         public string name;
+
         public Vessel gpsVessel;
 
         public Vector3d worldPos

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -541,7 +541,7 @@ namespace BDArmory.Radar
                 MissileFire wm = loadedvessels.Current.FindPartModuleImplementing<MissileFire>();
                 if (wm != null)
                 {
-                    if (missile.Team == wm.team)
+                    if (missile.Team.IsFriendly(wm.Team))
                         continue;
                 }                
 

--- a/BDArmory/Radar/VesselRadarData.cs
+++ b/BDArmory/Radar/VesselRadarData.cs
@@ -765,7 +765,7 @@ namespace BDArmory.Radar
                 TargetSignatureData lockedTarget = displayedTargets[lockedTargetIndexes[i]].targetData;
                 if (i == activeLockedTargetIndex)
                 {
-                    if (weaponManager && weaponManager.Team.IsEnemy(lockedTarget.team))
+                    if (weaponManager && weaponManager.Team.IsEnemy(lockedTarget.Team))
                     {
                         BDGUIUtils.DrawTextureOnWorldPos(lockedTarget.predictedPosition,
                             BDArmorySetup.Instance.crossedGreenSquare, new Vector2(20, 20), 0);
@@ -1893,7 +1893,7 @@ namespace BDArmory.Radar
                         Color origGUIColor = GUI.color;
                         GUI.color = Color.white - new Color(0, 0, 0, minusAlpha);
                         if (weaponManager &&
-                            displayedTargets[i].targetData.Team == weaponManager.Team)
+                            weaponManager.Team.IsFriendly(displayedTargets[i].targetData.Team))
                         {
                             GUI.DrawTexture(pingRect, friendlyContactIcon, ScaleMode.StretchToFill, true);
                         }
@@ -1973,7 +1973,7 @@ namespace BDArmory.Radar
                             }
 
                             if (jammed ||
-                                displayedTargets[i].targetData.Team != weaponManager.Team)
+                                !weaponManager.Team.IsFriendly(displayedTargets[i].targetData.Team))
                             {
                                 BDGUIUtils.DrawRectangle(jammedRect, iconColor - new Color(0, 0, 0, minusAlpha));
                             }

--- a/BDArmory/Radar/VesselRadarData.cs
+++ b/BDArmory/Radar/VesselRadarData.cs
@@ -360,19 +360,13 @@ namespace BDArmory.Radar
             }
             rad.Dispose();
             // Now rebuild range display array
-            bool maxReached = false;
             List<float> newArray = new List<float>();
             for (int x = 0; x < baseIncrements.Length; x++)
             {
-                if (_maxRadarRange > baseIncrements[x])
+                newArray.Add(baseIncrements[x]);
+                if (_maxRadarRange <= baseIncrements[x])
                 {
-                    newArray.Add(baseIncrements[x]);
-                }
-                else if (maxReached) break;
-                else
-                {
-                    newArray.Add(baseIncrements[x]);
-                    maxReached = true;
+                    break;
                 }
             }
             if (newArray.Count > 0) rIncrements = newArray.ToArray();

--- a/BDArmory/Radar/VesselRadarData.cs
+++ b/BDArmory/Radar/VesselRadarData.cs
@@ -453,7 +453,7 @@ namespace BDArmory.Radar
                 {
                     radarsToRemove.Add(radar.Current);
                 }
-                else if (!radar.Current.weaponManager || (weaponManager && radar.Current.weaponManager.team != weaponManager.team))
+                else if (!radar.Current.weaponManager || (weaponManager && radar.Current.weaponManager.Team != weaponManager.Team))
                 {
                     radarsToRemove.Add(radar.Current);
                 }
@@ -771,7 +771,7 @@ namespace BDArmory.Radar
                 TargetSignatureData lockedTarget = displayedTargets[lockedTargetIndexes[i]].targetData;
                 if (i == activeLockedTargetIndex)
                 {
-                    if (weaponManager && lockedTarget.team == BDATargetManager.BoolToTeam(weaponManager.team))
+                    if (weaponManager && weaponManager.Team.IsEnemy(lockedTarget.team))
                     {
                         BDGUIUtils.DrawTextureOnWorldPos(lockedTarget.predictedPosition,
                             BDArmorySetup.Instance.crossedGreenSquare, new Vector2(20, 20), 0);
@@ -1385,17 +1385,17 @@ namespace BDArmory.Radar
             {
                 if (v.Current == null || !v.Current.loaded || vessel == null || v.Current == vessel) continue;
 
-                BDArmorySetup.BDATeams team = BDArmorySetup.BDATeams.None;
+                BDTeam team = null;
                 List<MissileFire>.Enumerator mf = v.Current.FindPartModulesImplementing<MissileFire>().GetEnumerator();
                 while (mf.MoveNext())
                 {
                     if (mf.Current == null) continue;
-                    team = BDATargetManager.BoolToTeam(mf.Current.team);
+                    team = mf.Current.Team;
                     break;
                 }
                 mf.Dispose();
 
-                if (team != BDATargetManager.BoolToTeam(weaponManager.team)) continue;
+                if (team != weaponManager.Team) continue;
                 VesselRadarData vrd = v.Current.gameObject.GetComponent<VesselRadarData>();
                 if (vrd && vrd.radarCount > 0)
                 {
@@ -1899,7 +1899,7 @@ namespace BDArmory.Radar
                         Color origGUIColor = GUI.color;
                         GUI.color = Color.white - new Color(0, 0, 0, minusAlpha);
                         if (weaponManager &&
-                            displayedTargets[i].targetData.team == BDATargetManager.BoolToTeam(weaponManager.team))
+                            displayedTargets[i].targetData.Team == weaponManager.Team)
                         {
                             GUI.DrawTexture(pingRect, friendlyContactIcon, ScaleMode.StretchToFill, true);
                         }
@@ -1979,7 +1979,7 @@ namespace BDArmory.Radar
                             }
 
                             if (jammed ||
-                                displayedTargets[i].targetData.team != BDATargetManager.BoolToTeam(weaponManager.team))
+                                displayedTargets[i].targetData.Team != weaponManager.Team)
                             {
                                 BDGUIUtils.DrawRectangle(jammedRect, iconColor - new Color(0, 0, 0, minusAlpha));
                             }

--- a/BDArmory/Radar/VesselRadarData.cs
+++ b/BDArmory/Radar/VesselRadarData.cs
@@ -1864,7 +1864,7 @@ namespace BDArmory.Radar
                     //draw missiles and debris as dots
                     if ((displayedTargets[i].targetData.targetInfo &&
                          displayedTargets[i].targetData.targetInfo.isMissile) ||
-                        displayedTargets[i].targetData.team == BDArmorySetup.BDATeams.None)
+                        displayedTargets[i].targetData.Team == null)
                     {
                         float mDotSize = 6;
                         pingRect = new Rect(pingPosition.x - (mDotSize / 2), pingPosition.y - (mDotSize / 2), mDotSize,

--- a/BDArmory/Radar/VesselRadarData.cs
+++ b/BDArmory/Radar/VesselRadarData.cs
@@ -244,7 +244,7 @@ namespace BDArmory.Radar
             mf.Dispose();
             GameEvents.onVesselDestroy.Add(OnVesselDestroyed);
             GameEvents.onVesselCreate.Add(OnVesselDestroyed);
-            MissileFire.OnToggleTeam += OnToggleTeam;
+            MissileFire.OnChangeTeam += OnChangeTeam;
             GameEvents.onGameStateSave.Add(OnGameStateSave);
             GameEvents.onPartDestroyed.Add(PartDestroyed);
 
@@ -315,7 +315,7 @@ namespace BDArmory.Radar
         {
             GameEvents.onVesselDestroy.Remove(OnVesselDestroyed);
             GameEvents.onVesselCreate.Remove(OnVesselDestroyed);
-            MissileFire.OnToggleTeam -= OnToggleTeam;
+            MissileFire.OnChangeTeam -= OnChangeTeam;
             GameEvents.onGameStateSave.Remove(OnGameStateSave);
             GameEvents.onPartDestroyed.Remove(PartDestroyed);
 
@@ -328,11 +328,11 @@ namespace BDArmory.Radar
             }
         }
 
-        private void OnToggleTeam(MissileFire wm, BDArmorySetup.BDATeams team)
+        private void OnChangeTeam(MissileFire wm, BDTeam team)
         {
             if (!weaponManager || !wm) return;
 
-            if (team != BDATargetManager.BoolToTeam(weaponManager.team))
+            if (team != weaponManager.Team)
             {
                 if (wm.vesselRadarData)
                 {

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -14,7 +14,7 @@ namespace BDArmory.Targeting
 		public bool isMissile;
 		public MissileBase MissileBaseModule;
 		public MissileFire weaponManager;
-        Dictionary<BDTeam, List<MissileFire>> friendliesEngaging;
+        Dictionary<BDTeam, List<MissileFire>> friendliesEngaging = new Dictionary<BDTeam, List<MissileFire>>();
         public Dictionary<BDTeam, float> detectedTime = new Dictionary<BDTeam, float>();
 
         public float radarBaseSignature = -1;
@@ -262,10 +262,12 @@ namespace BDArmory.Targeting
                 return;
 
             if (friendliesEngaging.TryGetValue(mf.Team, out var friendlies))
+            {
                 if (!friendlies.Contains(mf))
                     friendlies.Add(mf);
-                else
-                    friendliesEngaging.Add(mf.Team, new List<MissileFire> { mf });
+            }
+            else
+                friendliesEngaging.Add(mf.Team, new List<MissileFire> { mf });
 		}
 
 		public void Disengage(MissileFire mf)

--- a/BDArmory/Targeting/TargetSignatureData.cs
+++ b/BDArmory/Targeting/TargetSignatureData.cs
@@ -60,9 +60,9 @@ namespace BDArmory.Targeting
 
             Team = null;
 
-			if(targetInfo)
+			if(targetInfo)  // Always true, as we just set it?
 			{
-				Team = targetInfo.team;
+				Team = targetInfo.Team;
                 targetInfo.detectedTime = Time.time;
             }
 			else

--- a/BDArmory/Targeting/TargetSignatureData.cs
+++ b/BDArmory/Targeting/TargetSignatureData.cs
@@ -63,7 +63,6 @@ namespace BDArmory.Targeting
 			if(targetInfo)  // Always true, as we just set it?
 			{
 				Team = targetInfo.Team;
-                targetInfo.detectedTime = Time.time;
             }
 			else
 			{

--- a/BDArmory/Targeting/TargetSignatureData.cs
+++ b/BDArmory/Targeting/TargetSignatureData.cs
@@ -19,7 +19,7 @@ namespace BDArmory.Targeting
 		public float timeAcquired;
         public float signalStrength;
 		public TargetInfo targetInfo;
-		public BDArmorySetup.BDATeams team;
+		public BDTeam Team;
 		public Vector2 pingPosition;
 		public VesselECMJInfo vesselJammer;
 		public ModuleRadar lockedByRadar;
@@ -58,11 +58,11 @@ namespace BDArmory.Targeting
                 targetInfo = v.gameObject.AddComponent<TargetInfo>();
             }
 
-            team = BDArmorySetup.BDATeams.None;
+            Team = null;
 
 			if(targetInfo)
 			{
-				team = targetInfo.team;
+				Team = targetInfo.team;
                 targetInfo.detectedTime = Time.time;
             }
 			else
@@ -70,7 +70,7 @@ namespace BDArmory.Targeting
                 List<MissileFire>.Enumerator mf = v.FindPartModulesImplementing<MissileFire>().GetEnumerator();
                 while (mf.MoveNext())
                 {
-                    team = BDATargetManager.BoolToTeam(mf.Current.team);
+                    Team = mf.Current.Team;
 					break;
 				}
                 mf.Dispose();
@@ -92,7 +92,7 @@ namespace BDArmory.Targeting
 			signalStrength = _signalStrength;
 			targetInfo = null;
 			vesselJammer = null;
-			team = BDArmorySetup.BDATeams.None;
+			Team = null;
 			pingPosition = Vector2.zero;
 			orbital = false;
 			orbit = null;
@@ -110,7 +110,7 @@ namespace BDArmory.Targeting
 			signalStrength = _signalStrength;
 			targetInfo = null;
 			vesselJammer = null;
-			team = BDArmorySetup.BDATeams.None;
+			Team = null;
 			pingPosition = Vector2.zero;
 			orbital = false;
 			orbit = null;

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -19,8 +19,8 @@ namespace BDArmory.UI
 	[KSPAddon(KSPAddon.Startup.Flight, false)]
 	public class BDATargetManager : MonoBehaviour
 	{
-		public static Dictionary<BDTeam, List<TargetInfo>> TargetDatabase;
-		public static Dictionary<BDTeam, List<GPSTargetInfo>> GPSTargets;
+		private static Dictionary<BDTeam, List<TargetInfo>> TargetDatabase;
+		private static Dictionary<BDTeam, List<GPSTargetInfo>> GPSTargets;
 		public static List<ModuleTargetingCamera> ActiveLasers;
 		public static List<IBDWeapon> FiredMissiles;
 		public static List<DestructibleBuilding> LoadedBuildings;

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -342,9 +342,10 @@ namespace BDArmory.UI
                     continue;
 
                 TargetInfo tInfo = vessel.gameObject.GetComponent<TargetInfo>();
+                // If no weaponManager or no target or the target is not a missile with engines on..??? and the target weighs less than 50kg, abort.
 				if(mf == null || 
 					!tInfo || 
-					!(mf && tInfo.isMissile && tInfo.team != BoolToTeam(mf.team) && (tInfo.MissileBaseModule.MissileState == MissileBase.MissileStates.Boost || tInfo.MissileBaseModule.MissileState == MissileBase.MissileStates.Cruise)))
+					!(mf && tInfo.isMissile && (tInfo.MissileBaseModule.MissileState == MissileBase.MissileStates.Boost || tInfo.MissileBaseModule.MissileState == MissileBase.MissileStates.Cruise)))
 				{
 					if(vessel.GetTotalMass() < minMass)
 					{
@@ -352,9 +353,10 @@ namespace BDArmory.UI
 					}
 				}
 
+                // Abort if target is friendly.
 			    if (mf != null && tInfo != null)
 			    {
-			        if (BoolToTeam(mf.team) == tInfo.team)
+			        if (mf.Team.IsFriendly(tInfo.Team))
 			        {
 			            continue;
 			        }
@@ -583,14 +585,6 @@ namespace BDArmory.UI
             catch { }
 		}
 
-		//Legacy target managing stuff
-
-        [Obsolete]
-		public static BDArmorySetup.BDATeams BoolToTeam(bool team)
-		{
-			return team ? BDArmorySetup.BDATeams.B : BDArmorySetup.BDATeams.A;
-		}
-
 		IEnumerator CleanDatabaseRoutine()
 		{
 			while(enabled)
@@ -646,7 +640,7 @@ namespace BDArmory.UI
                     if (ml.Current == null) continue;
                     if (ml.Current.HasFired)
                     {
-                        if (ml.Current.Team != reporter.team)
+                        if (reporter.Team.IsEnemy(ml.Current.Team))
                         {
                             info = v.gameObject.AddComponent<TargetInfo>();
                             break;

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -1,7 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
 using BDArmory.Core.Extension;
 using BDArmory.CounterMeasure;
 using BDArmory.Misc;
@@ -556,15 +554,21 @@ namespace BDArmory.UI
 			}
 		}
 
+        [Serializable]
+        public class GPSInfoContainer
+        {
+            public Dictionary<string, List<GPSTargetInfo>> data = new Dictionary<string, List<GPSTargetInfo>>();
+        }
+
 		//format: json
 		private string GPSListToString()
 		{
-            var dictForSerialization = new Dictionary<string, List<GPSTargetInfo>>();
+            var dictForSerialization = new GPSInfoContainer();
             using (var kvp = GPSTargets.GetEnumerator())
                 while (kvp.MoveNext())
-                    dictForSerialization.Add(kvp.Current.Key.Name, kvp.Current.Value);
+                    dictForSerialization.data.Add(kvp.Current.Key.Name, kvp.Current.Value);
 
-			return JsonConvert.SerializeObject(dictForSerialization);
+			return JsonUtility.ToJson(dictForSerialization);
 		}
 
 		private void StringToGPSList(string listString)
@@ -575,9 +579,9 @@ namespace BDArmory.UI
 			}
             try
             {
-                var deserializedDict = JsonConvert.DeserializeObject<Dictionary<string, List<GPSTargetInfo>>>(listString);
+                var deserializedDict = JsonUtility.FromJson<GPSInfoContainer>(listString);
 			    GPSTargets.Clear();
-                using (var kvp = deserializedDict.GetEnumerator())
+                using (var kvp = deserializedDict.data.GetEnumerator())
                     while (kvp.MoveNext())
                         GPSTargets.Add(BDTeam.Get(kvp.Current.Key), kvp.Current.Value);
 

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -456,7 +456,7 @@ namespace BDArmory.UI
         }
 
 		
-		void SaveGPSTargets(ConfigNode saveNode)
+		public void SaveGPSTargets(ConfigNode saveNode = null)
 		{
 			string saveTitle = HighLogic.CurrentGame.Title;
 			Debug.Log("[BDArmory]: Save title: " + saveTitle);

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -178,7 +178,6 @@ namespace BDArmory.UI
                     updateTimer = 0.5f;    //next update in half a sec only
                 }
 			}
-
 		}
 
 		public static void RegisterLaserPoint(ModuleTargetingCamera cam)
@@ -688,7 +687,7 @@ namespace BDArmory.UI
             }
 
             // add target to database
-            if (info)
+            if (info && reporter.Team.IsEnemy(info.Team))
             {
                 AddTarget(info, reporter.Team);
                 info.detectedTime[reporter.Team] = Time.time;

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -721,7 +721,14 @@ namespace BDArmory.UI
                         new Rect(leftIndent + (contentWidth/2), contentTop + (line*entryHeight), contentWidth/2,
                             entryHeight), teamText, teamButtonStyle))
                 {
-                    ActiveWeaponManager.NextTeam();
+                    if (Event.current.button == 1)
+                    {
+                        BDTeamSelector.Instance.Open(ActiveWeaponManager, new Vector2(Input.mousePosition.x, Screen.height - Input.mousePosition.y));
+                    }
+                    else
+                    {
+                        ActiveWeaponManager.NextTeam();
+                    }
                 }
                 line++;
                 line += 0.25f;

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1287,6 +1287,7 @@ namespace BDArmory.UI
                     new GPSTargetInfo(BDATargetManager.GPSTargetList(myTeam)[editingGPSNameIndex].gpsCoordinates,
                         newGPSName);
                 editingGPSNameIndex = 0;
+                BDATargetManager.Instance.SaveGPSTargets();
             }
 
             GUI.EndGroup();
@@ -1294,6 +1295,7 @@ namespace BDArmory.UI
             if (indexToRemove >= 0)
             {
                 BDATargetManager.GPSTargetList(myTeam).RemoveAt(indexToRemove);
+                BDATargetManager.Instance.SaveGPSTargets();
             }
 
             WindowRectGps.height = (2*gpsBorder) + (gpsEntryCount*gpsEntryHeight);

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -137,6 +137,7 @@ namespace BDArmory.UI
             B,
             None
         };
+        public Dictionary<string, BDTeam> BDTeams = new Dictionary<string, BDTeam> { { "Neutral", new BDTeam("Neutral", neutral: true) } };
 
         //competition mode
         float competitionDist = 8000;

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -131,6 +131,7 @@ namespace BDArmory.UI
         GUIStyle redErrorStyle;
         GUIStyle redErrorShadowStyle;
 
+        [Obsolete]
         public enum BDATeams
         {
             A,

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -713,25 +713,15 @@ namespace BDArmory.UI
                     }
                 }
 
-                GUIStyle teamButtonStyle;
-                string teamText = "Team: ";
-                if (ActiveWeaponManager.team)
-                {
-                    teamButtonStyle = BDGuiSkin.box;
-                    teamText += "B";
-                }
-                else
-                {
-                    teamButtonStyle = BDGuiSkin.button;
-                    teamText += "A";
-                }
+                GUIStyle teamButtonStyle = BDGuiSkin.box;
+                string teamText = $"Team: {ActiveWeaponManager.Team.Name}";
 
                 if (
                     GUI.Button(
                         new Rect(leftIndent + (contentWidth/2), contentTop + (line*entryHeight), contentWidth/2,
                             entryHeight), teamText, teamButtonStyle))
                 {
-                    ActiveWeaponManager.ToggleTeam();
+                    ActiveWeaponManager.NextTeam();
                 }
                 line++;
                 line += 0.25f;

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -627,7 +627,7 @@ namespace BDArmory.UI
                 //gpsWindowRect = GUI.Window(424333, gpsWindowRect, GPSWindow, "", GUI.skin.box);
                 BDGUIUtils.UseMouseEventInRect(WindowRectGps);
                 List<GPSTargetInfo>.Enumerator coord = 
-                  BDATargetManager.GPSTargets[BDATargetManager.BoolToTeam(ActiveWeaponManager.team)].GetEnumerator();
+                  BDATargetManager.GPSTargetList(ActiveWeaponManager.Team).GetEnumerator();
                 while (coord.MoveNext())
                 {
                   BDGUIUtils.DrawTextureOnWorldPos(coord.Current.worldPos, Instance.greenDotTexture, new Vector2(8, 8), 0);
@@ -1210,10 +1210,10 @@ namespace BDArmory.UI
             gpsEntryCount += 1.35f;
             int indexToRemove = -1;
             int index = 0;
-            BDATeams myTeam = BDATargetManager.BoolToTeam(ActiveWeaponManager.team);
+            BDTeam myTeam = ActiveWeaponManager.Team;
             if (showTargets)
             {
-              List<GPSTargetInfo>.Enumerator coordinate = BDATargetManager.GPSTargets[myTeam].GetEnumerator();
+              List<GPSTargetInfo>.Enumerator coordinate = BDATargetManager.GPSTargetList(myTeam).GetEnumerator();
               while (coordinate.MoveNext())
               {
                 Color origWColor = GUI.color;
@@ -1286,16 +1286,16 @@ namespace BDArmory.UI
               coordinate.Dispose();
             }
 
-            if (hasEnteredGPSName && editingGPSNameIndex < BDATargetManager.GPSTargets[myTeam].Count)
+            if (hasEnteredGPSName && editingGPSNameIndex < BDATargetManager.GPSTargetList(myTeam).Count)
             {
                 hasEnteredGPSName = false;
-                GPSTargetInfo old = BDATargetManager.GPSTargets[myTeam][editingGPSNameIndex];
+                GPSTargetInfo old = BDATargetManager.GPSTargetList(myTeam)[editingGPSNameIndex];
                 if (ActiveWeaponManager.designatedGPSInfo.EqualsTarget(old))
                 {
                     ActiveWeaponManager.designatedGPSInfo.name = newGPSName;
                 }
-                BDATargetManager.GPSTargets[myTeam][editingGPSNameIndex] =
-                    new GPSTargetInfo(BDATargetManager.GPSTargets[myTeam][editingGPSNameIndex].gpsCoordinates,
+                BDATargetManager.GPSTargetList(myTeam)[editingGPSNameIndex] =
+                    new GPSTargetInfo(BDATargetManager.GPSTargetList(myTeam)[editingGPSNameIndex].gpsCoordinates,
                         newGPSName);
                 editingGPSNameIndex = 0;
             }
@@ -1304,7 +1304,7 @@ namespace BDArmory.UI
 
             if (indexToRemove >= 0)
             {
-                BDATargetManager.GPSTargets[myTeam].RemoveAt(indexToRemove);
+                BDATargetManager.GPSTargetList(myTeam).RemoveAt(indexToRemove);
             }
 
             WindowRectGps.height = (2*gpsBorder) + (gpsEntryCount*gpsEntryHeight);

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -137,7 +137,11 @@ namespace BDArmory.UI
             B,
             None
         };
-        public Dictionary<string, BDTeam> BDTeams = new Dictionary<string, BDTeam> { { "Neutral", new BDTeam("Neutral", neutral: true) } };
+
+        public SortedList<string, BDTeam> Teams = new SortedList<string, BDTeam>
+        {
+            { "Neutral", new BDTeam("Neutral", neutral: true) }
+        };
 
         //competition mode
         float competitionDist = 8000;

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -131,14 +131,6 @@ namespace BDArmory.UI
         GUIStyle redErrorStyle;
         GUIStyle redErrorShadowStyle;
 
-        [Obsolete]
-        public enum BDATeams
-        {
-            A,
-            B,
-            None
-        };
-
         public SortedList<string, BDTeam> Teams = new SortedList<string, BDTeam>
         {
             { "Neutral", new BDTeam("Neutral", neutral: true) }

--- a/BDArmory/UI/BDTeamSelector.cs
+++ b/BDArmory/UI/BDTeamSelector.cs
@@ -1,0 +1,163 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using BDArmory.Modules;
+using BDArmory.Misc;
+using UnityEngine;
+
+namespace BDArmory.UI
+{
+    [KSPAddon(KSPAddon.Startup.FlightAndEditor, false)]
+    public class BDTeamSelector : MonoBehaviour
+    {
+        public static BDTeamSelector Instance;
+
+        const float width = 250;
+        const float margin = 5;
+        const float buttonHeight = 20;
+        const float buttonGap = 2;
+        const float newTeanButtonWidth = 40;
+        const float scrollWidth = 20;
+
+        private int guiCheckIndex;
+        private bool ready = false;
+        private bool open = false;
+        private Rect window;
+        private float height;
+        private bool scrollable;
+        private Vector2 scrollPosition = Vector2.zero;
+
+        private Vector2 windowLocation;
+        private MissileFire targetWeaponManager;
+        private string newTeamName = string.Empty;
+
+        public void Open(MissileFire weaponManager, Vector2 position)
+        {
+            open = true;
+            targetWeaponManager = weaponManager;
+            newTeamName = string.Empty;
+            windowLocation = position;
+        }
+
+        private void TeamSelectorWindow(int id)
+        {
+            height = margin;
+            // Team input field
+            newTeamName = GUI.TextField(new Rect(margin, margin, width - buttonGap - 2* margin - newTeanButtonWidth, buttonHeight), newTeamName, 30);
+
+            // New team button
+            Rect newTeamButtonRect = new Rect(width - margin - newTeanButtonWidth, height, newTeanButtonWidth, buttonHeight);
+            if (GUI.Button(newTeamButtonRect, "New", BDArmorySetup.BDGuiSkin.button))
+            {
+                if (!string.IsNullOrEmpty(newTeamName.Trim()))
+                {
+                    targetWeaponManager.SetTeam(BDTeam.Get(newTeamName.Trim()));
+                    open = false;
+                }
+            }
+
+            height += buttonHeight;
+
+            // Scrollable list of existing teams
+            scrollable = (BDArmorySetup.Instance.Teams.Count * (buttonHeight + buttonGap) * 2 > Screen.height);
+
+            if (scrollable)
+                scrollPosition = GUI.BeginScrollView(
+                    new Rect(margin, height, width - margin * 2 + scrollWidth, Screen.height / 2), 
+                    scrollPosition, 
+                    new Rect(margin, height, width - margin * 2, BDArmorySetup.Instance.Teams.Count * (buttonHeight + buttonGap)), 
+                    false, true);
+
+            using (var teams = BDArmorySetup.Instance.Teams.Values.GetEnumerator())
+                while (teams.MoveNext())
+                {
+                    if (teams.Current == null || !teams.Current.Name.ToLowerInvariant().StartsWith(newTeamName.ToLowerInvariant().Trim())) continue;
+
+                    height += buttonGap;
+                    Rect buttonRect = new Rect(margin, height, width - 2 * margin, buttonHeight);
+                    GUIStyle buttonStyle = (teams.Current == targetWeaponManager.Team) ? BDArmorySetup.BDGuiSkin.box : BDArmorySetup.BDGuiSkin.button;
+
+                    if (GUI.Button(buttonRect, teams.Current.Name, buttonStyle))
+                    {
+                        targetWeaponManager.SetTeam(teams.Current);
+                        open = false;
+                    }
+
+                    height += buttonHeight;
+                }
+
+            if (scrollable)
+                GUI.EndScrollView();
+
+            // Buttons
+            if (Event.current.type == EventType.keyUp)
+            {
+                if ((Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter) && !string.IsNullOrEmpty(newTeamName.Trim()))
+                {
+                    targetWeaponManager.SetTeam(BDTeam.Get(newTeamName.Trim()));
+                    open = false;
+                }
+                else if (Event.current.keyCode == KeyCode.Escape)
+                {
+                    open = false;
+                }
+            }
+
+            height += margin;
+            BDGUIUtils.RepositionWindow(ref window);
+        }
+
+        protected virtual void OnGUI()
+        {
+            if (ready)
+            {
+                if (open && BDArmorySetup.GAME_UI_ENABLED 
+                    && Event.current.type == EventType.MouseDown 
+                    && !window.Contains(Event.current.mousePosition))
+                {
+                    open = false;
+                }
+
+                if (open && BDArmorySetup.GAME_UI_ENABLED)
+                {
+                    var clientRect = new Rect(
+                        Mathf.Min(windowLocation.x, Screen.width - (scrollable ? width + scrollWidth : width)),
+                        Mathf.Min(windowLocation.y, Screen.height - height),
+                        width,
+                        scrollable ? Screen.height / 2 + buttonHeight + buttonGap + 2 * margin : height);
+                    window = GUI.Window(10591029, clientRect, TeamSelectorWindow, "", BDArmorySetup.BDGuiSkin.window);
+                    Misc.Misc.UpdateGUIRect(window, guiCheckIndex);
+                }
+                else
+                {
+                    Misc.Misc.UpdateGUIRect(new Rect(), guiCheckIndex);
+                }
+            }
+        }
+
+        private void Awake()
+        {
+            if (Instance)
+                Destroy(Instance);
+            Instance = this;
+        }
+
+        private void Start()
+        {
+            StartCoroutine(WaitForBdaSettings());
+        }
+
+        private void OnDestroy()
+        {
+            ready = false;
+        }
+
+        private IEnumerator WaitForBdaSettings()
+        {
+            while (BDArmorySetup.Instance == null)
+                yield return null;
+
+            ready = true;
+            guiCheckIndex = Misc.Misc.RegisterGUIRect(new Rect());
+        }
+    }
+}

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -232,8 +232,15 @@ namespace BDArmory.UI
                                 _buttonHeight, _buttonHeight);
                             if (GUI.Button(teamButtonRect, "T", BDArmorySetup.BDGuiSkin.button))
                             {
-                                _wmToSwitchTeam = wm.Current;
-                                _teamSwitchDirty = true;
+                                if (Event.current.button == 1)
+                                {
+                                    BDTeamSelector.Instance.Open(wm.Current, new Vector2(Input.mousePosition.x, Screen.height - Input.mousePosition.y));
+                                }
+                                else
+                                {
+                                    _wmToSwitchTeam = wm.Current;
+                                    _teamSwitchDirty = true;
+                                }
                             }
 
                             height += _buttonHeight + _buttonGap;

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -199,7 +199,6 @@ namespace BDArmory.UI
                         {
                             if (wm.Current == null) continue;
 
-                            height += _buttonHeight + _buttonGap;
                             Rect buttonRect = new Rect(_margin, height, vesselButtonWidth, _buttonHeight);
                             GUIStyle vButtonStyle = wm.Current.vessel.isActiveVessel ? BDArmorySetup.BDGuiSkin.box : BDArmorySetup.BDGuiSkin.button;
                             string status = UpdateVesselStatus(wm.Current, vButtonStyle);
@@ -231,6 +230,8 @@ namespace BDArmory.UI
                                 _wmToSwitchTeam = wm.Current;
                                 _teamSwitchDirty = true;
                             }
+
+                            height += _buttonHeight + _buttonGap;
                         }
                 }
 

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using BDArmory.Modules;
+using BDArmory.Misc;
 using UnityEngine;
 
 namespace BDArmory.UI
@@ -82,7 +83,7 @@ namespace BDArmory.UI
             _guiCheckIndex = Misc.Misc.RegisterGUIRect(new Rect());
         }
 
-        private void MissileFireOnToggleTeam(MissileFire wm, BDArmorySetup.BDATeams team)
+        private void MissileFireOnToggleTeam(MissileFire wm, BDTeam team)
         {
             if (_showGui)
                 UpdateList();

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -45,7 +45,7 @@ namespace BDArmory.UI
             GameEvents.onVesselDestroy.Add(VesselEventUpdate);
             GameEvents.onVesselGoOffRails.Add(VesselEventUpdate);
             GameEvents.onVesselGoOnRails.Add(VesselEventUpdate);
-            MissileFire.OnToggleTeam += MissileFireOnToggleTeam;
+            MissileFire.OnChangeTeam += MissileFireOnToggleTeam;
 
             _ready = false;
             StartCoroutine(WaitForBdaSettings());
@@ -64,7 +64,7 @@ namespace BDArmory.UI
                 GameEvents.onVesselDestroy.Remove(VesselEventUpdate);
                 GameEvents.onVesselGoOffRails.Remove(VesselEventUpdate);
                 GameEvents.onVesselGoOnRails.Remove(VesselEventUpdate);
-                MissileFire.OnToggleTeam -= MissileFireOnToggleTeam;
+                MissileFire.OnChangeTeam -= MissileFireOnToggleTeam;
 
                 _ready = false;
 


### PR DESCRIPTION
Adds functionality to have more than two teams in BDA.

- BDTeam is now uniformly an `object` (removing both the `bool` and the `enum` team types).
- Teams are fully customizable and saved with the craft.
 - Custom team names (`A` and `B` are ghost-hardcoded so the `Next team` button always switches between at least two teams).
 - Teams can be `Neutral` (no UI, `Neutral` team is hardcoded to be neutral).
 - Teams can be set to be friendly toward other teams (currently no option to set this in the UI).
- Updated vessel switcher to accomodate more teams.
- Updated infrastructure to accomodate more teams (`TargetInfo`, target databases, gps database, etc.)
- Added team selection dropdown (right click the team button in weapon manager or vessel switcher.