### PR TITLE
Potential Rocket Launcher code refactor

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/MMPatches/LegacyRocketLauncher.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/MMPatches/LegacyRocketLauncher.cfg
@@ -1,0 +1,24 @@
+@PART[*]:HAS[@MODULE[RocketLauncher]]
+{	
+	&stagingIcon = SOLID_BOOSTER 
+	MODULE
+	{
+		name = ModuleWeapon
+		fireTransformName = rockets
+		shortName = #$../MODULE[RocketLauncher]/shortName$
+		ammoName = #$../MODULE[RocketLauncher]/rocketType$
+		rocketMass = #$../MODULE[RocketLauncher]/rocketMass$
+		rocketModelPath = #$../MODULE[RocketLauncher]/rocketModelPath $
+		deployAnimName = #$../MODULE[RocketLauncher]/deployAnimationName$
+		thrust = #$../MODULE[RocketLauncher]/thrust$
+ 		thrustTime = #$../MODULE[RocketLauncher]/thrustTime$
+  		blastRadius = #$../MODULE[RocketLauncher]/blastRadius$
+  		blastForce = #$../MODULE[RocketLauncher]/blastForce$
+  		roundsPerMinute = #$../MODULE[RocketLauncher]/rippleRPM$
+		thrustDeviation = #$../MODULE[RocketLauncher]/thrustDeviation$
+  		weaponType = rocket
+		MaxEffectiveDistance = 8000
+		maxTargetingRange = 8000
+	}
+	!MODULE[RocketLauncher]{}
+}

--- a/BDArmory/Modules/BDModuleSurfaceAI.cs
+++ b/BDArmory/Modules/BDModuleSurfaceAI.cs
@@ -396,7 +396,7 @@ namespace BDArmory.Modules
                                         }
                                         break;
                                     case WeaponClasses.Rocket:
-                                        var rocket = (RocketLauncher)weaponManager.selectedWeapon;
+                                        var rocket = (ModuleWeapon)weaponManager.selectedWeapon;
                                         if (rocket.yawRange == 0 || rocket.maxPitch == rocket.minPitch)
                                         {
                                             aimingMode = true;

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -16,4499 +16,4419 @@ using UnityEngine;
 
 namespace BDArmory.Modules
 {
-    public class MissileFire : PartModule
-    {
+	public class MissileFire : PartModule
+	{
 
-        #region  Declarations
+		#region  Declarations
 
-        //weapons
-        private const int LIST_CAPACITY = 100;
-        private List<IBDWeapon> weaponTypes = new List<IBDWeapon>(LIST_CAPACITY);
-        public IBDWeapon[] weaponArray;
+		//weapons
+		private const int LIST_CAPACITY = 100;
+		private List<IBDWeapon> weaponTypes = new List<IBDWeapon>(LIST_CAPACITY);
+		public IBDWeapon[] weaponArray;
 
-        // extension for feature_engagementenvelope: specific lists by weapon engagement type
-        private List<IBDWeapon> weaponTypesAir = new List<IBDWeapon>(LIST_CAPACITY);
-        private List<IBDWeapon> weaponTypesMissile = new List<IBDWeapon>(LIST_CAPACITY);
-        private List<IBDWeapon> weaponTypesGround = new List<IBDWeapon>(LIST_CAPACITY);
-        private List<IBDWeapon> weaponTypesSLW = new List<IBDWeapon>(LIST_CAPACITY);
+		// extension for feature_engagementenvelope: specific lists by weapon engagement type
+		private List<IBDWeapon> weaponTypesAir = new List<IBDWeapon>(LIST_CAPACITY);
+		private List<IBDWeapon> weaponTypesMissile = new List<IBDWeapon>(LIST_CAPACITY);
+		private List<IBDWeapon> weaponTypesGround = new List<IBDWeapon>(LIST_CAPACITY);
+		private List<IBDWeapon> weaponTypesSLW = new List<IBDWeapon>(LIST_CAPACITY);
 
-        [KSPField(guiActiveEditor = false, isPersistant = true, guiActive = false)] public int weaponIndex;
+		[KSPField(guiActiveEditor = false, isPersistant = true, guiActive = false)] public int weaponIndex;
 
-        //ScreenMessage armedMessage;
-        ScreenMessage selectionMessage;
-        string selectionText = "";
+		//ScreenMessage armedMessage;
+		ScreenMessage selectionMessage;
+		string selectionText = "";
 
-        Transform cameraTransform;
+		Transform cameraTransform;
 
-        float startTime;
-        int missilesAway;
+		float startTime;
+		int missilesAway;
 
-        public bool hasLoadedRippleData;
-        float rippleTimer;
+		public bool hasLoadedRippleData;
+		float rippleTimer;
+		public TargetSignatureData heatTarget;
+		//[KSPField(isPersistant = true)]
+		public float rippleRPM
+		{
+			get
+			{
+				if (selectedWeapon != null)
+				{
+					return rippleDictionary[selectedWeapon.GetShortName()].rpm;
+				}
+				else
+				{
+					return 0;
+				}
+			}
+			set
+			{
+				if (selectedWeapon != null)
+				{
+					if (rippleDictionary.ContainsKey(selectedWeapon.GetShortName()))
+					{
+						rippleDictionary[selectedWeapon.GetShortName()].rpm = value;
+					}
+					else
+					{
+						return;
+					}
+				}
+				else
+				{
+					return;
+				}
+			}
+		}
 
-        public TargetSignatureData heatTarget;
-        //[KSPField(isPersistant = true)]
-        public float rippleRPM
-        {
-            get
-            {
-                if (selectedWeapon != null)
-                {
-                    return rippleDictionary[selectedWeapon.GetShortName()].rpm;
-                }
-                else
-                {
-                    return 0;
-                }
-            }
-            set
-            {
-                if (selectedWeapon != null)
-                {
-                    if (rippleDictionary.ContainsKey(selectedWeapon.GetShortName()))
-                    {
-                        rippleDictionary[selectedWeapon.GetShortName()].rpm = value;
-                    }
-                    else
-                    {
-                        return;
-                    }
-                }
-                else
-                {
-                    return;
-                }
-            }
-        }
+		float triggerTimer;
+		int rippleGunCount;
+		int _gunRippleIndex;
+		public float gunRippleRpm;
 
-        float triggerTimer;
-        int rippleGunCount;
-        int _gunRippleIndex;
-        public float gunRippleRpm;
+		public int gunRippleIndex
+		{
+			get { return _gunRippleIndex; }
+			set
+			{
+				_gunRippleIndex = value;
+				if (_gunRippleIndex >= rippleGunCount)
+				{
+					_gunRippleIndex = 0;
+				}
+			}
+		}
 
-        public int gunRippleIndex
-        {
-            get { return _gunRippleIndex; }
-            set
-            {
-                _gunRippleIndex = value;
-                if (_gunRippleIndex >= rippleGunCount)
-                {
-                    _gunRippleIndex = 0;
-                }
-            }
-        }
-        
-        //ripple stuff
-        string rippleData = string.Empty;
-        Dictionary<string, RippleOption> rippleDictionary; //weapon name, ripple option
-        public bool canRipple;
+		//ripple stuff
+		string rippleData = string.Empty;
+		Dictionary<string, RippleOption> rippleDictionary; //weapon name, ripple option
+		public bool canRipple;
 
-        //public float triggerHoldTime = 0.3f;
+		//public float triggerHoldTime = 0.3f;
 
-        //[KSPField(isPersistant = true)]
+		//[KSPField(isPersistant = true)]
 
-        public bool rippleFire
-        {
-            get
-            {
-                if (selectedWeapon == null) return false;
-                if (rippleDictionary.ContainsKey(selectedWeapon.GetShortName()))
-                {
-                    return rippleDictionary[selectedWeapon.GetShortName()].rippleFire;
-                }
-                //rippleDictionary.Add(selectedWeapon.GetShortName(), new RippleOption(false, 650));
-                return false;
-            }
-        }
+		public bool rippleFire
+		{
+			get
+			{
+				if (selectedWeapon == null) return false;
+				if (rippleDictionary.ContainsKey(selectedWeapon.GetShortName()))
+				{
+					return rippleDictionary[selectedWeapon.GetShortName()].rippleFire;
+				}
+				//rippleDictionary.Add(selectedWeapon.GetShortName(), new RippleOption(false, 650));
+				return false;
+			}
+		}
 
-        public void ToggleRippleFire()
-        {
-            if (selectedWeapon != null)
-            {
-                RippleOption ro;
-                if (rippleDictionary.ContainsKey(selectedWeapon.GetShortName()))
-                {
-                    ro = rippleDictionary[selectedWeapon.GetShortName()];
-                }
-                else
-                {
-                    ro = new RippleOption(false, 650); //default to true ripple fire for guns, otherwise, false
-                    if (selectedWeapon.GetWeaponClass() == WeaponClasses.Gun)
-                    {
-                        ro.rippleFire = currentGun.useRippleFire;
-                    }
-                    rippleDictionary.Add(selectedWeapon.GetShortName(), ro);
-                }
+		public void ToggleRippleFire()
+		{
+			if (selectedWeapon != null)
+			{
+				RippleOption ro;
+				if (rippleDictionary.ContainsKey(selectedWeapon.GetShortName()))
+				{
+					ro = rippleDictionary[selectedWeapon.GetShortName()];
+				}
+				else
+				{
+					ro = new RippleOption(false, 650); //default to true ripple fire for guns, otherwise, false
+					if (selectedWeapon.GetWeaponClass() == WeaponClasses.Gun || selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket)
+					{
+						ro.rippleFire = currentGun.useRippleFire;
+					}
+					rippleDictionary.Add(selectedWeapon.GetShortName(), ro);
+				}
 
-                ro.rippleFire = !ro.rippleFire;
+				ro.rippleFire = !ro.rippleFire;
 
-                if (selectedWeapon.GetWeaponClass() == WeaponClasses.Gun)
-                {
-                    List<ModuleWeapon>.Enumerator w = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
-                    while (w.MoveNext())
-                    {
-                        if (w.Current == null) continue;
+				if (selectedWeapon.GetWeaponClass() == WeaponClasses.Gun || selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket)
+				{
+					List<ModuleWeapon>.Enumerator w = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
+					while (w.MoveNext())
+					{
+						if (w.Current == null) continue;
 						if (w.Current.GetShortName() == selectedWeapon.GetShortName())
-                            w.Current.useRippleFire = ro.rippleFire;
-                    }
-                    w.Dispose();
-                }
-            }
-        }
+							w.Current.useRippleFire = ro.rippleFire;
+					}
+					w.Dispose();
+				}
+			}
+		}
 
-        public void AGToggleRipple(KSPActionParam param)
-        {
-            ToggleRippleFire();
-        }
+		public void AGToggleRipple(KSPActionParam param)
+		{
+			ToggleRippleFire();
+		}
 
-        void ParseRippleOptions()
-        {
-            rippleDictionary = new Dictionary<string, RippleOption>();
-            //Debug.Log("[BDArmory]: Parsing ripple options");
-            if (!string.IsNullOrEmpty(rippleData))
-            {
-                //Debug.Log("[BDArmory]: Ripple data: " + rippleData);
-                try
-                {
-                    IEnumerator<string> weapon = rippleData.Split(new char[] {';'}).AsEnumerable().GetEnumerator(); ;
-                    while (weapon.MoveNext())
-                    {
-                        if (weapon.Current == string.Empty) continue;
+		void ParseRippleOptions()
+		{
+			rippleDictionary = new Dictionary<string, RippleOption>();
+			//Debug.Log("[BDArmory]: Parsing ripple options");
+			if (!string.IsNullOrEmpty(rippleData))
+			{
+				//Debug.Log("[BDArmory]: Ripple data: " + rippleData);
+				try
+				{
+					IEnumerator<string> weapon = rippleData.Split(new char[] { ';' }).AsEnumerable().GetEnumerator(); ;
+					while (weapon.MoveNext())
+					{
+						if (weapon.Current == string.Empty) continue;
 
-                        string[] options = weapon.Current.Split(new char[] {','});
-                        string wpnName = options[0];
-                        bool rf = bool.Parse(options[1]);
-                        float rpm = float.Parse(options[2]);
-                        RippleOption ro = new RippleOption(rf, rpm);
-                        rippleDictionary.Add(wpnName, ro);
-                    }
-                    weapon.Dispose();
-                }
-                catch (Exception)
-                {
-                    //Debug.Log("[BDArmory]: Ripple data was invalid.");
-                    rippleData = string.Empty;
-                }
-            }
-            else
-            {
-                //Debug.Log("[BDArmory]: Ripple data is empty.");
-            }
+						string[] options = weapon.Current.Split(new char[] { ',' });
+						string wpnName = options[0];
+						bool rf = bool.Parse(options[1]);
+						float rpm = float.Parse(options[2]);
+						RippleOption ro = new RippleOption(rf, rpm);
+						rippleDictionary.Add(wpnName, ro);
+					}
+					weapon.Dispose();
+				}
+				catch (Exception)
+				{
+					//Debug.Log("[BDArmory]: Ripple data was invalid.");
+					rippleData = string.Empty;
+				}
+			}
+			else
+			{
+				//Debug.Log("[BDArmory]: Ripple data is empty.");
+			}
+			hasLoadedRippleData = true;
+		}
 
-            if (vessel)
-            {
-                List<RocketLauncher>.Enumerator rl = vessel.FindPartModulesImplementing<RocketLauncher>().GetEnumerator();
-                while (rl.MoveNext())
-                {
-                    if (rl.Current == null) continue;
-                    if (!rippleDictionary.ContainsKey(rl.Current.GetShortName()))
-                    {
-                        rippleDictionary.Add(rl.Current.GetShortName(), new RippleOption(false, 650f));
-                    }
-                }
-                rl.Dispose();
-            }
-            hasLoadedRippleData = true;
-        }
+		void SaveRippleOptions(ConfigNode node)
+		{
+			if (rippleDictionary != null)
+			{
+				rippleData = string.Empty;
+				Dictionary<string, RippleOption>.KeyCollection.Enumerator wpnName = rippleDictionary.Keys.GetEnumerator();
+				while (wpnName.MoveNext())
+				{
+					if (wpnName.Current == null) continue;
+					rippleData += $"{wpnName},{rippleDictionary[wpnName.Current].rippleFire},{rippleDictionary[wpnName.Current].rpm};";
+				}
+				wpnName.Dispose();
+				node.SetValue("RippleData", rippleData, true);
+			}
+			//Debug.Log("[BDArmory]: Saved ripple data");
+		}
 
-        void SaveRippleOptions(ConfigNode node)
-        {
-            if (rippleDictionary != null)
-            {
-                rippleData = string.Empty;
-                Dictionary<string, RippleOption>.KeyCollection.Enumerator wpnName = rippleDictionary.Keys.GetEnumerator();
-                while (wpnName.MoveNext())
-                {
-                    if (wpnName.Current == null) continue;
-                    rippleData += $"{wpnName},{rippleDictionary[wpnName.Current].rippleFire},{rippleDictionary[wpnName.Current].rpm};";
-                }
-                wpnName.Dispose();
-                node.SetValue("RippleData", rippleData, true);
-            }
-            //Debug.Log("[BDArmory]: Saved ripple data");
-        }
+		public bool hasSingleFired;
 
-        public bool hasSingleFired;
+		//bomb aimer
+		Part bombPart;
+		Vector3 bombAimerPosition = Vector3.zero;
+		Texture2D bombAimerTexture = GameDatabase.Instance.GetTexture("BDArmory/Textures/grayCircle", false);
+		bool showBombAimer;
 
-        //bomb aimer
-        Part bombPart;
-        Vector3 bombAimerPosition = Vector3.zero;
-        Texture2D bombAimerTexture = GameDatabase.Instance.GetTexture("BDArmory/Textures/grayCircle", false);
-        bool showBombAimer;
-        
-        //targeting
-        private List<Vessel> loadedVessels = new List<Vessel>();
-        float targetListTimer;
-        
-        //rocket aimer handling
-        RocketLauncher currentRocket;
-        
-        //sounds
-        AudioSource audioSource;
-        public AudioSource warningAudioSource;
-        AudioSource targetingAudioSource;
-        AudioClip clickSound;
-        AudioClip warningSound;
-        AudioClip armOnSound;
-        AudioClip armOffSound;
-        AudioClip heatGrowlSound;
-        bool warningSounding;
+		//targeting
+		private List<Vessel> loadedVessels = new List<Vessel>();
+		float targetListTimer;
 
-        //missile warning
-        public bool missileIsIncoming;
-        public float incomingMissileDistance = float.MaxValue;
-        public Vessel incomingMissileVessel;
+		//sounds
+		AudioSource audioSource;
+		public AudioSource warningAudioSource;
+		AudioSource targetingAudioSource;
+		AudioClip clickSound;
+		AudioClip warningSound;
+		AudioClip armOnSound;
+		AudioClip armOffSound;
+		AudioClip heatGrowlSound;
+		bool warningSounding;
 
-        //guard mode vars
-        float targetScanTimer;
-        Vessel guardTarget;
-        public TargetInfo currentTarget;
-        TargetInfo overrideTarget; //used for setting target next guard scan for stuff like assisting teammates
-        float overrideTimer;
+		//missile warning
+		public bool missileIsIncoming;
+		public float incomingMissileDistance = float.MaxValue;
+		public Vessel incomingMissileVessel;
 
-        public bool TargetOverride
-        {
-            get { return overrideTimer > 0; }
-        }
+		//guard mode vars
+		float targetScanTimer;
+		Vessel guardTarget;
+		public TargetInfo currentTarget;
+		TargetInfo overrideTarget; //used for setting target next guard scan for stuff like assisting teammates
+		float overrideTimer;
+
+		public bool TargetOverride
+		{
+			get { return overrideTimer > 0; }
+		}
 
 		//AIPilot
 		public IBDAIControl AI;
 		// some extending related code still uses pilotAI, which is implementation specific and does not make sense to include in the interface
-        private BDModulePilotAI pilotAI { get { return AI as BDModulePilotAI; } }
-        public float timeBombReleased;
+		private BDModulePilotAI pilotAI { get { return AI as BDModulePilotAI; } }
+		public float timeBombReleased;
 
-        //targeting pods
-        public ModuleTargetingCamera mainTGP = null;
-        public List<ModuleTargetingCamera> targetingPods = new List<ModuleTargetingCamera>();
+		//targeting pods
+		public ModuleTargetingCamera mainTGP = null;
+		public List<ModuleTargetingCamera> targetingPods = new List<ModuleTargetingCamera>();
 
-        //radar
-        public List<ModuleRadar> radars = new List<ModuleRadar>();
-        public VesselRadarData vesselRadarData;
+		//radar
+		public List<ModuleRadar> radars = new List<ModuleRadar>();
+		public VesselRadarData vesselRadarData;
 
-        //jammers
-        public List<ModuleECMJammer> jammers = new List<ModuleECMJammer>();
+		//jammers
+		public List<ModuleECMJammer> jammers = new List<ModuleECMJammer>();
 
-        //other modules
-        public List<IBDWMModule> wmModules = new List<IBDWMModule>();
+		//other modules
+		public List<IBDWMModule> wmModules = new List<IBDWMModule>();
 
-        //wingcommander
-        public ModuleWingCommander wingCommander;
+		//wingcommander
+		public ModuleWingCommander wingCommander;
 
-        //RWR
-        private RadarWarningReceiver radarWarn;
+		//RWR
+		private RadarWarningReceiver radarWarn;
 
-        public RadarWarningReceiver rwr
-        {
-            get
-            {
-                if (!radarWarn || radarWarn.vessel != vessel)
-                {
-                    return null;
-                }
-                return radarWarn;
-            }
-            set { radarWarn = value; }
-        }
+		public RadarWarningReceiver rwr
+		{
+			get
+			{
+				if (!radarWarn || radarWarn.vessel != vessel)
+				{
+					return null;
+				}
+				return radarWarn;
+			}
+			set { radarWarn = value; }
+		}
 
-        //GPS
-        public GPSTargetInfo designatedGPSInfo;
+		//GPS
+		public GPSTargetInfo designatedGPSInfo;
 
-        public Vector3d designatedGPSCoords => designatedGPSInfo.gpsCoordinates;
+		public Vector3d designatedGPSCoords => designatedGPSInfo.gpsCoordinates;
 
-        //Guard view scanning
-        float guardViewScanDirection = 1;
-        float guardViewScanRate = 200;
-        float currentGuardViewAngle;
-        private Transform vrt;
+		//Guard view scanning
+		float guardViewScanDirection = 1;
+		float guardViewScanRate = 200;
+		float currentGuardViewAngle;
+		private Transform vrt;
 
-        public Transform viewReferenceTransform
-        {
-            get
-            {
-                if (vrt == null)
-                {
-                    vrt = (new GameObject()).transform;
-                    vrt.parent = transform;
-                    vrt.localPosition = Vector3.zero;
-                    vrt.rotation = Quaternion.LookRotation(-transform.forward, -vessel.ReferenceTransform.forward);
-                }
+		public Transform viewReferenceTransform
+		{
+			get
+			{
+				if (vrt == null)
+				{
+					vrt = (new GameObject()).transform;
+					vrt.parent = transform;
+					vrt.localPosition = Vector3.zero;
+					vrt.rotation = Quaternion.LookRotation(-transform.forward, -vessel.ReferenceTransform.forward);
+				}
 
-                return vrt;
-            }
-        }
+				return vrt;
+			}
+		}
 
-        //weapon slaving
-        public bool slavingTurrets = false;
-        public Vector3 slavedPosition;
-        public Vector3 slavedVelocity;
-        public Vector3 slavedAcceleration;
-        public TargetSignatureData slavedTarget;
+		//weapon slaving
+		public bool slavingTurrets = false;
+		public Vector3 slavedPosition;
+		public Vector3 slavedVelocity;
+		public Vector3 slavedAcceleration;
+		public TargetSignatureData slavedTarget;
 
 		//current weapon ref
 		public MissileBase CurrentMissile;
-        public ModuleWeapon currentGun
-        {
-            get
-            {
-                if (selectedWeapon != null && selectedWeapon.GetWeaponClass() == WeaponClasses.Gun)
-                {
-                    return selectedWeapon.GetPart().FindModuleImplementing<ModuleWeapon>();
-                }
-                else
-                {
-                    return null;
-                }
-            }
-        }
+		public ModuleWeapon currentGun
+		{
+			get
+			{
+				if (selectedWeapon != null && (selectedWeapon.GetWeaponClass() == WeaponClasses.Gun || selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket))
+				{
+					return selectedWeapon.GetPart().FindModuleImplementing<ModuleWeapon>();
+				}
+				else
+				{
+					return null;
+				}
+			}
+		}
+		
+		public bool underAttack;
+		public bool underFire;
+		Coroutine ufRoutine;
 
-        public bool underAttack;
-        public bool underFire;
-        Coroutine ufRoutine;
+		Vector3 debugGuardViewDirection;
+		bool focusingOnTarget;
+		float focusingOnTargetTimer;
+		public Vector3 incomingThreatPosition;
+		public Vessel incomingThreatVessel;
 
-        Vector3 debugGuardViewDirection;
-        bool focusingOnTarget;
-        float focusingOnTargetTimer;
-        public Vector3 incomingThreatPosition;
-        public Vessel incomingThreatVessel;
+		bool guardFiringMissile;
+		bool antiRadTargetAcquired;
+		Vector3 antiRadiationTarget;
+		bool laserPointDetected;
 
-        bool guardFiringMissile;
-        bool disabledRocketAimers;
-        bool antiRadTargetAcquired;
-        Vector3 antiRadiationTarget;
-        bool laserPointDetected;
+		ModuleTargetingCamera foundCam;
 
-        ModuleTargetingCamera foundCam;
+		#region KSPFields,events,actions
 
-        #region KSPFields,events,actions
+		[KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Firing Interval"),
+		 UI_FloatRange(minValue = 1f, maxValue = 60f, stepIncrement = 1f, scene = UI_Scene.All)] public float
+			targetScanInterval = 3;
 
-        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Firing Interval"),
-         UI_FloatRange(minValue = 1f, maxValue = 60f, stepIncrement = 1f, scene = UI_Scene.All)] public float
-            targetScanInterval = 3;
+		// extension for feature_engagementenvelope: burst length for guns
+		[KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Firing Burst Length"),
+		 UI_FloatRange(minValue = 0f, maxValue = 60f, stepIncrement = 0.5f, scene = UI_Scene.All)]
+		public float fireBurstLength = 0;
 
-        // extension for feature_engagementenvelope: burst length for guns
-        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Firing Burst Length"),
-         UI_FloatRange(minValue = 0f, maxValue = 60f, stepIncrement = 0.5f, scene = UI_Scene.All)]
-        public float fireBurstLength = 0;
+		[KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Field of View"),
+		 UI_FloatRange(minValue = 10f, maxValue = 360f, stepIncrement = 10f, scene = UI_Scene.All)] public float
+			guardAngle = 360;
 
-        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Field of View"),
-         UI_FloatRange(minValue = 10f, maxValue = 360f, stepIncrement = 10f, scene = UI_Scene.All)] public float
-            guardAngle = 360;
+		[KSPField(isPersistant = true, guiActive = false, guiActiveEditor = false, guiName = "Visual Range"),
+		 UI_FloatRange(minValue = 100f, maxValue = 5000, stepIncrement = 100f, scene = UI_Scene.All)] public float
+			guardRange = 10000;
 
-        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = false, guiName = "Visual Range"),
-         UI_FloatRange(minValue = 100f, maxValue = 5000, stepIncrement = 100f, scene = UI_Scene.All)] public float
-            guardRange = 10000;
+		[KSPField(isPersistant = true, guiActive = false, guiActiveEditor = false, guiName = "Guns Range"),
+		 UI_FloatRange(minValue = 0f, maxValue = 10000f, stepIncrement = 10f, scene = UI_Scene.All)] public float
+			gunRange = 2500f;
 
-        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = false, guiName = "Guns Range"),
-         UI_FloatRange(minValue = 0f, maxValue = 10000f, stepIncrement = 10f, scene = UI_Scene.All)] public float
-            gunRange = 2500f;
+		public const float maxAllowableMissilesOnTarget = 18f;
 
-        public const float maxAllowableMissilesOnTarget = 18f;
+		[KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Missiles/Target"), UI_FloatRange(minValue = 1f, maxValue = maxAllowableMissilesOnTarget, stepIncrement = 1f, scene = UI_Scene.All)]
+		public float maxMissilesOnTarget = 1;
 
-        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Missiles/Target"), UI_FloatRange(minValue = 1f, maxValue = maxAllowableMissilesOnTarget, stepIncrement = 1f, scene = UI_Scene.All)]
-        public float maxMissilesOnTarget = 1;
+		public void ToggleGuardMode()
+		{
+			guardMode = !guardMode;
 
-        public void ToggleGuardMode()
-        {
-            guardMode = !guardMode;
-
-            if (guardMode) return;
-            //disable turret firing and guard mode
-            List<ModuleWeapon>.Enumerator weapon = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
-            while (weapon.MoveNext())
-            {
-                if (weapon.Current == null) continue;
-                weapon.Current.legacyTargetVessel = null;
-                weapon.Current.autoFire = false;
-                weapon.Current.aiControlled = false;
-            }
-            weapon.Dispose();
-        }
-
-
-        [KSPAction("Toggle Guard Mode")]
-        public void AGToggleGuardMode(KSPActionParam param)
-        {
-            ToggleGuardMode();
-        }
+			if (guardMode) return;
+			//disable turret firing and guard mode
+			List<ModuleWeapon>.Enumerator weapon = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
+			while (weapon.MoveNext())
+			{
+				if (weapon.Current == null) continue;
+				weapon.Current.legacyTargetVessel = null;
+				weapon.Current.autoFire = false;
+				weapon.Current.aiControlled = false;
+			}
+			weapon.Dispose();
+		}
 
 
-        //[KSPField(isPersistant = true)] public bool guardMode;
+		[KSPAction("Toggle Guard Mode")]
+		public void AGToggleGuardMode(KSPActionParam param)
+		{
+			ToggleGuardMode();
+		}
 
-        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = false, guiName = "Gaurd Mode: "),
-            UI_Toggle(disabledText = "OFF", enabledText = "ON")]
-        public bool guardMode;
+
+		//[KSPField(isPersistant = true)] public bool guardMode;
+
+		[KSPField(isPersistant = true, guiActive = false, guiActiveEditor = false, guiName = "Gaurd Mode: "),
+			UI_Toggle(disabledText = "OFF", enabledText = "ON")]
+		public bool guardMode;
 
 
-        //[KSPField(isPersistant = false, guiActive = false, guiActiveEditor = false, guiName = "Target Type: "), UI_Toggle(disabledText = "Vessels", enabledText = "Missiles")]
-        public bool targetMissiles = false;
+		//[KSPField(isPersistant = false, guiActive = false, guiActiveEditor = false, guiName = "Target Type: "), UI_Toggle(disabledText = "Vessels", enabledText = "Missiles")]
+		public bool targetMissiles = false;
 
-        [KSPAction("Toggle Target Type")]
-        public void AGToggleTargetType(KSPActionParam param)
-        {
-            ToggleTargetType();
-        }
+		[KSPAction("Toggle Target Type")]
+		public void AGToggleTargetType(KSPActionParam param)
+		{
+			ToggleTargetType();
+		}
 
-        public void ToggleTargetType()
-        {
-            targetMissiles = !targetMissiles;
-            audioSource.PlayOneShot(clickSound);
-        }
+		public void ToggleTargetType()
+		{
+			targetMissiles = !targetMissiles;
+			audioSource.PlayOneShot(clickSound);
+		}
 
 		[KSPAction("Jettison Weapon")]
 		public void AGJettisonWeapon(KSPActionParam param)
 		{
-			if(CurrentMissile)
+			if (CurrentMissile)
 			{
-			    List<MissileBase>.Enumerator missile = vessel.FindPartModulesImplementing<MissileBase>().GetEnumerator();
-				while(missile.MoveNext())
+				List<MissileBase>.Enumerator missile = vessel.FindPartModulesImplementing<MissileBase>().GetEnumerator();
+				while (missile.MoveNext())
 				{
-				    if(missile.Current == null) continue;
-					if(missile.Current.GetShortName() == CurrentMissile.GetShortName())
+					if (missile.Current == null) continue;
+					if (missile.Current.GetShortName() == CurrentMissile.GetShortName())
 					{
 						missile.Current.Jettison();
 					}
 				}
-                missile.Dispose();
+				missile.Dispose();
 			}
-			else if(selectedWeapon!=null && selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket)
+			else if (selectedWeapon != null && selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket)
 			{
-			    List<RocketLauncher>.Enumerator rocket = vessel.FindPartModulesImplementing<RocketLauncher>().GetEnumerator();
-				while(rocket.MoveNext())
+				List<ModuleWeapon>.Enumerator rocket = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
+				while (rocket.MoveNext())
 				{
-				    if (rocket.Current == null) continue;
-					rocket.Current.Jettison();
+					if (rocket.Current == null) continue;
+					if (rocket.Current.GetWeaponClass() != WeaponClasses.Rocket) continue;
+					if (rocket.Current.GetShortName() == currentGun.GetShortName())
+					{
+						rocket.Current.Jettison();
+					}
 				}
-                rocket.Dispose();
+				rocket.Dispose();
 			}
 		}
-		
-		
+
+
 		[KSPField(guiActive = true, guiActiveEditor = true, guiName = "Team")]
 		public string teamString = "A";
 		void UpdateTeamString()
 		{
 			teamString = Enum.GetName(typeof(BDArmorySetup.BDATeams), BDATargetManager.BoolToTeam(team));
 		}
-		
-		
+
+
 		[KSPField(isPersistant = true)]
-        public bool team = false;
-
-
-        [KSPAction("Toggle Team")]
-        public void AGToggleTeam(KSPActionParam param)
-        {
-            ToggleTeam();
-        }
-
-        public delegate void ToggleTeamDelegate(MissileFire wm, BDArmorySetup.BDATeams team);
-
-        public static event ToggleTeamDelegate OnToggleTeam;
-
-        [KSPEvent(active = true, guiActiveEditor = true, guiActive = false)]
-        public void ToggleTeam()
-        {
-            team = !team;
-
-            if (HighLogic.LoadedSceneIsFlight)
-            {
-                audioSource.PlayOneShot(clickSound);
-                List<MissileFire>.Enumerator wpnMgr = vessel.FindPartModulesImplementing<MissileFire>().GetEnumerator();
-                while (wpnMgr.MoveNext())
-                {
-                    if (wpnMgr.Current == null) continue;
-                    wpnMgr.Current.team = team;
-                }
-                wpnMgr.Dispose();
-                if (vessel.gameObject.GetComponent<TargetInfo>())
-                {
-                    vessel.gameObject.GetComponent<TargetInfo>().RemoveFromDatabases();
-                    Destroy(vessel.gameObject.GetComponent<TargetInfo>());
-                }
-                OnToggleTeam?.Invoke(this, BDATargetManager.BoolToTeam(team));
-            }
-            UpdateTeamString();
-            ResetGuardInterval();
-
-        }
-
-        [KSPField(isPersistant = true)]
-        public bool isArmed = false;
-
-
-        [KSPAction("Arm/Disarm")]
-        public void AGToggleArm(KSPActionParam param)
-        {
-            ToggleArm();
-        }
-
-        public void ToggleArm()
-        {
-            isArmed = !isArmed;
-            if (isArmed) audioSource.PlayOneShot(armOnSound);
-            else audioSource.PlayOneShot(armOffSound);
-        }
-
-
-        [KSPField(isPersistant = false, guiActive = true, guiName = "Weapon")] public string selectedWeaponString =
-            "None";
-
-        IBDWeapon sw;
-
-        public IBDWeapon selectedWeapon
-        {
-            get
-            {
-                if ((sw != null && sw.GetPart().vessel == vessel) || weaponIndex <= 0) return sw;
-                List<IBDWeapon>.Enumerator weapon = vessel.FindPartModulesImplementing<IBDWeapon>().GetEnumerator();
-                while (weapon.MoveNext())
-                {
-                    if (weapon.Current == null) continue;
-                    if (weapon.Current.GetShortName() != selectedWeaponString) continue;
-                    sw = weapon.Current;
-                    break;
-                }
-                weapon.Dispose();
-                return sw;
-            }
-            set
-            {
-                sw = value;
-                selectedWeaponString = GetWeaponName(value);
-            }
-        }
-
-        [KSPAction("Fire Missile")]
-        public void AGFire(KSPActionParam param)
-        {
-            FireMissile();
-        }
-
-        [KSPAction("Fire Guns (Hold)")]
-        public void AGFireGunsHold(KSPActionParam param)
-        {
-            if (weaponIndex <= 0 || (selectedWeapon.GetWeaponClass() != WeaponClasses.Gun &&
-                                     selectedWeapon.GetWeaponClass() != WeaponClasses.DefenseLaser)) return;
-            List<ModuleWeapon>.Enumerator weap = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
-            while (weap.MoveNext())
-            {
-                if (weap.Current == null) continue;
-                if (weap.Current.weaponState != ModuleWeapon.WeaponStates.Enabled ||
-                    weap.Current.GetShortName() != selectedWeapon.GetShortName()) continue;
-                weap.Current.AGFireHold(param);
-            }
-            weap.Dispose();
-        }
-
-        [KSPAction("Fire Guns (Toggle)")]
-        public void AGFireGunsToggle(KSPActionParam param)
-        {
-            if (weaponIndex <= 0 || (selectedWeapon.GetWeaponClass() != WeaponClasses.Gun &&
-                                     selectedWeapon.GetWeaponClass() != WeaponClasses.DefenseLaser)) return;
-            List<ModuleWeapon>.Enumerator weap = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
-            while (weap.MoveNext())
-            {
-                if (weap.Current == null) continue;
-                if (weap.Current.weaponState != ModuleWeapon.WeaponStates.Enabled ||
-                    weap.Current.GetShortName() != selectedWeapon.GetShortName()) continue;
-                weap.Current.AGFireToggle(param);
-            }
-            weap.Dispose();
-        }
-
-        [KSPAction("Next Weapon")]
-        public void AGCycle(KSPActionParam param)
-        {
-            CycleWeapon(true);
-        }
-
-        [KSPAction("Previous Weapon")]
-        public void AGCycleBack(KSPActionParam param)
-        {
-            CycleWeapon(false);
-        }
-
-        [KSPEvent(guiActive = true, guiActiveEditor = false, guiName = "Open GUI", active = true)]
-        public void ToggleToolbarGUI()
-        {
-            BDArmorySetup.windowBDAToolBarEnabled = !BDArmorySetup.windowBDAToolBarEnabled;
-        }
-
-        #endregion
-
-        #endregion
-
-        #region KSP Events
-             
-        public override void OnSave(ConfigNode node)
-        {
-            base.OnSave(node);
-
-            if (HighLogic.LoadedSceneIsFlight)
-            {
-                SaveRippleOptions(node);
-            }
-        }
-               
-        public override void OnLoad(ConfigNode node)
-        {
-            base.OnLoad(node);
-            if (HighLogic.LoadedSceneIsFlight)
-            {
-                rippleData = string.Empty;
-                if (node.HasValue("RippleData"))
-                {
-                    rippleData = node.GetValue("RippleData");
-                }
-                ParseRippleOptions();
-            }
-        }
-
-        public override void OnAwake()
-        {
-            clickSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/click");
-            warningSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/warning");
-            armOnSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/armOn");
-            armOffSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/armOff");
-            heatGrowlSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/heatGrowl");
-
-            //HEAT LOCKING
-            heatTarget = TargetSignatureData.noTarget;
-        }
-
-        public override void OnStart(StartState state)
-        {
-            UpdateMaxGuardRange();
-
-            startTime = Time.time;
-
-            UpdateTeamString();
-
-            if (HighLogic.LoadedSceneIsFlight)
-            {
-                part.force_activate();
-
-                selectionMessage = new ScreenMessage("", 2.0f, ScreenMessageStyle.LOWER_CENTER);
-
-                UpdateList();
-                if (weaponArray.Length > 0) selectedWeapon = weaponArray[weaponIndex];
-                //selectedWeaponString = GetWeaponName(selectedWeapon);
-
-                cameraTransform = part.FindModelTransform("BDARPMCameraTransform");
-
-                part.force_activate();
-                rippleTimer = Time.time;
-                targetListTimer = Time.time;
-
-                wingCommander = part.FindModuleImplementing<ModuleWingCommander>();
-
-
-                audioSource = gameObject.AddComponent<AudioSource>();
-                audioSource.minDistance = 1;
-                audioSource.maxDistance = 500;
-                audioSource.dopplerLevel = 0;
-                audioSource.spatialBlend = 1;
-
-                warningAudioSource = gameObject.AddComponent<AudioSource>();
-                warningAudioSource.minDistance = 1;
-                warningAudioSource.maxDistance = 500;
-                warningAudioSource.dopplerLevel = 0;
-                warningAudioSource.spatialBlend = 1;
-
-                targetingAudioSource = gameObject.AddComponent<AudioSource>();
-                targetingAudioSource.minDistance = 1;
-                targetingAudioSource.maxDistance = 250;
-                targetingAudioSource.dopplerLevel = 0;
-                targetingAudioSource.loop = true;
-                targetingAudioSource.spatialBlend = 1;
-
-                StartCoroutine(MissileWarningResetRoutine());
-
-                if (vessel.isActiveVessel)
-                {
-                    BDArmorySetup.Instance.ActiveWeaponManager = this;
-                }
-
-                UpdateVolume();
-                BDArmorySetup.OnVolumeChange += UpdateVolume;
-                BDArmorySetup.OnSavedSettings += ClampVisualRange;
-
-                StartCoroutine(StartupListUpdater());
-                missilesAway = 0;
-
-                GameEvents.onVesselCreate.Add(OnVesselCreate);
-                GameEvents.onPartJointBreak.Add(OnPartJointBreak);
-                GameEvents.onPartDie.Add(OnPartDie);
-
-                List<IBDAIControl>.Enumerator aipilot = vessel.FindPartModulesImplementing<IBDAIControl>().GetEnumerator();
-                while (aipilot.MoveNext())
-                {
-                    if (aipilot.Current == null) continue;
-                    AI = aipilot.Current;
-                    break;
-                }
-                aipilot.Dispose();
-
-                RefreshModules();
-            }
-        }
-
-        void OnPartDie(Part p)
-        {
-            if (p == part)
-            {
-                try
-                {
-                    GameEvents.onPartDie.Remove(OnPartDie);
-                    GameEvents.onPartJointBreak.Remove(OnPartJointBreak);
-                    GameEvents.onVesselCreate.Remove(OnVesselCreate);
-                }
-                catch(Exception e)
-                {
-                    if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[BDArmory]: Error OnPartDie: " + e.Message);
-                }                
-            }
-            RefreshModules();
-            UpdateList();
-        }
-
-        void OnVesselCreate(Vessel v)
-        {
-            RefreshModules();
-        }
-
-        void OnPartJointBreak(PartJoint j, float breakForce)
-        {
-            if (!part)
-            {
-                GameEvents.onPartJointBreak.Remove(OnPartJointBreak);
-            }
-
-            if ((j.Parent && j.Parent.vessel == vessel) || (j.Child && j.Child.vessel == vessel))
-            {
-                RefreshModules();
-                UpdateList();
-            }
-        }
-
-        public override void OnUpdate()
-        {
-
-            if (!HighLogic.LoadedSceneIsFlight)
-            {
-                return;
-            }
-
-            base.OnUpdate();
-            if (!vessel.packed)
-            {
-                if (weaponIndex >= weaponArray.Length)
-                {
-                    hasSingleFired = true;
-                    triggerTimer = 0;
-
-                    weaponIndex = Mathf.Clamp(weaponIndex, 0, weaponArray.Length - 1);
-
-                    DisplaySelectedWeaponMessage();
-                }
-                if (weaponArray.Length > 0) selectedWeapon = weaponArray[weaponIndex];
-
-                //finding next rocket to shoot (for aimer)
-                //FindNextRocket();
-
-
-                //targeting
-                if (weaponIndex > 0 &&
-                    (selectedWeapon.GetWeaponClass() == WeaponClasses.Missile ||
-                    selectedWeapon.GetWeaponClass() == WeaponClasses.SLW ||
-                     selectedWeapon.GetWeaponClass() == WeaponClasses.Bomb))
-                {
-                    SearchForLaserPoint();
-                    SearchForHeatTarget();
-                    SearchForRadarSource();
-                }
-
-                CalculateMissilesAway();
-            }
-
-            UpdateTargetingAudio();
-
-
-            if (vessel.isActiveVessel)
-            {
-                if (!CheckMouseIsOnGui() && isArmed && BDInputUtils.GetKey(BDInputSettingsFields.WEAP_FIRE_KEY))
-                {
-                    triggerTimer += Time.fixedDeltaTime;
-                }
-                else
-                {
-                    triggerTimer = 0;
-                    hasSingleFired = false;
-                }
-
-
-                //firing missiles and rockets===
-                if (!guardMode &&
-                    selectedWeapon != null &&
-                    (selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket
-                     || selectedWeapon.GetWeaponClass() == WeaponClasses.Missile
-                     || selectedWeapon.GetWeaponClass() == WeaponClasses.Bomb
-                     || selectedWeapon.GetWeaponClass() == WeaponClasses.SLW
-                    ))
-                {
-                    canRipple = true;
-                    if (!MapView.MapIsEnabled && triggerTimer > BDArmorySettings.TRIGGER_HOLD_TIME && !hasSingleFired)
-                    {
-                        if (rippleFire)
-                        {
-                            if (Time.time - rippleTimer > 60f / rippleRPM)
-                            {
-                                FireMissile();
-                                rippleTimer = Time.time;
-                            }
-                        }
-                        else
-                        {
-                            FireMissile();
-                            hasSingleFired = true;
-                        }
-                    }
-                }
-                else if (!guardMode &&
-                         selectedWeapon != null &&
-                         (selectedWeapon.GetWeaponClass() == WeaponClasses.Gun && currentGun.roundsPerMinute < 1500))
-                {
-                    canRipple = true;
-                }
-                else
-                {
-                    canRipple = false;
-                }
-            }
-
-        }
-
-        private void CalculateMissilesAway()
-        {
-            int tempMissilesAway = 0;
-            List<IBDWeapon>.Enumerator firedMissiles = BDATargetManager.FiredMissiles.GetEnumerator();
-
-            while (firedMissiles.MoveNext())
-            {
-                if(firedMissiles.Current == null) continue;
-
-                var missileBase = firedMissiles.Current as MissileBase;
-
-                if(missileBase.SourceVessel != this.vessel) continue;
-
-                if (!missileBase.HasMissed)
-                {
-                    tempMissilesAway++;
-                }
-
-            }
-
-            this.missilesAway = tempMissilesAway;
-        }
-
-        public override void OnFixedUpdate()
-        {
-            if (guardMode && vessel.IsControllable)
-            {
-                GuardMode();
-            }
-            else
-            {
-                targetScanTimer = -100;
-            }
-
-            if (vessel.isActiveVessel)
-            {
-                TargetAcquire();
-            }
-
-            BombAimer();
-        }
-
-        void OnDestroy()
-        {
-            BDArmorySetup.OnVolumeChange -= UpdateVolume;
-            BDArmorySetup.OnSavedSettings -= ClampVisualRange;
-            GameEvents.onVesselCreate.Remove(OnVesselCreate);
-            GameEvents.onPartJointBreak.Remove(OnPartJointBreak);
-            GameEvents.onPartDie.Remove(OnPartDie);
-        }
-
-        void ClampVisualRange()
-        {
-            if (!BDArmorySettings.ALLOW_LEGACY_TARGETING)
-            {
-                guardRange = Mathf.Clamp(guardRange, 0, BDArmorySettings.MAX_GUARD_VISUAL_RANGE);
-            }
-
-            //UpdateMaxGuardRange();
-        }
-
-        void OnGUI()
-        {
-            if (HighLogic.LoadedSceneIsFlight && vessel == FlightGlobals.ActiveVessel &&
-                BDArmorySetup.GAME_UI_ENABLED && !MapView.MapIsEnabled)
-            {
-                if (BDArmorySettings.DRAW_DEBUG_LINES)
-                {
-                    if (guardMode && !BDArmorySettings.ALLOW_LEGACY_TARGETING)
-                    {
-                        BDGUIUtils.DrawLineBetweenWorldPositions(part.transform.position,
-                            part.transform.position + (debugGuardViewDirection * 25), 2, Color.yellow);
-                    }
-
-                    if (incomingMissileVessel)
-                    {
-                        BDGUIUtils.DrawLineBetweenWorldPositions(part.transform.position,
-                            incomingMissileVessel.transform.position, 5, Color.cyan);
-                    }
-                }
-
-                if (showBombAimer)
-                {
-                    MissileBase ml = CurrentMissile;
-                    if (ml)
-                    {
-                        float size = 128;
-                        Texture2D texture = BDArmorySetup.Instance.greenCircleTexture;
-
-
-                        if ((ml is MissileLauncher && ((MissileLauncher)ml).guidanceActive) || ml is BDModularGuidance)
-                        {
-                            texture = BDArmorySetup.Instance.largeGreenCircleTexture;
-                            size = 256;
-                        }
-                        BDGUIUtils.DrawTextureOnWorldPos(bombAimerPosition, texture, new Vector2(size, size), 0);
-                    }
-                }
-
-
-
-                //MISSILE LOCK HUD
-                MissileBase missile = CurrentMissile;
-                if (missile)
-                {
-                    if (missile.TargetingMode == MissileBase.TargetingModes.Laser)
-                    {
-                        if (laserPointDetected && foundCam)
-                        {
-                            BDGUIUtils.DrawTextureOnWorldPos(foundCam.groundTargetPosition, BDArmorySetup.Instance.greenCircleTexture, new Vector2(48, 48), 1);
-                        }
-
-                        List<ModuleTargetingCamera>.Enumerator cam = BDATargetManager.ActiveLasers.GetEnumerator();
-                        while (cam.MoveNext())
-                        {
-                            if (cam.Current == null) continue;
-                            if (cam.Current.vessel != vessel && cam.Current.surfaceDetected && cam.Current.groundStabilized && !cam.Current.gimbalLimitReached)
-                            {
-                                BDGUIUtils.DrawTextureOnWorldPos(cam.Current.groundTargetPosition, BDArmorySetup.Instance.greenDiamondTexture, new Vector2(18, 18), 0);
-                            }
-                        }
-                        cam.Dispose();
-                    }
-                    else if (missile.TargetingMode == MissileBase.TargetingModes.Heat)
-                    {
-                        MissileBase ml = CurrentMissile;
-                        if (heatTarget.exists)
-                        {
-                            BDGUIUtils.DrawTextureOnWorldPos(heatTarget.position, BDArmorySetup.Instance.greenCircleTexture, new Vector2(36, 36), 3);
-                            float distanceToTarget = Vector3.Distance(heatTarget.position, ml.MissileReferenceTransform.position);
-                            BDGUIUtils.DrawTextureOnWorldPos(ml.MissileReferenceTransform.position + (distanceToTarget * ml.GetForwardTransform()), BDArmorySetup.Instance.largeGreenCircleTexture, new Vector2(128, 128), 0);
-                            Vector3 fireSolution = MissileGuidance.GetAirToAirFireSolution(ml, heatTarget.position, heatTarget.velocity);
-                            Vector3 fsDirection = (fireSolution - ml.MissileReferenceTransform.position).normalized;
-                            BDGUIUtils.DrawTextureOnWorldPos(ml.MissileReferenceTransform.position + (distanceToTarget * fsDirection), BDArmorySetup.Instance.greenDotTexture, new Vector2(6, 6), 0);
-                        }
-                        else
-                        {
-                            BDGUIUtils.DrawTextureOnWorldPos(ml.MissileReferenceTransform.position + (2000 * ml.GetForwardTransform()), BDArmorySetup.Instance.greenCircleTexture, new Vector2(36, 36), 3);
-                            BDGUIUtils.DrawTextureOnWorldPos(ml.MissileReferenceTransform.position + (2000 * ml.GetForwardTransform()), BDArmorySetup.Instance.largeGreenCircleTexture, new Vector2(156, 156), 0);
-                        }
-                    }
-                    else if (missile.TargetingMode == MissileBase.TargetingModes.Radar)
-                    {
-                        MissileBase ml = CurrentMissile;
-                        //if(radar && radar.locked)
-                        if (vesselRadarData && vesselRadarData.locked)
-                        {
-                            float distanceToTarget = Vector3.Distance(vesselRadarData.lockedTargetData.targetData.predictedPosition, ml.MissileReferenceTransform.position);
-                            BDGUIUtils.DrawTextureOnWorldPos(ml.MissileReferenceTransform.position + (distanceToTarget * ml.GetForwardTransform()), BDArmorySetup.Instance.dottedLargeGreenCircle, new Vector2(128, 128), 0);
-                            //Vector3 fireSolution = MissileGuidance.GetAirToAirFireSolution(CurrentMissile, radar.lockedTarget.predictedPosition, radar.lockedTarget.velocity);
-                            Vector3 fireSolution = MissileGuidance.GetAirToAirFireSolution(ml, vesselRadarData.lockedTargetData.targetData.predictedPosition, vesselRadarData.lockedTargetData.targetData.velocity);
-                            Vector3 fsDirection = (fireSolution - ml.MissileReferenceTransform.position).normalized;
-                            BDGUIUtils.DrawTextureOnWorldPos(ml.MissileReferenceTransform.position + (distanceToTarget * fsDirection), BDArmorySetup.Instance.greenDotTexture, new Vector2(6, 6), 0);
-
-                            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                            {
-                                string dynRangeDebug = string.Empty;
-                                MissileLaunchParams dlz = MissileLaunchParams.GetDynamicLaunchParams(missile, vesselRadarData.lockedTargetData.targetData.velocity, vesselRadarData.lockedTargetData.targetData.predictedPosition);
-                                dynRangeDebug += "MaxDLZ: " + dlz.maxLaunchRange;
-                                dynRangeDebug += "\nMinDLZ: " + dlz.minLaunchRange;
-                                GUI.Label(new Rect(800, 600, 200, 200), dynRangeDebug);
-                            }
-                        }
-                    }
-                    else if (missile.TargetingMode == MissileBase.TargetingModes.AntiRad)
-                    {
-                        if (rwr && rwr.rwrEnabled && rwr.displayRWR)
-                        {
-                            for (int i = 0; i < rwr.pingsData.Length; i++)
-                            {
-                                if (rwr.pingsData[i].exists && (rwr.pingsData[i].signalStrength == 0 || rwr.pingsData[i].signalStrength == 5) && Vector3.Dot(rwr.pingWorldPositions[i] - missile.transform.position, missile.GetForwardTransform()) > 0)
-                                {
-                                    BDGUIUtils.DrawTextureOnWorldPos(rwr.pingWorldPositions[i], BDArmorySetup.Instance.greenDiamondTexture, new Vector2(22, 22), 0);
-                                }
-                            }
-                        }
-
-                        if (antiRadTargetAcquired)
-                        {
-                            BDGUIUtils.DrawTextureOnWorldPos(antiRadiationTarget,
-                                BDArmorySetup.Instance.openGreenSquare, new Vector2(22, 22), 0);
-                        }
-                    }
-                }
-
-                if ((missile && missile.TargetingMode == MissileBase.TargetingModes.Gps) || BDArmorySetup.Instance.showingWindowGPS)
-                {
-                    if (designatedGPSCoords != Vector3d.zero)
-                    {
-                        BDGUIUtils.DrawTextureOnWorldPos(VectorUtils.GetWorldSurfacePostion(designatedGPSCoords, vessel.mainBody), BDArmorySetup.Instance.greenSpikedPointCircleTexture, new Vector2(22, 22), 0);
-                    }
-                }
-
-                if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                {
-                    GUI.Label(new Rect(600, 900, 100, 100), "Missiles away: " + missilesAway);
-                }
-            }
-
-        }
-
-        bool CheckMouseIsOnGui()
-        {
-            return Misc.Misc.CheckMouseIsOnGui();
-        }
-
-        #endregion
-
-        #region Enumerators
-
-        IEnumerator StartupListUpdater()
-        {
-            while (vessel.packed || !FlightGlobals.ready)
-            {
-                yield return null;
-                if (vessel.isActiveVessel)
-                {
-                    BDArmorySetup.Instance.ActiveWeaponManager = this;
-                }
-            }
-            UpdateList();
-        }
-
-        IEnumerator MissileWarningResetRoutine()
-        {
-            while (enabled)
-            {
-                missileIsIncoming = false;
-                yield return new WaitForSeconds(1);
-            }
-        }
-
-        IEnumerator UnderFireRoutine()
-        {
-            underFire = true;
-            yield return new WaitForSeconds(3);
-            underFire = false;
-        }
-
-        IEnumerator UnderAttackRoutine()
-        {
-            underAttack = true;
-            yield return new WaitForSeconds(3);
-            underAttack = false;
-        }
-
-
-        IEnumerator GuardTurretRoutine()
-        {
-            if (gameObject.activeInHierarchy && !BDArmorySettings.ALLOW_LEGACY_TARGETING)
-            //target is out of visual range, try using sensors
-            {
-                if (guardTarget.LandedOrSplashed)
-                {
-                    if (targetingPods.Count > 0)
-                    {
-                        List<ModuleTargetingCamera>.Enumerator tgp = targetingPods.GetEnumerator();
-                        while (tgp.MoveNext())
-                        {
-                            if (tgp.Current == null) continue;
-                            if (!tgp.Current.enabled || (tgp.Current.cameraEnabled && tgp.Current.groundStabilized &&
-                                                         !((tgp.Current.groundTargetPosition -
-                                                            guardTarget.transform.position).sqrMagnitude > 20*20))) continue;
-                            tgp.Current.EnableCamera();
-                            yield return StartCoroutine(tgp.Current.PointToPositionRoutine(guardTarget.CoM));
-                            //yield return StartCoroutine(tgp.Current.PointToPositionRoutine(TargetInfo.TargetCOMDispersion(guardTarget)));
-                            if (!tgp.Current) continue;
-                            if (tgp.Current.groundStabilized && guardTarget &&
-                                (tgp.Current.groundTargetPosition - guardTarget.transform.position).sqrMagnitude < 20*20)
-                            {
-                                tgp.Current.slaveTurrets = true;
-                                StartGuardTurretFiring();
-                                yield break;
-                            }
-                            tgp.Current.DisableCamera();
-                        }
-                        tgp.Dispose();
-                    }
-
-                    if (!guardTarget || (guardTarget.transform.position - transform.position).sqrMagnitude > guardRange*guardRange)
-                    {
-                        SetTarget(null); //disengage, sensors unavailable.
-                        yield break;
-                    }
-                }
-                else
-                {
-                    if (!vesselRadarData || !(vesselRadarData.radarCount > 0))
-                    {
-                        List<ModuleRadar>.Enumerator rd = radars.GetEnumerator();
-                        while (rd.MoveNext())
-                        {
-                            if (rd.Current == null) continue;
-                            if (!rd.Current.canLock) continue;
-                            rd.Current.EnableRadar();
-                            break;
-                        }
-                        rd.Dispose();
-                    }
-
-                    if (vesselRadarData &&
-                        (!vesselRadarData.locked ||
-                         (vesselRadarData.lockedTargetData.targetData.predictedPosition - guardTarget.transform.position)
-                             .sqrMagnitude > 40*40))
-                    {
-                        //vesselRadarData.TryLockTarget(guardTarget.transform.position);
-                        vesselRadarData.TryLockTarget(guardTarget);
-                        yield return new WaitForSeconds(0.5f);
-                        if (guardTarget && vesselRadarData && vesselRadarData.locked &&
-                            vesselRadarData.lockedTargetData.vessel == guardTarget)
-                        {
-                            vesselRadarData.SlaveTurrets();
-                            StartGuardTurretFiring();
-                            yield break;
-                        }
-                    }
-
-                    if (!guardTarget || (guardTarget.transform.position - transform.position).sqrMagnitude > guardRange*guardRange)
-                    {
-                        SetTarget(null); //disengage, sensors unavailable.
-                        yield break;
-                    }
-                }
-            }
-
-
-            StartGuardTurretFiring();
-            yield break;
-        }
-
-        IEnumerator ResetMissileThreatDistanceRoutine()
-        {
-            yield return new WaitForSeconds(8);
-            incomingMissileDistance = float.MaxValue;
-        }
-
-        IEnumerator GuardMissileRoutine()
-        {
-            MissileBase ml = CurrentMissile;
-
-            if (ml && !guardFiringMissile)
-            {
-                guardFiringMissile = true;
-
-
-                if (BDArmorySettings.ALLOW_LEGACY_TARGETING)
-                {
-                    //TODO BDModularGuidance Legacy and turret implementation
-                    if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                    {
-                        Debug.Log("[BDArmory]: Firing on target: " + guardTarget.GetName() + ", (legacy targeting)");
-                    }
-                    if (ml is MissileLauncher && ((MissileLauncher)ml).missileTurret)
-                    {
-                        ((MissileLauncher)ml).missileTurret.PrepMissileForFire(((MissileLauncher)ml));
-                        ((MissileLauncher)ml).FireMissileOnTarget(guardTarget);
-                        ((MissileLauncher)ml).missileTurret.UpdateMissileChildren();
-                    }
-                    else
-                    {
-                        ((MissileLauncher)ml).FireMissileOnTarget(guardTarget);
-                    }
-                    //StartCoroutine(MissileAwayRoutine(ml));
-                    UpdateList();
-                }
-                else if (ml.TargetingMode == MissileBase.TargetingModes.Radar && vesselRadarData)
-                {
-                    float attemptLockTime = Time.time;
-                    while ((!vesselRadarData.locked || (vesselRadarData.lockedTargetData.vessel != guardTarget)) && Time.time - attemptLockTime < 2)
-                    {
-                        if (vesselRadarData.locked)
-                        {
-                            vesselRadarData.UnlockAllTargets();
-                            yield return null;
-                        }
-                        //vesselRadarData.TryLockTarget(guardTarget.transform.position+(guardTarget.rb_velocity*Time.fixedDeltaTime));
-                        vesselRadarData.TryLockTarget(guardTarget);
-                        yield return new WaitForSeconds(0.25f);
-                    }
-
-                    if (ml && AIMightDirectFire() && vesselRadarData.locked)
-                    {
-                        SetCargoBays();
-                        float LAstartTime = Time.time;
-                        while (AIMightDirectFire() && Time.time - LAstartTime < 3 &&
-                               GetLaunchAuthorization(guardTarget, this))
-                        {
-                            yield return new WaitForFixedUpdate();
-                        }
-
-                        yield return new WaitForSeconds(0.5f);
-                    }
-
-
-                    //wait for missile turret to point at target
-                    //TODO BDModularGuidance: add turret
-                    MissileLauncher mlauncher = ml as MissileLauncher;
-                    if (mlauncher != null)
-                    {
-                        if (guardTarget && ml && mlauncher.missileTurret && vesselRadarData.locked)
-                        {
-                            vesselRadarData.SlaveTurrets();
-                            float turretStartTime = Time.time;
-                            while (Time.time - turretStartTime < 5)
-                            {
-                                float angle = Vector3.Angle(mlauncher.missileTurret.finalTransform.forward, mlauncher.missileTurret.slavedTargetPosition - mlauncher.missileTurret.finalTransform.position);
-                                if (angle < 1)
-                                {
-                                    turretStartTime -= 2 * Time.fixedDeltaTime;
-                                }
-                                yield return new WaitForFixedUpdate();
-                            }
-                        }
-                    }
-
-                    yield return null;
-
-                    if (ml && guardTarget && vesselRadarData.locked && (!AIMightDirectFire() || GetLaunchAuthorization(guardTarget, this)))
-                    {
-                        if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                        {
-                            Debug.Log("Firing on target: " + guardTarget.GetName());
-                        }
-                        FireCurrentMissile(true);
-                        //StartCoroutine(MissileAwayRoutine(mlauncher));
-                    }
-                }
-                else if (ml.TargetingMode == MissileBase.TargetingModes.Heat)
-                {
-                    if (vesselRadarData && vesselRadarData.locked)
-                    {
-                        vesselRadarData.UnlockAllTargets();
-                        vesselRadarData.UnslaveTurrets();
-                    }
-                    float attemptStartTime = Time.time;
-                    float attemptDuration = Mathf.Max(targetScanInterval * 0.75f, 5f);
-                    SetCargoBays();
-
-
-                    MissileLauncher mlauncher;
-                    while (ml && Time.time - attemptStartTime < attemptDuration && (!heatTarget.exists || (heatTarget.predictedPosition - guardTarget.transform.position).sqrMagnitude > 40*40))
-                    {
-                        //TODO BDModularGuidance: add turret
-                        //try using missile turret to lock target
-                        mlauncher = ml as MissileLauncher;
-                        if (mlauncher != null)
-                        {
-                            if (mlauncher.missileTurret)
-                            {
-                                mlauncher.missileTurret.slaved = true;
-                                mlauncher.missileTurret.slavedTargetPosition = guardTarget.CoM;
-                                mlauncher.missileTurret.SlavedAim();
-                            }
-                        }
-
-                        yield return new WaitForFixedUpdate();
-                    }
-
-
-                    //try uncaged IR lock with radar
-                    if (guardTarget && !heatTarget.exists && vesselRadarData && vesselRadarData.radarCount > 0)
-                    {
-                        if (!vesselRadarData.locked ||
-                            (vesselRadarData.lockedTargetData.targetData.predictedPosition -
-                             guardTarget.transform.position).sqrMagnitude > 40*40)
-                        {
-                            //vesselRadarData.TryLockTarget(guardTarget.transform.position);
-                            vesselRadarData.TryLockTarget(guardTarget);
-                            yield return new WaitForSeconds(Mathf.Min(1, (targetScanInterval * 0.25f)));
-                        }
-                    }
-
-                    if (AIMightDirectFire() && ml && heatTarget.exists)
-                    {
-                        float LAstartTime = Time.time;
-                        while (Time.time - LAstartTime < 3 && AIMightDirectFire() &&
-                               GetLaunchAuthorization(guardTarget, this))
-                        {
-                            yield return new WaitForFixedUpdate();
-                        }
-
-                        yield return new WaitForSeconds(0.5f);
-                    }
-
-                    //wait for missile turret to point at target
-                    mlauncher = ml as MissileLauncher;
-                    if (mlauncher != null)
-                    {
-                        if (ml && mlauncher.missileTurret && heatTarget.exists)
-                        {
-                            float turretStartTime = attemptStartTime;
-                            while (heatTarget.exists && Time.time - turretStartTime < Mathf.Max(targetScanInterval / 2f, 2))
-                            {
-                                float angle = Vector3.Angle(mlauncher.missileTurret.finalTransform.forward, mlauncher.missileTurret.slavedTargetPosition - mlauncher.missileTurret.finalTransform.position);
-                                mlauncher.missileTurret.slaved = true;
-                                mlauncher.missileTurret.slavedTargetPosition = MissileGuidance.GetAirToAirFireSolution(mlauncher, heatTarget.predictedPosition, heatTarget.velocity);
-                                mlauncher.missileTurret.SlavedAim();
-
-                                if (angle < 1)
-                                {
-                                    turretStartTime -= 3 * Time.fixedDeltaTime;
-                                }
-                                yield return new WaitForFixedUpdate();
-                            }
-                        }
-                    }
-
-                    yield return null;
-
-                    if (guardTarget && ml && heatTarget.exists &&
-                        (!AIMightDirectFire() || GetLaunchAuthorization(guardTarget, this)))
-                    {
-                        if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                        {
-                            Debug.Log("[BDArmory]: Firing on target: " + guardTarget.GetName());
-                        }
-
-                        FireCurrentMissile(true);
-                        //StartCoroutine(MissileAwayRoutine(mlauncher));
-                    }
-                }
-                else if (ml.TargetingMode == MissileBase.TargetingModes.Gps)
-                {
-                    designatedGPSInfo = new GPSTargetInfo(VectorUtils.WorldPositionToGeoCoords(guardTarget.CoM, vessel.mainBody), guardTarget.vesselName.Substring(0, Mathf.Min(12, guardTarget.vesselName.Length)));
-
-                    FireCurrentMissile(true);
-                    //if (FireCurrentMissile(true))
-                    //    StartCoroutine(MissileAwayRoutine(ml)); //NEW: try to prevent launching all missile complements at once...
-
-                }
-                else if (ml.TargetingMode == MissileBase.TargetingModes.AntiRad)
-                {
-                    if (rwr)
-                    {
-                        if (!rwr.rwrEnabled) rwr.EnableRWR();
-                        if (rwr.rwrEnabled && !rwr.displayRWR) rwr.displayRWR = true;
-                    }
-
-          float attemptStartTime = Time.time;
-                    float attemptDuration = targetScanInterval * 0.75f;
-                    while (Time.time - attemptStartTime < attemptDuration &&
-                           (!antiRadTargetAcquired || (antiRadiationTarget - guardTarget.CoM).sqrMagnitude > 20*20))
-                    {
-                        yield return new WaitForFixedUpdate();
-                    }
-
-                    if (SetCargoBays())
-                    {
-                        yield return new WaitForSeconds(1f);
-                    }
-
-                    if (ml && antiRadTargetAcquired && (antiRadiationTarget - guardTarget.CoM).sqrMagnitude < 20*20)
-                    {
-                        FireCurrentMissile(true);
-                        //StartCoroutine(MissileAwayRoutine(ml));
-                    }
-                }
-                else if (ml.TargetingMode == MissileBase.TargetingModes.Laser)
-                {
-                    if (targetingPods.Count > 0) //if targeting pods are available, slew them onto target and lock.
-                    {
-                        List<ModuleTargetingCamera>.Enumerator tgp = targetingPods.GetEnumerator();
-                        while (tgp.MoveNext())
-                        {
-                            if (tgp.Current == null) continue;
-                            tgp.Current.EnableCamera();
-                            yield return StartCoroutine(tgp.Current.PointToPositionRoutine(guardTarget.CoM));
-                            if (tgp.Current.groundStabilized && (tgp.Current.groundTargetPosition - guardTarget.transform.position).sqrMagnitude < 20*20)
-                            {
-                                break;
-                            }
-                        }
-                        tgp.Dispose();
-                    }
-
-                    //search for a laser point that corresponds with target vessel
-                    float attemptStartTime = Time.time;
-                    float attemptDuration = targetScanInterval * 0.75f;
-                    while (Time.time - attemptStartTime < attemptDuration && (!laserPointDetected || (foundCam && (foundCam.groundTargetPosition - guardTarget.CoM).sqrMagnitude > 20*20)))
-                    {
-                        yield return new WaitForFixedUpdate();
-                    }
-                    if (SetCargoBays())
-                    {
-                        yield return new WaitForSeconds(1f);
-                    }
-                    if (ml && laserPointDetected && foundCam && (foundCam.groundTargetPosition - guardTarget.CoM).sqrMagnitude < 20*20)
-                    {
-                        FireCurrentMissile(true);
-                        //StartCoroutine(MissileAwayRoutine(ml));
-                    }
-                    else
-                    {
-                        if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[BDArmory]: Laser Target Error");
-                    }
-
-                }
-
-
-                guardFiringMissile = false;
-            }
-        }
+		public bool team = false;
+
+
+		[KSPAction("Toggle Team")]
+		public void AGToggleTeam(KSPActionParam param)
+		{
+			ToggleTeam();
+		}
+
+		public delegate void ToggleTeamDelegate(MissileFire wm, BDArmorySetup.BDATeams team);
+
+		public static event ToggleTeamDelegate OnToggleTeam;
+
+		[KSPEvent(active = true, guiActiveEditor = true, guiActive = false)]
+		public void ToggleTeam()
+		{
+			team = !team;
+
+			if (HighLogic.LoadedSceneIsFlight)
+			{
+				audioSource.PlayOneShot(clickSound);
+				List<MissileFire>.Enumerator wpnMgr = vessel.FindPartModulesImplementing<MissileFire>().GetEnumerator();
+				while (wpnMgr.MoveNext())
+				{
+					if (wpnMgr.Current == null) continue;
+					wpnMgr.Current.team = team;
+				}
+				wpnMgr.Dispose();
+				if (vessel.gameObject.GetComponent<TargetInfo>())
+				{
+					vessel.gameObject.GetComponent<TargetInfo>().RemoveFromDatabases();
+					Destroy(vessel.gameObject.GetComponent<TargetInfo>());
+				}
+				OnToggleTeam?.Invoke(this, BDATargetManager.BoolToTeam(team));
+			}
+			UpdateTeamString();
+			ResetGuardInterval();
+
+		}
+
+		[KSPField(isPersistant = true)]
+		public bool isArmed = false;
+
+
+		[KSPAction("Arm/Disarm")]
+		public void AGToggleArm(KSPActionParam param)
+		{
+			ToggleArm();
+		}
+
+		public void ToggleArm()
+		{
+			isArmed = !isArmed;
+			if (isArmed) audioSource.PlayOneShot(armOnSound);
+			else audioSource.PlayOneShot(armOffSound);
+		}
+
+
+		[KSPField(isPersistant = false, guiActive = true, guiName = "Weapon")] public string selectedWeaponString =
+			"None";
+
+		IBDWeapon sw;
+
+		public IBDWeapon selectedWeapon
+		{
+			get
+			{
+				if ((sw != null && sw.GetPart().vessel == vessel) || weaponIndex <= 0) return sw;
+				List<IBDWeapon>.Enumerator weapon = vessel.FindPartModulesImplementing<IBDWeapon>().GetEnumerator();
+				while (weapon.MoveNext())
+				{
+					if (weapon.Current == null) continue;
+					if (weapon.Current.GetShortName() != selectedWeaponString) continue;
+					sw = weapon.Current;
+					break;
+				}
+				weapon.Dispose();
+				return sw;
+			}
+			set
+			{
+				sw = value;
+				selectedWeaponString = GetWeaponName(value);
+			}
+		}
+
+		[KSPAction("Fire Missile")]
+		public void AGFire(KSPActionParam param)
+		{
+			FireMissile();
+		}
+
+		[KSPAction("Fire Guns (Hold)")]
+		public void AGFireGunsHold(KSPActionParam param)
+		{
+			if (weaponIndex <= 0 || (selectedWeapon.GetWeaponClass() != WeaponClasses.Gun &&
+									 selectedWeapon.GetWeaponClass() != WeaponClasses.DefenseLaser)) return;
+			List<ModuleWeapon>.Enumerator weap = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
+			while (weap.MoveNext())
+			{
+				if (weap.Current == null) continue;
+				if (weap.Current.weaponState != ModuleWeapon.WeaponStates.Enabled ||
+					weap.Current.GetShortName() != selectedWeapon.GetShortName()) continue;
+				weap.Current.AGFireHold(param);
+			}
+			weap.Dispose();
+		}
+
+		[KSPAction("Fire Guns (Toggle)")]
+		public void AGFireGunsToggle(KSPActionParam param)
+		{
+			if (weaponIndex <= 0 || (selectedWeapon.GetWeaponClass() != WeaponClasses.Gun &&
+									 selectedWeapon.GetWeaponClass() != WeaponClasses.DefenseLaser)) return;
+			List<ModuleWeapon>.Enumerator weap = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
+			while (weap.MoveNext())
+			{
+				if (weap.Current == null) continue;
+				if (weap.Current.weaponState != ModuleWeapon.WeaponStates.Enabled ||
+					weap.Current.GetShortName() != selectedWeapon.GetShortName()) continue;
+				weap.Current.AGFireToggle(param);
+			}
+			weap.Dispose();
+		}
+
+		[KSPAction("Next Weapon")]
+		public void AGCycle(KSPActionParam param)
+		{
+			CycleWeapon(true);
+		}
+
+		[KSPAction("Previous Weapon")]
+		public void AGCycleBack(KSPActionParam param)
+		{
+			CycleWeapon(false);
+		}
+
+		[KSPEvent(guiActive = true, guiActiveEditor = false, guiName = "Open GUI", active = true)]
+		public void ToggleToolbarGUI()
+		{
+			BDArmorySetup.windowBDAToolBarEnabled = !BDArmorySetup.windowBDAToolBarEnabled;
+		}
+
+		#endregion
+
+		#endregion
+
+		#region KSP Events
+
+		public override void OnSave(ConfigNode node)
+		{
+			base.OnSave(node);
+
+			if (HighLogic.LoadedSceneIsFlight)
+			{
+				SaveRippleOptions(node);
+			}
+		}
+
+		public override void OnLoad(ConfigNode node)
+		{
+			base.OnLoad(node);
+			if (HighLogic.LoadedSceneIsFlight)
+			{
+				rippleData = string.Empty;
+				if (node.HasValue("RippleData"))
+				{
+					rippleData = node.GetValue("RippleData");
+				}
+				ParseRippleOptions();
+			}
+		}
+
+		public override void OnAwake()
+		{
+			clickSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/click");
+			warningSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/warning");
+			armOnSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/armOn");
+			armOffSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/armOff");
+			heatGrowlSound = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/heatGrowl");
+
+			//HEAT LOCKING
+			heatTarget = TargetSignatureData.noTarget;
+		}
+
+		public override void OnStart(StartState state)
+		{
+			UpdateMaxGuardRange();
+
+			startTime = Time.time;
+
+			UpdateTeamString();
+
+			if (HighLogic.LoadedSceneIsFlight)
+			{
+				part.force_activate();
+
+				selectionMessage = new ScreenMessage("", 2.0f, ScreenMessageStyle.LOWER_CENTER);
+
+				UpdateList();
+				if (weaponArray.Length > 0) selectedWeapon = weaponArray[weaponIndex];
+				//selectedWeaponString = GetWeaponName(selectedWeapon);
+
+				cameraTransform = part.FindModelTransform("BDARPMCameraTransform");
+
+				part.force_activate();
+				rippleTimer = Time.time;
+				targetListTimer = Time.time;
+
+				wingCommander = part.FindModuleImplementing<ModuleWingCommander>();
+
+
+				audioSource = gameObject.AddComponent<AudioSource>();
+				audioSource.minDistance = 1;
+				audioSource.maxDistance = 500;
+				audioSource.dopplerLevel = 0;
+				audioSource.spatialBlend = 1;
+
+				warningAudioSource = gameObject.AddComponent<AudioSource>();
+				warningAudioSource.minDistance = 1;
+				warningAudioSource.maxDistance = 500;
+				warningAudioSource.dopplerLevel = 0;
+				warningAudioSource.spatialBlend = 1;
+
+				targetingAudioSource = gameObject.AddComponent<AudioSource>();
+				targetingAudioSource.minDistance = 1;
+				targetingAudioSource.maxDistance = 250;
+				targetingAudioSource.dopplerLevel = 0;
+				targetingAudioSource.loop = true;
+				targetingAudioSource.spatialBlend = 1;
+
+				StartCoroutine(MissileWarningResetRoutine());
+
+				if (vessel.isActiveVessel)
+				{
+					BDArmorySetup.Instance.ActiveWeaponManager = this;
+				}
+
+				UpdateVolume();
+				BDArmorySetup.OnVolumeChange += UpdateVolume;
+				BDArmorySetup.OnSavedSettings += ClampVisualRange;
+
+				StartCoroutine(StartupListUpdater());
+				missilesAway = 0;
+
+				GameEvents.onVesselCreate.Add(OnVesselCreate);
+				GameEvents.onPartJointBreak.Add(OnPartJointBreak);
+				GameEvents.onPartDie.Add(OnPartDie);
+
+				List<IBDAIControl>.Enumerator aipilot = vessel.FindPartModulesImplementing<IBDAIControl>().GetEnumerator();
+				while (aipilot.MoveNext())
+				{
+					if (aipilot.Current == null) continue;
+					AI = aipilot.Current;
+					break;
+				}
+				aipilot.Dispose();
+
+				RefreshModules();
+			}
+		}
+
+		void OnPartDie(Part p)
+		{
+			if (p == part)
+			{
+				try
+				{
+					GameEvents.onPartDie.Remove(OnPartDie);
+					GameEvents.onPartJointBreak.Remove(OnPartJointBreak);
+					GameEvents.onVesselCreate.Remove(OnVesselCreate);
+				}
+				catch (Exception e)
+				{
+					if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[BDArmory]: Error OnPartDie: " + e.Message);
+				}
+			}
+			RefreshModules();
+			UpdateList();
+		}
+
+		void OnVesselCreate(Vessel v)
+		{
+			RefreshModules();
+		}
+
+		void OnPartJointBreak(PartJoint j, float breakForce)
+		{
+			if (!part)
+			{
+				GameEvents.onPartJointBreak.Remove(OnPartJointBreak);
+			}
+
+			if ((j.Parent && j.Parent.vessel == vessel) || (j.Child && j.Child.vessel == vessel))
+			{
+				RefreshModules();
+				UpdateList();
+			}
+		}
+
+		public override void OnUpdate()
+		{
+
+			if (!HighLogic.LoadedSceneIsFlight)
+			{
+				return;
+			}
+
+			base.OnUpdate();
+			if (!vessel.packed)
+			{
+				if (weaponIndex >= weaponArray.Length)
+				{
+					hasSingleFired = true;
+					triggerTimer = 0;
+
+					weaponIndex = Mathf.Clamp(weaponIndex, 0, weaponArray.Length - 1);
+
+					DisplaySelectedWeaponMessage();
+				}
+				if (weaponArray.Length > 0) selectedWeapon = weaponArray[weaponIndex];
+
+				//targeting
+				if (weaponIndex > 0 &&
+					(selectedWeapon.GetWeaponClass() == WeaponClasses.Missile ||
+					selectedWeapon.GetWeaponClass() == WeaponClasses.SLW ||
+					 selectedWeapon.GetWeaponClass() == WeaponClasses.Bomb))
+				{
+					SearchForLaserPoint();
+					SearchForHeatTarget();
+					SearchForRadarSource();
+				}
+
+				CalculateMissilesAway();
+			}
+
+			UpdateTargetingAudio();
+
+
+			if (vessel.isActiveVessel)
+			{
+				if (!CheckMouseIsOnGui() && isArmed && BDInputUtils.GetKey(BDInputSettingsFields.WEAP_FIRE_KEY))
+				{
+					triggerTimer += Time.fixedDeltaTime;
+				}
+				else
+				{
+					triggerTimer = 0;
+					hasSingleFired = false;
+				}
+
+				if (selectedWeapon != null && (selectedWeapon.GetWeaponClass() == WeaponClasses.Gun || (selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket && currentGun.externalAmmo)))
+				{
+					AmmoController(); //Could have this called by ModuleWeapon.Fire(); only need this called when a weapon fires, but salvo mode would have multiple duplicate calls 
+									  //so going with slightly less performance efficient method in general to prevent greater perfomance cost in specific circumstances
+				}
+
+				//firing missiles and rockets===
+				if (!guardMode &&
+					selectedWeapon != null &&
+					(selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket
+					 || selectedWeapon.GetWeaponClass() == WeaponClasses.Missile
+					 || selectedWeapon.GetWeaponClass() == WeaponClasses.Bomb
+					 || selectedWeapon.GetWeaponClass() == WeaponClasses.SLW
+					))
+				{
+					canRipple = true;
+					if (!MapView.MapIsEnabled && triggerTimer > BDArmorySettings.TRIGGER_HOLD_TIME && !hasSingleFired)
+					{
+						if (rippleFire)
+						{
+							if (Time.time - rippleTimer > 60f / rippleRPM)
+							{
+								FireMissile();
+								rippleTimer = Time.time;
+							}
+						}
+						else
+						{
+							FireMissile();
+							hasSingleFired = true;
+						}
+					}
+				}
+				else if (!guardMode &&
+						 selectedWeapon != null &&
+						 (selectedWeapon.GetWeaponClass() == WeaponClasses.Gun && currentGun.roundsPerMinute < 1500))
+				{
+					canRipple = true;
+				}
+				else
+				{
+					canRipple = false;
+				}
+			}
+		}
+
+		private void CalculateMissilesAway()
+		{
+			int tempMissilesAway = 0;
+			List<IBDWeapon>.Enumerator firedMissiles = BDATargetManager.FiredMissiles.GetEnumerator();
+
+			while (firedMissiles.MoveNext())
+			{
+				if (firedMissiles.Current == null) continue;
+
+				var missileBase = firedMissiles.Current as MissileBase;
+
+				if (missileBase.SourceVessel != this.vessel) continue;
+
+				if (!missileBase.HasMissed)
+				{
+					tempMissilesAway++;
+				}
+
+			}
+
+			this.missilesAway = tempMissilesAway;
+		}
+
+		public override void OnFixedUpdate()
+		{
+			if (guardMode && vessel.IsControllable)
+			{
+				GuardMode();
+			}
+			else
+			{
+				targetScanTimer = -100;
+			}
+
+			if (vessel.isActiveVessel)
+			{
+				TargetAcquire();
+			}
+			BombAimer();
+		}
+
+		void OnDestroy()
+		{
+			BDArmorySetup.OnVolumeChange -= UpdateVolume;
+			BDArmorySetup.OnSavedSettings -= ClampVisualRange;
+			GameEvents.onVesselCreate.Remove(OnVesselCreate);
+			GameEvents.onPartJointBreak.Remove(OnPartJointBreak);
+			GameEvents.onPartDie.Remove(OnPartDie);
+		}
+
+		void ClampVisualRange()
+		{
+			if (!BDArmorySettings.ALLOW_LEGACY_TARGETING)
+			{
+				guardRange = Mathf.Clamp(guardRange, 0, BDArmorySettings.MAX_GUARD_VISUAL_RANGE);
+			}
+
+			//UpdateMaxGuardRange();
+		}
+
+		void OnGUI()
+		{
+			if (HighLogic.LoadedSceneIsFlight && vessel == FlightGlobals.ActiveVessel &&
+				BDArmorySetup.GAME_UI_ENABLED && !MapView.MapIsEnabled)
+			{
+				if (BDArmorySettings.DRAW_DEBUG_LINES)
+				{
+					if (guardMode && !BDArmorySettings.ALLOW_LEGACY_TARGETING)
+					{
+						BDGUIUtils.DrawLineBetweenWorldPositions(part.transform.position,
+							part.transform.position + (debugGuardViewDirection * 25), 2, Color.yellow);
+					}
+
+					if (incomingMissileVessel)
+					{
+						BDGUIUtils.DrawLineBetweenWorldPositions(part.transform.position,
+							incomingMissileVessel.transform.position, 5, Color.cyan);
+					}
+				}
+
+				if (showBombAimer)
+				{
+					MissileBase ml = CurrentMissile;
+					if (ml)
+					{
+						float size = 128;
+						Texture2D texture = BDArmorySetup.Instance.greenCircleTexture;
+
+
+						if ((ml is MissileLauncher && ((MissileLauncher)ml).guidanceActive) || ml is BDModularGuidance)
+						{
+							texture = BDArmorySetup.Instance.largeGreenCircleTexture;
+							size = 256;
+						}
+						BDGUIUtils.DrawTextureOnWorldPos(bombAimerPosition, texture, new Vector2(size, size), 0);
+					}
+				}
+
+
+
+				//MISSILE LOCK HUD
+				MissileBase missile = CurrentMissile;
+				if (missile)
+				{
+					if (missile.TargetingMode == MissileBase.TargetingModes.Laser)
+					{
+						if (laserPointDetected && foundCam)
+						{
+							BDGUIUtils.DrawTextureOnWorldPos(foundCam.groundTargetPosition, BDArmorySetup.Instance.greenCircleTexture, new Vector2(48, 48), 1);
+						}
+
+						List<ModuleTargetingCamera>.Enumerator cam = BDATargetManager.ActiveLasers.GetEnumerator();
+						while (cam.MoveNext())
+						{
+							if (cam.Current == null) continue;
+							if (cam.Current.vessel != vessel && cam.Current.surfaceDetected && cam.Current.groundStabilized && !cam.Current.gimbalLimitReached)
+							{
+								BDGUIUtils.DrawTextureOnWorldPos(cam.Current.groundTargetPosition, BDArmorySetup.Instance.greenDiamondTexture, new Vector2(18, 18), 0);
+							}
+						}
+						cam.Dispose();
+					}
+					else if (missile.TargetingMode == MissileBase.TargetingModes.Heat)
+					{
+						MissileBase ml = CurrentMissile;
+						if (heatTarget.exists)
+						{
+							BDGUIUtils.DrawTextureOnWorldPos(heatTarget.position, BDArmorySetup.Instance.greenCircleTexture, new Vector2(36, 36), 3);
+							float distanceToTarget = Vector3.Distance(heatTarget.position, ml.MissileReferenceTransform.position);
+							BDGUIUtils.DrawTextureOnWorldPos(ml.MissileReferenceTransform.position + (distanceToTarget * ml.GetForwardTransform()), BDArmorySetup.Instance.largeGreenCircleTexture, new Vector2(128, 128), 0);
+							Vector3 fireSolution = MissileGuidance.GetAirToAirFireSolution(ml, heatTarget.position, heatTarget.velocity);
+							Vector3 fsDirection = (fireSolution - ml.MissileReferenceTransform.position).normalized;
+							BDGUIUtils.DrawTextureOnWorldPos(ml.MissileReferenceTransform.position + (distanceToTarget * fsDirection), BDArmorySetup.Instance.greenDotTexture, new Vector2(6, 6), 0);
+						}
+						else
+						{
+							BDGUIUtils.DrawTextureOnWorldPos(ml.MissileReferenceTransform.position + (2000 * ml.GetForwardTransform()), BDArmorySetup.Instance.greenCircleTexture, new Vector2(36, 36), 3);
+							BDGUIUtils.DrawTextureOnWorldPos(ml.MissileReferenceTransform.position + (2000 * ml.GetForwardTransform()), BDArmorySetup.Instance.largeGreenCircleTexture, new Vector2(156, 156), 0);
+						}
+					}
+					else if (missile.TargetingMode == MissileBase.TargetingModes.Radar)
+					{
+						MissileBase ml = CurrentMissile;
+						//if(radar && radar.locked)
+						if (vesselRadarData && vesselRadarData.locked)
+						{
+							float distanceToTarget = Vector3.Distance(vesselRadarData.lockedTargetData.targetData.predictedPosition, ml.MissileReferenceTransform.position);
+							BDGUIUtils.DrawTextureOnWorldPos(ml.MissileReferenceTransform.position + (distanceToTarget * ml.GetForwardTransform()), BDArmorySetup.Instance.dottedLargeGreenCircle, new Vector2(128, 128), 0);
+							//Vector3 fireSolution = MissileGuidance.GetAirToAirFireSolution(CurrentMissile, radar.lockedTarget.predictedPosition, radar.lockedTarget.velocity);
+							Vector3 fireSolution = MissileGuidance.GetAirToAirFireSolution(ml, vesselRadarData.lockedTargetData.targetData.predictedPosition, vesselRadarData.lockedTargetData.targetData.velocity);
+							Vector3 fsDirection = (fireSolution - ml.MissileReferenceTransform.position).normalized;
+							BDGUIUtils.DrawTextureOnWorldPos(ml.MissileReferenceTransform.position + (distanceToTarget * fsDirection), BDArmorySetup.Instance.greenDotTexture, new Vector2(6, 6), 0);
+
+							if (BDArmorySettings.DRAW_DEBUG_LABELS)
+							{
+								string dynRangeDebug = string.Empty;
+								MissileLaunchParams dlz = MissileLaunchParams.GetDynamicLaunchParams(missile, vesselRadarData.lockedTargetData.targetData.velocity, vesselRadarData.lockedTargetData.targetData.predictedPosition);
+								dynRangeDebug += "MaxDLZ: " + dlz.maxLaunchRange;
+								dynRangeDebug += "\nMinDLZ: " + dlz.minLaunchRange;
+								GUI.Label(new Rect(800, 600, 200, 200), dynRangeDebug);
+							}
+						}
+					}
+					else if (missile.TargetingMode == MissileBase.TargetingModes.AntiRad)
+					{
+						if (rwr && rwr.rwrEnabled && rwr.displayRWR)
+						{
+							for (int i = 0; i < rwr.pingsData.Length; i++)
+							{
+								if (rwr.pingsData[i].exists && (rwr.pingsData[i].signalStrength == 0 || rwr.pingsData[i].signalStrength == 5) && Vector3.Dot(rwr.pingWorldPositions[i] - missile.transform.position, missile.GetForwardTransform()) > 0)
+								{
+									BDGUIUtils.DrawTextureOnWorldPos(rwr.pingWorldPositions[i], BDArmorySetup.Instance.greenDiamondTexture, new Vector2(22, 22), 0);
+								}
+							}
+						}
+
+						if (antiRadTargetAcquired)
+						{
+							BDGUIUtils.DrawTextureOnWorldPos(antiRadiationTarget,
+								BDArmorySetup.Instance.openGreenSquare, new Vector2(22, 22), 0);
+						}
+					}
+				}
+
+				if ((missile && missile.TargetingMode == MissileBase.TargetingModes.Gps) || BDArmorySetup.Instance.showingWindowGPS)
+				{
+					if (designatedGPSCoords != Vector3d.zero)
+					{
+						BDGUIUtils.DrawTextureOnWorldPos(VectorUtils.GetWorldSurfacePostion(designatedGPSCoords, vessel.mainBody), BDArmorySetup.Instance.greenSpikedPointCircleTexture, new Vector2(22, 22), 0);
+					}
+				}
+
+				if (BDArmorySettings.DRAW_DEBUG_LABELS)
+				{
+					GUI.Label(new Rect(600, 900, 100, 100), "Missiles away: " + missilesAway);
+				}
+			}
+
+		}
+
+		bool CheckMouseIsOnGui()
+		{
+			return Misc.Misc.CheckMouseIsOnGui();
+		}
+
+		#endregion
+
+		#region Enumerators
+
+		IEnumerator StartupListUpdater()
+		{
+			while (vessel.packed || !FlightGlobals.ready)
+			{
+				yield return null;
+				if (vessel.isActiveVessel)
+				{
+					BDArmorySetup.Instance.ActiveWeaponManager = this;
+				}
+			}
+			UpdateList();
+		}
+
+		IEnumerator MissileWarningResetRoutine()
+		{
+			while (enabled)
+			{
+				missileIsIncoming = false;
+				yield return new WaitForSeconds(1);
+			}
+		}
+
+		IEnumerator UnderFireRoutine()
+		{
+			underFire = true;
+			yield return new WaitForSeconds(3);
+			underFire = false;
+		}
+
+		IEnumerator UnderAttackRoutine()
+		{
+			underAttack = true;
+			yield return new WaitForSeconds(3);
+			underAttack = false;
+		}
+
+
+		IEnumerator GuardTurretRoutine()
+		{
+			if (gameObject.activeInHierarchy && !BDArmorySettings.ALLOW_LEGACY_TARGETING)
+			//target is out of visual range, try using sensors
+			{
+				if (guardTarget.LandedOrSplashed)
+				{
+					if (targetingPods.Count > 0)
+					{
+						List<ModuleTargetingCamera>.Enumerator tgp = targetingPods.GetEnumerator();
+						while (tgp.MoveNext())
+						{
+							if (tgp.Current == null) continue;
+							if (!tgp.Current.enabled || (tgp.Current.cameraEnabled && tgp.Current.groundStabilized &&
+														 !((tgp.Current.groundTargetPosition -
+															guardTarget.transform.position).sqrMagnitude > 20 * 20))) continue;
+							tgp.Current.EnableCamera();
+							yield return StartCoroutine(tgp.Current.PointToPositionRoutine(guardTarget.CoM));
+							//yield return StartCoroutine(tgp.Current.PointToPositionRoutine(TargetInfo.TargetCOMDispersion(guardTarget)));
+							if (!tgp.Current) continue;
+							if (tgp.Current.groundStabilized && guardTarget &&
+								(tgp.Current.groundTargetPosition - guardTarget.transform.position).sqrMagnitude < 20 * 20)
+							{
+								tgp.Current.slaveTurrets = true;
+								StartGuardTurretFiring();
+								yield break;
+							}
+							tgp.Current.DisableCamera();
+						}
+						tgp.Dispose();
+					}
+
+					if (!guardTarget || (guardTarget.transform.position - transform.position).sqrMagnitude > guardRange * guardRange)
+					{
+						SetTarget(null); //disengage, sensors unavailable.
+						yield break;
+					}
+				}
+				else
+				{
+					if (!vesselRadarData || !(vesselRadarData.radarCount > 0))
+					{
+						List<ModuleRadar>.Enumerator rd = radars.GetEnumerator();
+						while (rd.MoveNext())
+						{
+							if (rd.Current == null) continue;
+							if (!rd.Current.canLock) continue;
+							rd.Current.EnableRadar();
+							break;
+						}
+						rd.Dispose();
+					}
+
+					if (vesselRadarData &&
+						(!vesselRadarData.locked ||
+						 (vesselRadarData.lockedTargetData.targetData.predictedPosition - guardTarget.transform.position)
+							 .sqrMagnitude > 40 * 40))
+					{
+						//vesselRadarData.TryLockTarget(guardTarget.transform.position);
+						vesselRadarData.TryLockTarget(guardTarget);
+						yield return new WaitForSeconds(0.5f);
+						if (guardTarget && vesselRadarData && vesselRadarData.locked &&
+							vesselRadarData.lockedTargetData.vessel == guardTarget)
+						{
+							vesselRadarData.SlaveTurrets();
+							StartGuardTurretFiring();
+							yield break;
+						}
+					}
+
+					if (!guardTarget || (guardTarget.transform.position - transform.position).sqrMagnitude > guardRange * guardRange)
+					{
+						SetTarget(null); //disengage, sensors unavailable.
+						yield break;
+					}
+				}
+			}
+
+
+			StartGuardTurretFiring();
+			yield break;
+		}
+
+		IEnumerator ResetMissileThreatDistanceRoutine()
+		{
+			yield return new WaitForSeconds(8);
+			incomingMissileDistance = float.MaxValue;
+		}
+
+		IEnumerator GuardMissileRoutine()
+		{
+			MissileBase ml = CurrentMissile;
+
+			if (ml && !guardFiringMissile)
+			{
+				guardFiringMissile = true;
+
+
+				if (BDArmorySettings.ALLOW_LEGACY_TARGETING)
+				{
+					//TODO BDModularGuidance Legacy and turret implementation
+					if (BDArmorySettings.DRAW_DEBUG_LABELS)
+					{
+						Debug.Log("[BDArmory]: Firing on target: " + guardTarget.GetName() + ", (legacy targeting)");
+					}
+					if (ml is MissileLauncher && ((MissileLauncher)ml).missileTurret)
+					{
+						((MissileLauncher)ml).missileTurret.PrepMissileForFire(((MissileLauncher)ml));
+						((MissileLauncher)ml).FireMissileOnTarget(guardTarget);
+						((MissileLauncher)ml).missileTurret.UpdateMissileChildren();
+					}
+					else
+					{
+						((MissileLauncher)ml).FireMissileOnTarget(guardTarget);
+					}
+					//StartCoroutine(MissileAwayRoutine(ml));
+					UpdateList();
+				}
+				else if (ml.TargetingMode == MissileBase.TargetingModes.Radar && vesselRadarData)
+				{
+					float attemptLockTime = Time.time;
+					while ((!vesselRadarData.locked || (vesselRadarData.lockedTargetData.vessel != guardTarget)) && Time.time - attemptLockTime < 2)
+					{
+						if (vesselRadarData.locked)
+						{
+							vesselRadarData.UnlockAllTargets();
+							yield return null;
+						}
+						//vesselRadarData.TryLockTarget(guardTarget.transform.position+(guardTarget.rb_velocity*Time.fixedDeltaTime));
+						vesselRadarData.TryLockTarget(guardTarget);
+						yield return new WaitForSeconds(0.25f);
+					}
+
+					if (ml && AIMightDirectFire() && vesselRadarData.locked)
+					{
+						SetCargoBays();
+						float LAstartTime = Time.time;
+						while (AIMightDirectFire() && Time.time - LAstartTime < 3 &&
+							   GetLaunchAuthorization(guardTarget, this))
+						{
+							yield return new WaitForFixedUpdate();
+						}
+
+						yield return new WaitForSeconds(0.5f);
+					}
+
+
+					//wait for missile turret to point at target
+					//TODO BDModularGuidance: add turret
+					MissileLauncher mlauncher = ml as MissileLauncher;
+					if (mlauncher != null)
+					{
+						if (guardTarget && ml && mlauncher.missileTurret && vesselRadarData.locked)
+						{
+							vesselRadarData.SlaveTurrets();
+							float turretStartTime = Time.time;
+							while (Time.time - turretStartTime < 5)
+							{
+								float angle = Vector3.Angle(mlauncher.missileTurret.finalTransform.forward, mlauncher.missileTurret.slavedTargetPosition - mlauncher.missileTurret.finalTransform.position);
+								if (angle < 1)
+								{
+									turretStartTime -= 2 * Time.fixedDeltaTime;
+								}
+								yield return new WaitForFixedUpdate();
+							}
+						}
+					}
+
+					yield return null;
+
+					if (ml && guardTarget && vesselRadarData.locked && (!AIMightDirectFire() || GetLaunchAuthorization(guardTarget, this)))
+					{
+						if (BDArmorySettings.DRAW_DEBUG_LABELS)
+						{
+							Debug.Log("Firing on target: " + guardTarget.GetName());
+						}
+						FireCurrentMissile(true);
+						//StartCoroutine(MissileAwayRoutine(mlauncher));
+					}
+				}
+				else if (ml.TargetingMode == MissileBase.TargetingModes.Heat)
+				{
+					if (vesselRadarData && vesselRadarData.locked)
+					{
+						vesselRadarData.UnlockAllTargets();
+						vesselRadarData.UnslaveTurrets();
+					}
+					float attemptStartTime = Time.time;
+					float attemptDuration = Mathf.Max(targetScanInterval * 0.75f, 5f);
+					SetCargoBays();
+
+
+					MissileLauncher mlauncher;
+					while (ml && Time.time - attemptStartTime < attemptDuration && (!heatTarget.exists || (heatTarget.predictedPosition - guardTarget.transform.position).sqrMagnitude > 40 * 40))
+					{
+						//TODO BDModularGuidance: add turret
+						//try using missile turret to lock target
+						mlauncher = ml as MissileLauncher;
+						if (mlauncher != null)
+						{
+							if (mlauncher.missileTurret)
+							{
+								mlauncher.missileTurret.slaved = true;
+								mlauncher.missileTurret.slavedTargetPosition = guardTarget.CoM;
+								mlauncher.missileTurret.SlavedAim();
+							}
+						}
+
+						yield return new WaitForFixedUpdate();
+					}
+
+
+					//try uncaged IR lock with radar
+					if (guardTarget && !heatTarget.exists && vesselRadarData && vesselRadarData.radarCount > 0)
+					{
+						if (!vesselRadarData.locked ||
+							(vesselRadarData.lockedTargetData.targetData.predictedPosition -
+							 guardTarget.transform.position).sqrMagnitude > 40 * 40)
+						{
+							//vesselRadarData.TryLockTarget(guardTarget.transform.position);
+							vesselRadarData.TryLockTarget(guardTarget);
+							yield return new WaitForSeconds(Mathf.Min(1, (targetScanInterval * 0.25f)));
+						}
+					}
+
+					if (AIMightDirectFire() && ml && heatTarget.exists)
+					{
+						float LAstartTime = Time.time;
+						while (Time.time - LAstartTime < 3 && AIMightDirectFire() &&
+							   GetLaunchAuthorization(guardTarget, this))
+						{
+							yield return new WaitForFixedUpdate();
+						}
+
+						yield return new WaitForSeconds(0.5f);
+					}
+
+					//wait for missile turret to point at target
+					mlauncher = ml as MissileLauncher;
+					if (mlauncher != null)
+					{
+						if (ml && mlauncher.missileTurret && heatTarget.exists)
+						{
+							float turretStartTime = attemptStartTime;
+							while (heatTarget.exists && Time.time - turretStartTime < Mathf.Max(targetScanInterval / 2f, 2))
+							{
+								float angle = Vector3.Angle(mlauncher.missileTurret.finalTransform.forward, mlauncher.missileTurret.slavedTargetPosition - mlauncher.missileTurret.finalTransform.position);
+								mlauncher.missileTurret.slaved = true;
+								mlauncher.missileTurret.slavedTargetPosition = MissileGuidance.GetAirToAirFireSolution(mlauncher, heatTarget.predictedPosition, heatTarget.velocity);
+								mlauncher.missileTurret.SlavedAim();
+
+								if (angle < 1)
+								{
+									turretStartTime -= 3 * Time.fixedDeltaTime;
+								}
+								yield return new WaitForFixedUpdate();
+							}
+						}
+					}
+
+					yield return null;
+
+					if (guardTarget && ml && heatTarget.exists &&
+						(!AIMightDirectFire() || GetLaunchAuthorization(guardTarget, this)))
+					{
+						if (BDArmorySettings.DRAW_DEBUG_LABELS)
+						{
+							Debug.Log("[BDArmory]: Firing on target: " + guardTarget.GetName());
+						}
+
+						FireCurrentMissile(true);
+						//StartCoroutine(MissileAwayRoutine(mlauncher));
+					}
+				}
+				else if (ml.TargetingMode == MissileBase.TargetingModes.Gps)
+				{
+					designatedGPSInfo = new GPSTargetInfo(VectorUtils.WorldPositionToGeoCoords(guardTarget.CoM, vessel.mainBody), guardTarget.vesselName.Substring(0, Mathf.Min(12, guardTarget.vesselName.Length)));
+
+					FireCurrentMissile(true);
+					//if (FireCurrentMissile(true))
+					//    StartCoroutine(MissileAwayRoutine(ml)); //NEW: try to prevent launching all missile complements at once...
+
+				}
+				else if (ml.TargetingMode == MissileBase.TargetingModes.AntiRad)
+				{
+					if (rwr)
+					{
+						if (!rwr.rwrEnabled) rwr.EnableRWR();
+						if (rwr.rwrEnabled && !rwr.displayRWR) rwr.displayRWR = true;
+					}
+
+					float attemptStartTime = Time.time;
+					float attemptDuration = targetScanInterval * 0.75f;
+					while (Time.time - attemptStartTime < attemptDuration &&
+						   (!antiRadTargetAcquired || (antiRadiationTarget - guardTarget.CoM).sqrMagnitude > 20 * 20))
+					{
+						yield return new WaitForFixedUpdate();
+					}
+
+					if (SetCargoBays())
+					{
+						yield return new WaitForSeconds(1f);
+					}
+
+					if (ml && antiRadTargetAcquired && (antiRadiationTarget - guardTarget.CoM).sqrMagnitude < 20 * 20)
+					{
+						FireCurrentMissile(true);
+						//StartCoroutine(MissileAwayRoutine(ml));
+					}
+				}
+				else if (ml.TargetingMode == MissileBase.TargetingModes.Laser)
+				{
+					if (targetingPods.Count > 0) //if targeting pods are available, slew them onto target and lock.
+					{
+						List<ModuleTargetingCamera>.Enumerator tgp = targetingPods.GetEnumerator();
+						while (tgp.MoveNext())
+						{
+							if (tgp.Current == null) continue;
+							tgp.Current.EnableCamera();
+							yield return StartCoroutine(tgp.Current.PointToPositionRoutine(guardTarget.CoM));
+							if (tgp.Current.groundStabilized && (tgp.Current.groundTargetPosition - guardTarget.transform.position).sqrMagnitude < 20 * 20)
+							{
+								break;
+							}
+						}
+						tgp.Dispose();
+					}
+
+					//search for a laser point that corresponds with target vessel
+					float attemptStartTime = Time.time;
+					float attemptDuration = targetScanInterval * 0.75f;
+					while (Time.time - attemptStartTime < attemptDuration && (!laserPointDetected || (foundCam && (foundCam.groundTargetPosition - guardTarget.CoM).sqrMagnitude > 20 * 20)))
+					{
+						yield return new WaitForFixedUpdate();
+					}
+					if (SetCargoBays())
+					{
+						yield return new WaitForSeconds(1f);
+					}
+					if (ml && laserPointDetected && foundCam && (foundCam.groundTargetPosition - guardTarget.CoM).sqrMagnitude < 20 * 20)
+					{
+						FireCurrentMissile(true);
+						//StartCoroutine(MissileAwayRoutine(ml));
+					}
+					else
+					{
+						if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[BDArmory]: Laser Target Error");
+					}
+
+				}
+
+
+				guardFiringMissile = false;
+			}
+		}
 
 		IEnumerator GuardBombRoutine()
-        {
-            guardFiringMissile = true;
-            bool hasSetCargoBays = false;
-            float bombStartTime = Time.time;
-            float bombAttemptDuration = Mathf.Max(targetScanInterval, 12f);
-            float radius = CurrentMissile.GetBlastRadius() * Mathf.Min((1 + (maxMissilesOnTarget / 2f)), 1.5f);
-            if (CurrentMissile.TargetingMode == MissileBase.TargetingModes.Gps && (designatedGPSInfo.worldPos - guardTarget.CoM).sqrMagnitude > CurrentMissile.GetBlastRadius()*CurrentMissile.GetBlastRadius())
-            {
-                //check database for target first
-                float twoxsqrRad = 4f * radius * radius;
-                bool foundTargetInDatabase = false;
-                List<GPSTargetInfo>.Enumerator gps = BDATargetManager.GPSTargets[BDATargetManager.BoolToTeam(team)].GetEnumerator();
-                while (gps.MoveNext())
-                {
-                    if (!((gps.Current.worldPos - guardTarget.CoM).sqrMagnitude < twoxsqrRad)) continue;
-                    designatedGPSInfo = gps.Current;
-                    foundTargetInDatabase = true;
-                    break;
-                }
-                gps.Dispose();
-
-                //no target in gps database, acquire via targeting pod
-                if (!foundTargetInDatabase)
-                {
-                    ModuleTargetingCamera tgp = null;
-                    List<ModuleTargetingCamera>.Enumerator t = targetingPods.GetEnumerator();
-                    while (t.MoveNext())
-                    {
-                        if (t.Current) tgp = t.Current;
-                    }
-                    t.Dispose();
-
-                    if (tgp != null)
-                    {
-                        tgp.EnableCamera();
-                        yield return StartCoroutine(tgp.PointToPositionRoutine(guardTarget.CoM));
-
-                        if (tgp)
-                        {
-                            if (guardTarget && tgp.groundStabilized && (tgp.groundTargetPosition - guardTarget.transform.position).sqrMagnitude < CurrentMissile.GetBlastRadius()*CurrentMissile.GetBlastRadius())
-                            {
-                                radius = 500;
-                                designatedGPSInfo = new GPSTargetInfo(tgp.bodyRelativeGTP, "Guard Target");
-                                bombStartTime = Time.time;
-                            }
-                            else//failed to acquire target via tgp, cancel.
-                            {
-                                tgp.DisableCamera();
-                                designatedGPSInfo = new GPSTargetInfo();
-                                guardFiringMissile = false;
-                                yield break;
-                            }
-                        }
-                        else//no gps target and lost tgp, cancel.
-                        {
-                            guardFiringMissile = false;
-                            yield break;
-                        }
-                    }
-                    else //no gps target and no tgp, cancel.
-                    {
-                        guardFiringMissile = false;
-                        yield break;
-                    }
-                }
-            }
-
-            bool doProxyCheck = true;
-
-            float prevDist = 2 * radius;
-            radius = Mathf.Max(radius, 50f);
-            while (guardTarget && Time.time - bombStartTime < bombAttemptDuration && weaponIndex > 0 &&
-                   weaponArray[weaponIndex].GetWeaponClass() == WeaponClasses.Bomb && missilesAway < maxMissilesOnTarget)
-            {
-                float targetDist = Vector3.Distance(bombAimerPosition, guardTarget.CoM);
-
-                if (targetDist < (radius * 20f) && !hasSetCargoBays)
-                {
-                    SetCargoBays();
-                    hasSetCargoBays = true;
-                }
-
-                if (targetDist > radius 
-                    || Vector3.Dot(VectorUtils.GetUpDirection(vessel.CoM), vessel.transform.forward) > 0) // roll check
-                {
-                    if (targetDist < Mathf.Max(radius * 2, 800f) &&
-                        Vector3.Dot(guardTarget.CoM - bombAimerPosition, guardTarget.CoM - transform.position) < 0)
-                    {
-                        pilotAI.RequestExtend(guardTarget.CoM);
-                        break;
-                    }
-                    yield return null;
-                }
-                else
-                {
-                    if (doProxyCheck)
-                    {
-                        if (targetDist - prevDist > 0)
-                        {
-                            doProxyCheck = false;
-                        }
-                        else
-                        {
-                            prevDist = targetDist;
-                        }
-                    }
-
-                    if (!doProxyCheck)
-                    {
-                        FireCurrentMissile(true);
-                        timeBombReleased = Time.time;
-                        yield return new WaitForSeconds(rippleFire ? 60f / rippleRPM : 0.06f);
-                        if (missilesAway >= maxMissilesOnTarget)
-                        {
-                            yield return new WaitForSeconds(1f);
-                            if (pilotAI)
-                            {
-                                pilotAI.RequestExtend(guardTarget.CoM);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        yield return null;
-                    }
-                }
-            }
-
-            designatedGPSInfo = new GPSTargetInfo();
-            guardFiringMissile = false;
-        }
-
-        //IEnumerator MissileAwayRoutine(MissileBase ml)
-        //{
-        //    missilesAway++;
-
-        //    MissileLauncher launcher = ml as MissileLauncher;
-        //    if (launcher != null)
-        //    {
-        //        float timeStart = Time.time;
-        //        float timeLimit = Mathf.Max(launcher.dropTime + launcher.cruiseTime + launcher.boostTime + 4, 10);
-        //        while (ml)
-        //        {
-        //            if (ml.guidanceActive && Time.time - timeStart < timeLimit)
-        //            {
-        //                yield return null;
-        //            }
-        //            else
-        //            {
-        //                break;
-        //            }
-
-        //        }
-        //    }
-        //    else 
-        //    {
-        //        while (ml)
-        //        {
-        //            if (ml.MissileState != MissileBase.MissileStates.PostThrust)
-        //            {
-        //                yield return null;
-
-        //            }
-        //            else
-        //            {
-        //                break;
-        //            }
-        //        }
-        //    }
-
-           
-        //    missilesAway--;
-        //}
-
-        //IEnumerator BombsAwayRoutine(MissileBase ml)
-        //{
-        //    missilesAway++;
-        //    float timeStart = Time.time;
-        //    float timeLimit = 3;
-        //    while (ml)
-        //    {
-        //        if (Time.time - timeStart < timeLimit)
-        //        {
-        //            yield return null;
-        //        }
-        //        else
-        //        {
-        //            break;
-        //        }
-        //    }
-        //    missilesAway--;
-        //}
-
-        
-
-
-        #endregion
-
-        #region Audio
-
-        void UpdateVolume()
-        {
-            if (audioSource)
-            {
-                audioSource.volume = BDArmorySettings.BDARMORY_UI_VOLUME;
-            }
-            if (warningAudioSource)
-            {
-                warningAudioSource.volume = BDArmorySettings.BDARMORY_UI_VOLUME;
-            }
-            if (targetingAudioSource)
-            {
-                targetingAudioSource.volume = BDArmorySettings.BDARMORY_UI_VOLUME;
-            }
-        }
-
-        void UpdateTargetingAudio()
-        {
-            if (BDArmorySetup.GameIsPaused)
-            {
-                if (targetingAudioSource.isPlaying)
-                {
-                    targetingAudioSource.Stop();
-                }
-                return;
-            }
-
-            if (selectedWeapon != null && selectedWeapon.GetWeaponClass() == WeaponClasses.Missile && vessel.isActiveVessel)
-            {
-                MissileBase ml = CurrentMissile;
-                if (ml.TargetingMode == MissileBase.TargetingModes.Heat)
-                {
-                    if (targetingAudioSource.clip != heatGrowlSound)
-                    {
-                        targetingAudioSource.clip = heatGrowlSound;
-                    }
-
-                    if (heatTarget.exists)
-                    {
-                        targetingAudioSource.pitch = Mathf.MoveTowards(targetingAudioSource.pitch, 2, 8 * Time.deltaTime);
-                    }
-                    else
-                    {
-                        targetingAudioSource.pitch = Mathf.MoveTowards(targetingAudioSource.pitch, 1, 8 * Time.deltaTime);
-                    }
-
-                    if (!targetingAudioSource.isPlaying)
-                    {
-                        targetingAudioSource.Play();
-                    }
-                }
-                else
-                {
-                    if (targetingAudioSource.isPlaying)
-                    {
-                        targetingAudioSource.Stop();
-                    }
-                }
-            }
-            else
-            {
-                targetingAudioSource.pitch = 1;
-                if (targetingAudioSource.isPlaying)
-                {
-                    targetingAudioSource.Stop();
-                }
-            }
-        }
-
-        IEnumerator WarningSoundRoutine(float distance, MissileBase ml)//give distance parameter
-        {
-            if (distance < this.guardRange)
-            {
-                warningSounding = true;
-                BDArmorySetup.Instance.missileWarningTime = Time.time;
-                BDArmorySetup.Instance.missileWarning = true;
-                warningAudioSource.pitch = distance < 800 ? 1.45f : 1f;
-                warningAudioSource.PlayOneShot(warningSound);
-
-                float waitTime = distance < 800 ? .25f : 1.5f;
-
-                yield return new WaitForSeconds(waitTime);
-
-                if (ml.vessel && CanSeeTarget(ml.vessel))
-                {
-                    BDATargetManager.ReportVessel(ml.vessel, this);
-                }
-            }
-            warningSounding = false;
-        }
-
-        #endregion
-
-        #region CounterMeasure
-        public bool isChaffing;
-        public bool isFlaring;
-        public bool isECMJamming;
-
-        bool isLegacyCMing;
-
-        int cmCounter;
-        int cmAmount = 5;
-
-        public void FireAllCountermeasures(int count)
-        {
-            StartCoroutine(AllCMRoutine(count));
-        }
-
-        public void FireECM()
-        {
-            if (!isECMJamming)
-            {
-                StartCoroutine(ECMRoutine());
-            }
-        }
-        
-        public void FireChaff()
-        {
-            if (!isChaffing)
-            {
-                StartCoroutine(ChaffRoutine());
-            }
-        }
-
-        
-        IEnumerator ECMRoutine()
-        {
-            isECMJamming = true;
-            //yield return new WaitForSeconds(UnityEngine.Random.Range(0.2f, 1f));
-            List<ModuleECMJammer>.Enumerator ecm = vessel.FindPartModulesImplementing<ModuleECMJammer>().GetEnumerator();
-            while (ecm.MoveNext())
-            {
-                if (ecm.Current == null) continue;
-                if (ecm.Current.jammerEnabled) yield break;
-                ecm.Current.EnableJammer();
-            }
-            ecm.Dispose();
-            yield return new WaitForSeconds(10.0f);
-            isECMJamming = false;
-
-            List<ModuleECMJammer>.Enumerator ecm1 = vessel.FindPartModulesImplementing<ModuleECMJammer>().GetEnumerator();
-            while (ecm1.MoveNext())
-            {
-                if (ecm1.Current == null) continue;
-                ecm1.Current.DisableJammer();
-            }
-            ecm1.Dispose();
-        }
-
-        IEnumerator ChaffRoutine()
-        {
-            isChaffing = true;
-            yield return new WaitForSeconds(UnityEngine.Random.Range(0.2f, 1f));
-            List<CMDropper>.Enumerator cm = vessel.FindPartModulesImplementing<CMDropper>().GetEnumerator();
-            while (cm.MoveNext())
-            {
-                if (cm.Current == null) continue;
-                if (cm.Current.cmType == CMDropper.CountermeasureTypes.Chaff)
-                {
-                    cm.Current.DropCM();
-                }
-            }
-            cm.Dispose();
-
-            yield return new WaitForSeconds(0.6f);
-
-            isChaffing = false;
-        }
-
-        IEnumerator FlareRoutine(float time)
-        {
-            if (isFlaring) yield break;
-            time = Mathf.Clamp(time, 2, 8);
-            isFlaring = true;
-            yield return new WaitForSeconds(UnityEngine.Random.Range(0f, 1f));
-            float flareStartTime = Time.time;
-            while (Time.time - flareStartTime < time)
-            {
-                List<CMDropper>.Enumerator cm = vessel.FindPartModulesImplementing<CMDropper>().GetEnumerator();
-                while (cm.MoveNext())
-                {
-                    if (cm.Current == null) continue;
-                    if (cm.Current.cmType == CMDropper.CountermeasureTypes.Flare)
-                    {
-                        cm.Current.DropCM();
-                    }
-                }
-                cm.Dispose();
-                yield return new WaitForSeconds(0.6f);
-            }
-            isFlaring = false;
-        }
-
-        IEnumerator AllCMRoutine(int count)
-        {
-            for (int i = 0; i < count; i++)
-            {
-                List<CMDropper>.Enumerator cm = vessel.FindPartModulesImplementing<CMDropper>().GetEnumerator();
-                while (cm.MoveNext())
-                {
-                    if (cm.Current == null) continue;
-                    if ((cm.Current.cmType == CMDropper.CountermeasureTypes.Flare && !isFlaring)
-                        || (cm.Current.cmType == CMDropper.CountermeasureTypes.Chaff && !isChaffing)
-                        || (cm.Current.cmType == CMDropper.CountermeasureTypes.Smoke))
-                    {
-                        cm.Current.DropCM();
-                    }
-                }
-                cm.Dispose();
-                isFlaring = true;
-                isChaffing = true;
-                yield return new WaitForSeconds(1f);
-            }
-            isFlaring = false;
-            isChaffing = false;
-        }
-
-        IEnumerator LegacyCMRoutine()
-        {
-            isLegacyCMing = true;
-            yield return new WaitForSeconds(UnityEngine.Random.Range(.2f, 1f));
-            if (incomingMissileDistance < 2500)
-            {
-                cmAmount = Mathf.RoundToInt((2500 - incomingMissileDistance) / 400);
-                List<CMDropper>.Enumerator cm = vessel.FindPartModulesImplementing<CMDropper>().GetEnumerator();
-                while (cm.MoveNext())
-                {
-                    if (cm.Current == null) continue;
-                    cm.Current.DropCM();
-                }
-                cm.Dispose();
-                cmCounter++;
-                if (cmCounter < cmAmount)
-                {
-                    yield return new WaitForSeconds(0.15f);
-                }
-                else
-                {
-                    cmCounter = 0;
-                    yield return new WaitForSeconds(UnityEngine.Random.Range(.5f, 1f));
-                }
-            }
-            isLegacyCMing = false;
-        }
-        
-        public void MissileWarning(float distance, MissileBase ml)//take distance parameter
-        {
-            if (vessel.isActiveVessel && !warningSounding)
-            {
-                StartCoroutine(WarningSoundRoutine(distance, ml));
-            }
-
-            missileIsIncoming = true;
-            incomingMissileDistance = distance;
-        }
-
-        #endregion
-
-        #region Fire
-
-        bool FireCurrentMissile(bool checkClearance)
-        {
-            MissileBase missile = CurrentMissile;
-            if (missile == null) return false;
-
-            if (missile is MissileBase)
-            {
-
-                MissileBase ml = missile;
-                if (checkClearance && (!CheckBombClearance(ml) || (ml is MissileLauncher && ((MissileLauncher)ml).rotaryRail && !((MissileLauncher)ml).rotaryRail.readyMissile == ml)))
-                {
-                    List<MissileBase>.Enumerator otherMissile = vessel.FindPartModulesImplementing<MissileBase>().GetEnumerator();
-                    while (otherMissile.MoveNext())
-                    {
-                        if (otherMissile.Current == null) continue;
-                        if (otherMissile.Current == ml || otherMissile.Current.GetShortName() != ml.GetShortName() ||
-                            !CheckBombClearance(otherMissile.Current)) continue;
-                        CurrentMissile = otherMissile.Current;
-                        selectedWeapon = otherMissile.Current;
-                        FireCurrentMissile(false);
-                        return true;
-                    }
-                    otherMissile.Dispose();
-                    CurrentMissile = ml;
-                    selectedWeapon = ml;
-                    return false;
-                }
-                                
-                if (ml is MissileLauncher && ((MissileLauncher)ml).missileTurret)
-                {
-                    ((MissileLauncher)ml).missileTurret.FireMissile(((MissileLauncher)ml));
-                }
-                else if (ml is MissileLauncher && ((MissileLauncher)ml).rotaryRail)
-                {
-                    ((MissileLauncher)ml).rotaryRail.FireMissile(((MissileLauncher)ml));
-                }
-                else
-                {
-                    SendTargetDataToMissile(ml);
-                    ml.FireMissile();
-                }
-
-                if (guardMode)
-                {
-                    if (ml.GetWeaponClass() == WeaponClasses.Bomb)
-                    {
-                        //StartCoroutine(BombsAwayRoutine(ml));
-                    }
-                }
-                else
-                {
-                    if (vesselRadarData && vesselRadarData.autoCycleLockOnFire)
-                    {
-                        vesselRadarData.CycleActiveLock();
-                    }
-                }
-            }
-            else
-            {
-                SendTargetDataToMissile(missile);
-                missile.FireMissile();
-            }
-
-            UpdateList();
-            return true;
-        }
-
-        void FireMissile()
-        {
-            if (weaponIndex == 0)
-            {
-                return;
-            }
-
-            if (selectedWeapon == null)
-            {
-                return;
-            }
-
-            if (selectedWeapon.GetWeaponClass() == WeaponClasses.Missile ||
-                selectedWeapon.GetWeaponClass() == WeaponClasses.SLW ||
-                selectedWeapon.GetWeaponClass() == WeaponClasses.Bomb )
-            {
-                FireCurrentMissile(true);
-            }
-            else if (selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket)
-            {
-                if (!currentRocket || currentRocket.part.name != selectedWeapon.GetPart().name)
-                {
-                    FindNextRocket(null);
-                }
-
-                if (currentRocket)
-                {
-                    currentRocket.FireRocket();
-                    FindNextRocket(currentRocket);
-                }
-            }
-
-            UpdateList();
-        }
-
-
-        #endregion
-
-        #region Weapon Info
-
-        void DisplaySelectedWeaponMessage()
-        {
-            if (BDArmorySetup.GAME_UI_ENABLED && vessel == FlightGlobals.ActiveVessel)
-            {
-                ScreenMessages.RemoveMessage(selectionMessage);
-                selectionMessage.textInstance = null;
-
-                selectionText = "Selected Weapon: " + (GetWeaponName(weaponArray[weaponIndex])).ToString();
-                selectionMessage.message = selectionText;
-                selectionMessage.style = ScreenMessageStyle.UPPER_CENTER;
-
-                ScreenMessages.PostScreenMessage(selectionMessage);
-            }
-        }
-
-        string GetWeaponName(IBDWeapon weapon)
-        {
-            if (weapon == null)
-            {
-                return "None";
-            }
-            else
-            {
-                return weapon.GetShortName();
-            }
-        }
-
-        public void UpdateList()
-        {
-            weaponTypes.Clear();
-            // extension for feature_engagementenvelope: also clear engagement specific weapon lists
-            weaponTypesAir.Clear();
-            weaponTypesMissile.Clear();
-            weaponTypesGround.Clear();
-            weaponTypesSLW.Clear();
-
-            List<IBDWeapon>.Enumerator weapon = vessel.FindPartModulesImplementing<IBDWeapon>().GetEnumerator();
-            while (weapon.MoveNext() )
-            {
-                if (weapon.Current == null) continue;
-                string weaponName = weapon.Current.GetShortName();
-                bool alreadyAdded = false;
-                List<IBDWeapon>.Enumerator weap = weaponTypes.GetEnumerator();
-                while (weap.MoveNext())
-                {
-                    if (weap.Current == null) continue;
-                    if (weap.Current.GetShortName() == weaponName)
-                    {
-                        alreadyAdded = true;
-                        //break;
-                    }
-                }
-                weap.Dispose();
-
-                //dont add empty rocket pods
-                if (weapon.Current.GetWeaponClass() == WeaponClasses.Rocket &&
-                    weapon.Current.GetPart().FindModuleImplementing<RocketLauncher>().GetRocketResource().amount < 1
-                    && !BDArmorySettings.INFINITE_AMMO)
-                {
-                    continue;
-                }
-
-                if (!alreadyAdded)
-                {
-                    weaponTypes.Add(weapon.Current);
-                }
-
-                EngageableWeapon engageableWeapon = weapon.Current as EngageableWeapon;
-
-                if (engageableWeapon != null)
-                {
-                    if (engageableWeapon.GetEngageAirTargets()) weaponTypesAir.Add(weapon.Current);
-                    if (engageableWeapon.GetEngageMissileTargets()) weaponTypesMissile.Add(weapon.Current);
-                    if (engageableWeapon.GetEngageGroundTargets()) weaponTypesGround.Add(weapon.Current);
-                    if (engageableWeapon.GetEngageSLWTargets()) weaponTypesSLW.Add(weapon.Current);
-                }
-                else
-                {
-                    weaponTypesAir.Add(weapon.Current);
-                    weaponTypesMissile.Add(weapon.Current);
-                    weaponTypesGround.Add(weapon.Current);
-                    weaponTypesSLW.Add(weapon.Current);
-                }  
-            }
-            weapon.Dispose();
-
-            //weaponTypes.Sort();
-            weaponTypes = weaponTypes.OrderBy(w => w.GetShortName()).ToList();
-
-            List<IBDWeapon> tempList = new List<IBDWeapon> {null};
-            tempList.AddRange(weaponTypes);
-
-            weaponArray = tempList.ToArray();
-
-            if (weaponIndex >= weaponArray.Length)
-            {
-                hasSingleFired = true;
-                triggerTimer = 0;
-            }
-            PrepareWeapons();
-        }
-
-        // EXTRACTED METHOD FROM UpdateList()
-        private void PrepareWeapons()
-        {
-            if (vessel == null) return;
-
-            weaponIndex = Mathf.Clamp(weaponIndex, 0, weaponArray.Length - 1);
-
-            if (selectedWeapon == null || selectedWeapon.GetPart() == null ||(selectedWeapon.GetPart().vessel != null && selectedWeapon.GetPart().vessel != vessel) ||
-                GetWeaponName(selectedWeapon) != GetWeaponName(weaponArray[weaponIndex]))
-            {
-                selectedWeapon = weaponArray[weaponIndex];
-
-                if (vessel.isActiveVessel && Time.time - startTime > 1)
-                {
-                    hasSingleFired = true;
-                }
-
-                if (vessel.isActiveVessel && weaponIndex != 0)
-                {
-                    DisplaySelectedWeaponMessage();
-                }
-            }
-
-            if (weaponIndex == 0)
-            {
-                selectedWeapon = null;
-                hasSingleFired = true;
-            }
-
-            MissileBase aMl = GetAsymMissile();
-            if (aMl)
-            {                
-                selectedWeapon = aMl;
-                CurrentMissile = aMl;
-            }
-
-            MissileBase rMl = GetRotaryReadyMissile();
-            if (rMl)
-            {             
-                selectedWeapon = rMl;
-                CurrentMissile = rMl;
-            }
-
-            if (selectedWeapon != null && (selectedWeapon.GetWeaponClass() == WeaponClasses.Bomb || selectedWeapon.GetWeaponClass() == WeaponClasses.Missile || selectedWeapon.GetWeaponClass() == WeaponClasses.SLW))
-            {
-                //Debug.Log("[BDArmory]: =====selected weapon: " + selectedWeapon.GetPart().name);
-                if (!CurrentMissile || CurrentMissile.part.name != selectedWeapon.GetPart().name)
-                {
-                    CurrentMissile = selectedWeapon.GetPart().FindModuleImplementing<MissileBase>();
-                }
-            }
-            else
-            {
-                CurrentMissile = null;
-            }
-
-            //selectedWeapon = weaponArray[weaponIndex];
-
-            //bomb stuff
-            if (selectedWeapon != null && selectedWeapon.GetWeaponClass() == WeaponClasses.Bomb)
-            {
-                bombPart = selectedWeapon.GetPart();
-            }
-            else
-            {
-                bombPart = null;
-            }
-
-            //gun ripple stuff
-            if (selectedWeapon != null && selectedWeapon.GetWeaponClass() == WeaponClasses.Gun &&
-                currentGun.roundsPerMinute < 1500)
-            {
-                float counter = 0; // Used to get a count of the ripple weapons.  a float version of rippleGunCount.
-                gunRippleIndex = 0;
-                // This value will be incremented as we set the ripple weapons
-                rippleGunCount = 0;
-                float weaponRpm = 0;  // used to set the rippleGunRPM
-
-                // JDK:  this looks like it can be greatly simplified...
-                #region Old Code (for reference.  remove when satisfied new code works as expected.
-                //List<ModuleWeapon> tempListModuleWeapon = vessel.FindPartModulesImplementing<ModuleWeapon>();
-                //foreach (ModuleWeapon weapon in tempListModuleWeapon)
-                //{
-                //    if (selectedWeapon.GetShortName() == weapon.GetShortName())
-                //    {
-                //        weapon.rippleIndex = Mathf.RoundToInt(counter);
-                //        weaponRPM = weapon.roundsPerMinute;
-                //        ++counter;
-                //        rippleGunCount++;
-                //    }
-                //}
-                //gunRippleRpm = weaponRPM * counter;
-                //float timeDelayPerGun = 60f / (weaponRPM * counter);
-                ////number of seconds between each gun firing; will reduce with increasing RPM or number of guns
-                //foreach (ModuleWeapon weapon in tempListModuleWeapon)
-                //{
-                //    if (selectedWeapon.GetShortName() == weapon.GetShortName())
-                //    {
-                //        weapon.initialFireDelay = timeDelayPerGun; //set the time delay for moving to next index
-                //    }
-                //}
-
-                //RippleOption ro; //ripplesetup and stuff
-                //if (rippleDictionary.ContainsKey(selectedWeapon.GetShortName()))
-                //{
-                //    ro = rippleDictionary[selectedWeapon.GetShortName()];
-                //}
-                //else
-                //{
-                //    ro = new RippleOption(currentGun.useRippleFire, 650); //take from gun's persistant value
-                //    rippleDictionary.Add(selectedWeapon.GetShortName(), ro);
-                //}
-
-                //foreach (ModuleWeapon w in vessel.FindPartModulesImplementing<ModuleWeapon>())
-                //{
-                //    if (w.GetShortName() == selectedWeapon.GetShortName())
-                //        w.useRippleFire = ro.rippleFire;
-                //}
-                #endregion
-
-                // TODO:  JDK verify new code works as expected.
-                // New code, simplified. 
-
-                //First lest set the Ripple Option. Doing it first eliminates a loop.
-                RippleOption ro; //ripplesetup and stuff
-                if (rippleDictionary.ContainsKey(selectedWeapon.GetShortName()))
-                {
-                    ro = rippleDictionary[selectedWeapon.GetShortName()];
-                }
-                else
-                {
-                    ro = new RippleOption(currentGun.useRippleFire, 650); //take from gun's persistant value
-                    rippleDictionary.Add(selectedWeapon.GetShortName(), ro);
-                }
-
-                //Get ripple weapon count, so we don't have to enumerate the whole list again.
-                List<ModuleWeapon> rippleWeapons = new List<ModuleWeapon>();
-                List<ModuleWeapon>.Enumerator weapCnt = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
-                while (weapCnt.MoveNext())
-                {
-                    if (weapCnt.Current == null) continue;
-                    if (selectedWeapon.GetShortName() != weapCnt.Current.GetShortName()) continue;
-                    weaponRpm = weapCnt.Current.roundsPerMinute;
-                    counter += weaponRpm; // grab sum of weapons rpm
+		{
+			guardFiringMissile = true;
+			bool hasSetCargoBays = false;
+			float bombStartTime = Time.time;
+			float bombAttemptDuration = Mathf.Max(targetScanInterval, 12f);
+			float radius = CurrentMissile.GetBlastRadius() * Mathf.Min((1 + (maxMissilesOnTarget / 2f)), 1.5f);
+			if (CurrentMissile.TargetingMode == MissileBase.TargetingModes.Gps && (designatedGPSInfo.worldPos - guardTarget.CoM).sqrMagnitude > CurrentMissile.GetBlastRadius() * CurrentMissile.GetBlastRadius())
+			{
+				//check database for target first
+				float twoxsqrRad = 4f * radius * radius;
+				bool foundTargetInDatabase = false;
+				List<GPSTargetInfo>.Enumerator gps = BDATargetManager.GPSTargets[BDATargetManager.BoolToTeam(team)].GetEnumerator();
+				while (gps.MoveNext())
+				{
+					if (!((gps.Current.worldPos - guardTarget.CoM).sqrMagnitude < twoxsqrRad)) continue;
+					designatedGPSInfo = gps.Current;
+					foundTargetInDatabase = true;
+					break;
 				}
-                weapCnt.Dispose();
+				gps.Dispose();
 
-                gunRippleRpm = counter;
+				//no target in gps database, acquire via targeting pod
+				if (!foundTargetInDatabase)
+				{
+					ModuleTargetingCamera tgp = null;
+					List<ModuleTargetingCamera>.Enumerator t = targetingPods.GetEnumerator();
+					while (t.MoveNext())
+					{
+						if (t.Current) tgp = t.Current;
+					}
+					t.Dispose();
+
+					if (tgp != null)
+					{
+						tgp.EnableCamera();
+						yield return StartCoroutine(tgp.PointToPositionRoutine(guardTarget.CoM));
+
+						if (tgp)
+						{
+							if (guardTarget && tgp.groundStabilized && (tgp.groundTargetPosition - guardTarget.transform.position).sqrMagnitude < CurrentMissile.GetBlastRadius() * CurrentMissile.GetBlastRadius())
+							{
+								radius = 500;
+								designatedGPSInfo = new GPSTargetInfo(tgp.bodyRelativeGTP, "Guard Target");
+								bombStartTime = Time.time;
+							}
+							else//failed to acquire target via tgp, cancel.
+							{
+								tgp.DisableCamera();
+								designatedGPSInfo = new GPSTargetInfo();
+								guardFiringMissile = false;
+								yield break;
+							}
+						}
+						else//no gps target and lost tgp, cancel.
+						{
+							guardFiringMissile = false;
+							yield break;
+						}
+					}
+					else //no gps target and no tgp, cancel.
+					{
+						guardFiringMissile = false;
+						yield break;
+					}
+				}
+			}
+
+			bool doProxyCheck = true;
+
+			float prevDist = 2 * radius;
+			radius = Mathf.Max(radius, 50f);
+			while (guardTarget && Time.time - bombStartTime < bombAttemptDuration && weaponIndex > 0 &&
+				   weaponArray[weaponIndex].GetWeaponClass() == WeaponClasses.Bomb && missilesAway < maxMissilesOnTarget)
+			{
+				float targetDist = Vector3.Distance(bombAimerPosition, guardTarget.CoM);
+
+				if (targetDist < (radius * 20f) && !hasSetCargoBays)
+				{
+					SetCargoBays();
+					hasSetCargoBays = true;
+				}
+
+				if (targetDist > radius
+					|| Vector3.Dot(VectorUtils.GetUpDirection(vessel.CoM), vessel.transform.forward) > 0) // roll check
+				{
+					if (targetDist < Mathf.Max(radius * 2, 800f) &&
+						Vector3.Dot(guardTarget.CoM - bombAimerPosition, guardTarget.CoM - transform.position) < 0)
+					{
+						pilotAI.RequestExtend(guardTarget.CoM);
+						break;
+					}
+					yield return null;
+				}
+				else
+				{
+					if (doProxyCheck)
+					{
+						if (targetDist - prevDist > 0)
+						{
+							doProxyCheck = false;
+						}
+						else
+						{
+							prevDist = targetDist;
+						}
+					}
+
+					if (!doProxyCheck)
+					{
+						FireCurrentMissile(true);
+						timeBombReleased = Time.time;
+						yield return new WaitForSeconds(rippleFire ? 60f / rippleRPM : 0.06f);
+						if (missilesAway >= maxMissilesOnTarget)
+						{
+							yield return new WaitForSeconds(1f);
+							if (pilotAI)
+							{
+								pilotAI.RequestExtend(guardTarget.CoM);
+							}
+						}
+					}
+					else
+					{
+						yield return null;
+					}
+				}
+			}
+
+			designatedGPSInfo = new GPSTargetInfo();
+			guardFiringMissile = false;
+		}
+
+		//IEnumerator MissileAwayRoutine(MissileBase ml)
+		//{
+		//    missilesAway++;
+
+		//    MissileLauncher launcher = ml as MissileLauncher;
+		//    if (launcher != null)
+		//    {
+		//        float timeStart = Time.time;
+		//        float timeLimit = Mathf.Max(launcher.dropTime + launcher.cruiseTime + launcher.boostTime + 4, 10);
+		//        while (ml)
+		//        {
+		//            if (ml.guidanceActive && Time.time - timeStart < timeLimit)
+		//            {
+		//                yield return null;
+		//            }
+		//            else
+		//            {
+		//                break;
+		//            }
+
+		//        }
+		//    }
+		//    else 
+		//    {
+		//        while (ml)
+		//        {
+		//            if (ml.MissileState != MissileBase.MissileStates.PostThrust)
+		//            {
+		//                yield return null;
+
+		//            }
+		//            else
+		//            {
+		//                break;
+		//            }
+		//        }
+		//    }
+
+
+		//    missilesAway--;
+		//}
+
+		//IEnumerator BombsAwayRoutine(MissileBase ml)
+		//{
+		//    missilesAway++;
+		//    float timeStart = Time.time;
+		//    float timeLimit = 3;
+		//    while (ml)
+		//    {
+		//        if (Time.time - timeStart < timeLimit)
+		//        {
+		//            yield return null;
+		//        }
+		//        else
+		//        {
+		//            break;
+		//        }
+		//    }
+		//    missilesAway--;
+		//}
+
+
+
+
+		#endregion
+
+		#region Audio
+
+		void UpdateVolume()
+		{
+			if (audioSource)
+			{
+				audioSource.volume = BDArmorySettings.BDARMORY_UI_VOLUME;
+			}
+			if (warningAudioSource)
+			{
+				warningAudioSource.volume = BDArmorySettings.BDARMORY_UI_VOLUME;
+			}
+			if (targetingAudioSource)
+			{
+				targetingAudioSource.volume = BDArmorySettings.BDARMORY_UI_VOLUME;
+			}
+		}
+
+		void UpdateTargetingAudio()
+		{
+			if (BDArmorySetup.GameIsPaused)
+			{
+				if (targetingAudioSource.isPlaying)
+				{
+					targetingAudioSource.Stop();
+				}
+				return;
+			}
+
+			if (selectedWeapon != null && selectedWeapon.GetWeaponClass() == WeaponClasses.Missile && vessel.isActiveVessel)
+			{
+				MissileBase ml = CurrentMissile;
+				if (ml.TargetingMode == MissileBase.TargetingModes.Heat)
+				{
+					if (targetingAudioSource.clip != heatGrowlSound)
+					{
+						targetingAudioSource.clip = heatGrowlSound;
+					}
+
+					if (heatTarget.exists)
+					{
+						targetingAudioSource.pitch = Mathf.MoveTowards(targetingAudioSource.pitch, 2, 8 * Time.deltaTime);
+					}
+					else
+					{
+						targetingAudioSource.pitch = Mathf.MoveTowards(targetingAudioSource.pitch, 1, 8 * Time.deltaTime);
+					}
+
+					if (!targetingAudioSource.isPlaying)
+					{
+						targetingAudioSource.Play();
+					}
+				}
+				else
+				{
+					if (targetingAudioSource.isPlaying)
+					{
+						targetingAudioSource.Stop();
+					}
+				}
+			}
+			else
+			{
+				targetingAudioSource.pitch = 1;
+				if (targetingAudioSource.isPlaying)
+				{
+					targetingAudioSource.Stop();
+				}
+			}
+		}
+
+		IEnumerator WarningSoundRoutine(float distance, MissileBase ml)//give distance parameter
+		{
+			if (distance < this.guardRange)
+			{
+				warningSounding = true;
+				BDArmorySetup.Instance.missileWarningTime = Time.time;
+				BDArmorySetup.Instance.missileWarning = true;
+				warningAudioSource.pitch = distance < 800 ? 1.45f : 1f;
+				warningAudioSource.PlayOneShot(warningSound);
+
+				float waitTime = distance < 800 ? .25f : 1.5f;
+
+				yield return new WaitForSeconds(waitTime);
+
+				if (ml.vessel && CanSeeTarget(ml.vessel))
+				{
+					BDATargetManager.ReportVessel(ml.vessel, this);
+				}
+			}
+			warningSounding = false;
+		}
+
+		#endregion
+
+		#region CounterMeasure
+		public bool isChaffing;
+		public bool isFlaring;
+		public bool isECMJamming;
+
+		bool isLegacyCMing;
+
+		int cmCounter;
+		int cmAmount = 5;
+
+		public void FireAllCountermeasures(int count)
+		{
+			StartCoroutine(AllCMRoutine(count));
+		}
+
+		public void FireECM()
+		{
+			if (!isECMJamming)
+			{
+				StartCoroutine(ECMRoutine());
+			}
+		}
+
+		public void FireChaff()
+		{
+			if (!isChaffing)
+			{
+				StartCoroutine(ChaffRoutine());
+			}
+		}
+
+
+		IEnumerator ECMRoutine()
+		{
+			isECMJamming = true;
+			//yield return new WaitForSeconds(UnityEngine.Random.Range(0.2f, 1f));
+			List<ModuleECMJammer>.Enumerator ecm = vessel.FindPartModulesImplementing<ModuleECMJammer>().GetEnumerator();
+			while (ecm.MoveNext())
+			{
+				if (ecm.Current == null) continue;
+				if (ecm.Current.jammerEnabled) yield break;
+				ecm.Current.EnableJammer();
+			}
+			ecm.Dispose();
+			yield return new WaitForSeconds(10.0f);
+			isECMJamming = false;
+
+			List<ModuleECMJammer>.Enumerator ecm1 = vessel.FindPartModulesImplementing<ModuleECMJammer>().GetEnumerator();
+			while (ecm1.MoveNext())
+			{
+				if (ecm1.Current == null) continue;
+				ecm1.Current.DisableJammer();
+			}
+			ecm1.Dispose();
+		}
+
+		IEnumerator ChaffRoutine()
+		{
+			isChaffing = true;
+			yield return new WaitForSeconds(UnityEngine.Random.Range(0.2f, 1f));
+			List<CMDropper>.Enumerator cm = vessel.FindPartModulesImplementing<CMDropper>().GetEnumerator();
+			while (cm.MoveNext())
+			{
+				if (cm.Current == null) continue;
+				if (cm.Current.cmType == CMDropper.CountermeasureTypes.Chaff)
+				{
+					cm.Current.DropCM();
+				}
+			}
+			cm.Dispose();
+
+			yield return new WaitForSeconds(0.6f);
+
+			isChaffing = false;
+		}
+
+		IEnumerator FlareRoutine(float time)
+		{
+			if (isFlaring) yield break;
+			time = Mathf.Clamp(time, 2, 8);
+			isFlaring = true;
+			yield return new WaitForSeconds(UnityEngine.Random.Range(0f, 1f));
+			float flareStartTime = Time.time;
+			while (Time.time - flareStartTime < time)
+			{
+				List<CMDropper>.Enumerator cm = vessel.FindPartModulesImplementing<CMDropper>().GetEnumerator();
+				while (cm.MoveNext())
+				{
+					if (cm.Current == null) continue;
+					if (cm.Current.cmType == CMDropper.CountermeasureTypes.Flare)
+					{
+						cm.Current.DropCM();
+					}
+				}
+				cm.Dispose();
+				yield return new WaitForSeconds(0.6f);
+			}
+			isFlaring = false;
+		}
+
+		IEnumerator AllCMRoutine(int count)
+		{
+			for (int i = 0; i < count; i++)
+			{
+				List<CMDropper>.Enumerator cm = vessel.FindPartModulesImplementing<CMDropper>().GetEnumerator();
+				while (cm.MoveNext())
+				{
+					if (cm.Current == null) continue;
+					if ((cm.Current.cmType == CMDropper.CountermeasureTypes.Flare && !isFlaring)
+						|| (cm.Current.cmType == CMDropper.CountermeasureTypes.Chaff && !isChaffing)
+						|| (cm.Current.cmType == CMDropper.CountermeasureTypes.Smoke))
+					{
+						cm.Current.DropCM();
+					}
+				}
+				cm.Dispose();
+				isFlaring = true;
+				isChaffing = true;
+				yield return new WaitForSeconds(1f);
+			}
+			isFlaring = false;
+			isChaffing = false;
+		}
+
+		IEnumerator LegacyCMRoutine()
+		{
+			isLegacyCMing = true;
+			yield return new WaitForSeconds(UnityEngine.Random.Range(.2f, 1f));
+			if (incomingMissileDistance < 2500)
+			{
+				cmAmount = Mathf.RoundToInt((2500 - incomingMissileDistance) / 400);
+				List<CMDropper>.Enumerator cm = vessel.FindPartModulesImplementing<CMDropper>().GetEnumerator();
+				while (cm.MoveNext())
+				{
+					if (cm.Current == null) continue;
+					cm.Current.DropCM();
+				}
+				cm.Dispose();
+				cmCounter++;
+				if (cmCounter < cmAmount)
+				{
+					yield return new WaitForSeconds(0.15f);
+				}
+				else
+				{
+					cmCounter = 0;
+					yield return new WaitForSeconds(UnityEngine.Random.Range(.5f, 1f));
+				}
+			}
+			isLegacyCMing = false;
+		}
+
+		public void MissileWarning(float distance, MissileBase ml)//take distance parameter
+		{
+			if (vessel.isActiveVessel && !warningSounding)
+			{
+				StartCoroutine(WarningSoundRoutine(distance, ml));
+			}
+
+			missileIsIncoming = true;
+			incomingMissileDistance = distance;
+		}
+
+		#endregion
+
+		#region Fire
+
+		bool FireCurrentMissile(bool checkClearance)
+		{
+			MissileBase missile = CurrentMissile;
+			if (missile == null) return false;
+
+			if (missile is MissileBase)
+			{
+
+				MissileBase ml = missile;
+				if (checkClearance && (!CheckBombClearance(ml) || (ml is MissileLauncher && ((MissileLauncher)ml).rotaryRail && !((MissileLauncher)ml).rotaryRail.readyMissile == ml)))
+				{
+					List<MissileBase>.Enumerator otherMissile = vessel.FindPartModulesImplementing<MissileBase>().GetEnumerator();
+					while (otherMissile.MoveNext())
+					{
+						if (otherMissile.Current == null) continue;
+						if (otherMissile.Current == ml || otherMissile.Current.GetShortName() != ml.GetShortName() ||
+							!CheckBombClearance(otherMissile.Current)) continue;
+						CurrentMissile = otherMissile.Current;
+						selectedWeapon = otherMissile.Current;
+						FireCurrentMissile(false);
+						return true;
+					}
+					otherMissile.Dispose();
+					CurrentMissile = ml;
+					selectedWeapon = ml;
+					return false;
+				}
+
+				if (ml is MissileLauncher && ((MissileLauncher)ml).missileTurret)
+				{
+					((MissileLauncher)ml).missileTurret.FireMissile(((MissileLauncher)ml));
+				}
+				else if (ml is MissileLauncher && ((MissileLauncher)ml).rotaryRail)
+				{
+					((MissileLauncher)ml).rotaryRail.FireMissile(((MissileLauncher)ml));
+				}
+				else
+				{
+					SendTargetDataToMissile(ml);
+					ml.FireMissile();
+				}
+
+				if (guardMode)
+				{
+					if (ml.GetWeaponClass() == WeaponClasses.Bomb)
+					{
+						//StartCoroutine(BombsAwayRoutine(ml));
+					}
+				}
+				else
+				{
+					if (vesselRadarData && vesselRadarData.autoCycleLockOnFire)
+					{
+						vesselRadarData.CycleActiveLock();
+					}
+				}
+			}
+			else
+			{
+				SendTargetDataToMissile(missile);
+				missile.FireMissile();
+			}
+
+			UpdateList();
+			return true;
+		}
+
+		void FireMissile()
+		{
+			if (weaponIndex == 0)
+			{
+				return;
+			}
+
+			if (selectedWeapon == null)
+			{
+				return;
+			}
+
+			if (selectedWeapon.GetWeaponClass() == WeaponClasses.Missile ||
+				selectedWeapon.GetWeaponClass() == WeaponClasses.SLW ||
+				selectedWeapon.GetWeaponClass() == WeaponClasses.Bomb)
+			{
+				FireCurrentMissile(true);
+			}
+
+			UpdateList();
+		}
+
+
+		#endregion
+
+		#region Weapon Info
+
+		void DisplaySelectedWeaponMessage()
+		{
+			if (BDArmorySetup.GAME_UI_ENABLED && vessel == FlightGlobals.ActiveVessel)
+			{
+				ScreenMessages.RemoveMessage(selectionMessage);
+				selectionMessage.textInstance = null;
+
+				selectionText = "Selected Weapon: " + (GetWeaponName(weaponArray[weaponIndex])).ToString();
+				selectionMessage.message = selectionText;
+				selectionMessage.style = ScreenMessageStyle.UPPER_CENTER;
+
+				ScreenMessages.PostScreenMessage(selectionMessage);
+			}
+		}
+
+		string GetWeaponName(IBDWeapon weapon)
+		{
+			if (weapon == null)
+			{
+				return "None";
+			}
+			else
+			{
+				return weapon.GetShortName();
+			}
+		}
+
+		public void UpdateList()
+		{
+			weaponTypes.Clear();
+			// extension for feature_engagementenvelope: also clear engagement specific weapon lists
+			weaponTypesAir.Clear();
+			weaponTypesMissile.Clear();
+			weaponTypesGround.Clear();
+			weaponTypesSLW.Clear();
+
+			List<IBDWeapon>.Enumerator weapon = vessel.FindPartModulesImplementing<IBDWeapon>().GetEnumerator();
+			while (weapon.MoveNext())
+			{
+				if (weapon.Current == null) continue;
+				string weaponName = weapon.Current.GetShortName();
+				bool alreadyAdded = false;
+				List<IBDWeapon>.Enumerator weap = weaponTypes.GetEnumerator();
+				while (weap.MoveNext())
+				{
+					if (weap.Current == null) continue;
+					if (weap.Current.GetShortName() == weaponName)
+					{
+						alreadyAdded = true;
+						//break;
+					}
+				}
+				weap.Dispose();
+
+				if (weapon.Current.GetWeaponClass() == WeaponClasses.Rocket &&
+					weapon.Current.GetPart().FindModuleImplementing<ModuleWeapon>().ammoAmount < 1
+					&& !BDArmorySettings.INFINITE_AMMO)
+				{
+					continue;
+				}
+
+				if (!alreadyAdded)
+				{
+					weaponTypes.Add(weapon.Current);
+				}
+
+				EngageableWeapon engageableWeapon = weapon.Current as EngageableWeapon;
+
+				if (engageableWeapon != null)
+				{
+					if (engageableWeapon.GetEngageAirTargets()) weaponTypesAir.Add(weapon.Current);
+					if (engageableWeapon.GetEngageMissileTargets()) weaponTypesMissile.Add(weapon.Current);
+					if (engageableWeapon.GetEngageGroundTargets()) weaponTypesGround.Add(weapon.Current);
+					if (engageableWeapon.GetEngageSLWTargets()) weaponTypesSLW.Add(weapon.Current);
+				}
+				else
+				{
+					weaponTypesAir.Add(weapon.Current);
+					weaponTypesMissile.Add(weapon.Current);
+					weaponTypesGround.Add(weapon.Current);
+					weaponTypesSLW.Add(weapon.Current);
+				}
+			}
+			weapon.Dispose();
+
+			//weaponTypes.Sort();
+			weaponTypes = weaponTypes.OrderBy(w => w.GetShortName()).ToList();
+
+			List<IBDWeapon> tempList = new List<IBDWeapon> { null };
+			tempList.AddRange(weaponTypes);
+
+			weaponArray = tempList.ToArray();
+
+			if (weaponIndex >= weaponArray.Length)
+			{
+				hasSingleFired = true;
+				triggerTimer = 0;
+			}
+			PrepareWeapons();
+		}
+
+		// EXTRACTED METHOD FROM UpdateList()
+		private void PrepareWeapons()
+		{
+			if (vessel == null) return;
+
+			weaponIndex = Mathf.Clamp(weaponIndex, 0, weaponArray.Length - 1);
+
+			if (selectedWeapon == null || selectedWeapon.GetPart() == null || (selectedWeapon.GetPart().vessel != null && selectedWeapon.GetPart().vessel != vessel) ||
+				GetWeaponName(selectedWeapon) != GetWeaponName(weaponArray[weaponIndex]))
+			{
+				selectedWeapon = weaponArray[weaponIndex];
+
+				if (vessel.isActiveVessel && Time.time - startTime > 1)
+				{
+					hasSingleFired = true;
+				}
+
+				if (vessel.isActiveVessel && weaponIndex != 0)
+				{
+					DisplaySelectedWeaponMessage();
+				}
+			}
+
+			if (weaponIndex == 0)
+			{
+				selectedWeapon = null;
+				hasSingleFired = true;
+			}
+
+			MissileBase aMl = GetAsymMissile();
+			if (aMl)
+			{
+				selectedWeapon = aMl;
+				CurrentMissile = aMl;
+			}
+
+			MissileBase rMl = GetRotaryReadyMissile();
+			if (rMl)
+			{
+				selectedWeapon = rMl;
+				CurrentMissile = rMl;
+			}
+
+			if (selectedWeapon != null && (selectedWeapon.GetWeaponClass() == WeaponClasses.Bomb || selectedWeapon.GetWeaponClass() == WeaponClasses.Missile || selectedWeapon.GetWeaponClass() == WeaponClasses.SLW))
+			{
+				//Debug.Log("[BDArmory]: =====selected weapon: " + selectedWeapon.GetPart().name);
+				if (!CurrentMissile || CurrentMissile.part.name != selectedWeapon.GetPart().name)
+				{
+					CurrentMissile = selectedWeapon.GetPart().FindModuleImplementing<MissileBase>();
+				}
+			}
+			else
+			{
+				CurrentMissile = null;
+			}
+
+			//selectedWeapon = weaponArray[weaponIndex];
+
+			//bomb stuff
+			if (selectedWeapon != null && selectedWeapon.GetWeaponClass() == WeaponClasses.Bomb)
+			{
+				bombPart = selectedWeapon.GetPart();
+			}
+			else
+			{
+				bombPart = null;
+			}
+
+			//gun ripple stuff
+			if (selectedWeapon != null && (selectedWeapon.GetWeaponClass() == WeaponClasses.Gun || selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket) &&
+				currentGun.roundsPerMinute < 1500)
+			{
+				float counter = 0; // Used to get a count of the ripple weapons.  a float version of rippleGunCount.
+				gunRippleIndex = 0;
+				// This value will be incremented as we set the ripple weapons
+				rippleGunCount = 0;
+				float weaponRpm = 0;  // used to set the rippleGunRPM
+
+				// JDK:  this looks like it can be greatly simplified...
+				#region Old Code (for reference.  remove when satisfied new code works as expected.
+				//List<ModuleWeapon> tempListModuleWeapon = vessel.FindPartModulesImplementing<ModuleWeapon>();
+				//foreach (ModuleWeapon weapon in tempListModuleWeapon)
+				//{
+				//    if (selectedWeapon.GetShortName() == weapon.GetShortName())
+				//    {
+				//        weapon.rippleIndex = Mathf.RoundToInt(counter);
+				//        weaponRPM = weapon.roundsPerMinute;
+				//        ++counter;
+				//        rippleGunCount++;
+				//    }
+				//}
+				//gunRippleRpm = weaponRPM * counter;
+				//float timeDelayPerGun = 60f / (weaponRPM * counter);
+				////number of seconds between each gun firing; will reduce with increasing RPM or number of guns
+				//foreach (ModuleWeapon weapon in tempListModuleWeapon)
+				//{
+				//    if (selectedWeapon.GetShortName() == weapon.GetShortName())
+				//    {
+				//        weapon.initialFireDelay = timeDelayPerGun; //set the time delay for moving to next index
+				//    }
+				//}
+
+				//RippleOption ro; //ripplesetup and stuff
+				//if (rippleDictionary.ContainsKey(selectedWeapon.GetShortName()))
+				//{
+				//    ro = rippleDictionary[selectedWeapon.GetShortName()];
+				//}
+				//else
+				//{
+				//    ro = new RippleOption(currentGun.useRippleFire, 650); //take from gun's persistant value
+				//    rippleDictionary.Add(selectedWeapon.GetShortName(), ro);
+				//}
+
+				//foreach (ModuleWeapon w in vessel.FindPartModulesImplementing<ModuleWeapon>())
+				//{
+				//    if (w.GetShortName() == selectedWeapon.GetShortName())
+				//        w.useRippleFire = ro.rippleFire;
+				//}
+				#endregion
+
+				// TODO:  JDK verify new code works as expected.
+				// New code, simplified. 
+
+				//First lest set the Ripple Option. Doing it first eliminates a loop.
+				RippleOption ro; //ripplesetup and stuff
+				if (rippleDictionary.ContainsKey(selectedWeapon.GetShortName()))
+				{
+					ro = rippleDictionary[selectedWeapon.GetShortName()];
+				}
+				else
+				{
+					ro = new RippleOption(currentGun.useRippleFire, 650); //take from gun's persistant value
+					rippleDictionary.Add(selectedWeapon.GetShortName(), ro);
+				}
+
+				//Get ripple weapon count, so we don't have to enumerate the whole list again.
+				List<ModuleWeapon> rippleWeapons = new List<ModuleWeapon>();
+				List<ModuleWeapon>.Enumerator weapCnt = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
+				while (weapCnt.MoveNext())
+				{
+					if (weapCnt.Current == null) continue;
+					if (selectedWeapon.GetShortName() != weapCnt.Current.GetShortName()) continue;
+					//guessing that all weapons of the same shortname have the same rpm, as we are storing the last found weapon value...
+					weaponRpm = weapCnt.Current.roundsPerMinute;
+					rippleWeapons.Add(weapCnt.Current);
+					counter += weaponRpm;
+				}
+				weapCnt.Dispose();
+
+				gunRippleRpm = counter;
 				//number of seconds between each gun firing; will reduce with increasing RPM or number of guns
-				float timeDelayPerGun = 60f / (weaponRpm * counter);
+				float timeDelayPerGun = 60f / gunRippleRpm;
 
 				// Now lets act on the filtered list.
 				List<ModuleWeapon>.Enumerator weapon = rippleWeapons.GetEnumerator();
-                while (weapon.MoveNext())
-                {
-                    if (weapon.Current == null) continue;
-                    // set the weapon ripple index just before we increment rippleGunCount.
-                    weapon.Current.rippleIndex = rippleGunCount;
-                    //set the time delay for moving to next index
-                    weapon.Current.initialFireDelay = timeDelayPerGun;
-                    weapon.Current.useRippleFire = ro.rippleFire;
-                    rippleGunCount++;
-                }
-                weapon.Dispose();
-            }
-
-            //rocket
-            FindNextRocket(null);
-
-            ToggleTurret();
-            SetMissileTurrets();
-            SetRocketTurrets();
-            SetRotaryRails();
-        }
-
-        private bool SetCargoBays()
-        {
-            if (!guardMode) return false;
-            bool openingBays = false;
-
-            if (weaponIndex > 0 && CurrentMissile && guardTarget && Vector3.Dot(guardTarget.transform.position - CurrentMissile.transform.position, CurrentMissile.GetForwardTransform()) > 0)
-            {
-                if (CurrentMissile.part.ShieldedFromAirstream)
-                {
-                    List<MissileBase>.Enumerator ml = vessel.FindPartModulesImplementing<MissileBase>().GetEnumerator();
-                    while (ml.MoveNext())
-                    {
-                        if (ml.Current == null) continue;
-                        if (ml.Current.part.ShieldedFromAirstream) ml.Current.inCargoBay = true;
-                    }
-                    ml.Dispose();
-                }
-
-                if (CurrentMissile.inCargoBay)
-                {
-                    List<ModuleCargoBay>.Enumerator bay = vessel.FindPartModulesImplementing<ModuleCargoBay>().GetEnumerator();
-                    while (bay.MoveNext())
-                    {
-                        if (bay.Current == null) continue;
-                        if (CurrentMissile.part.airstreamShields.Contains(bay.Current))
-                        {
-                            ModuleAnimateGeneric anim = bay.Current.part.Modules.GetModule(bay.Current.DeployModuleIndex) as ModuleAnimateGeneric;
-                            if (anim == null) continue;
-
-                            string toggleOption = anim.Events["Toggle"].guiName;
-                            if (toggleOption == "Open")
-                            {
-                                if (anim)
-                                {
-                                    anim.Toggle();
-                                    openingBays = true;
-                                }
-                            }
-                        }
-                        else
-                        {
-                            ModuleAnimateGeneric anim =
-                                bay.Current.part.Modules.GetModule(bay.Current.DeployModuleIndex) as ModuleAnimateGeneric;
-                            if (anim == null) continue;
-
-                            string toggleOption = anim.Events["Toggle"].guiName;
-                            if (toggleOption == "Close")
-                            {
-                                if (anim)
-                                {
-                                    anim.Toggle();
-                                }
-                            }
-                        }
-                    }
-                    bay.Dispose();
-                }
-                else
-                {
-                    List<ModuleCargoBay>.Enumerator bay = vessel.FindPartModulesImplementing<ModuleCargoBay>().GetEnumerator();
-                    while (bay.MoveNext())
-                    {
-                        if (bay.Current == null) continue;
-                        ModuleAnimateGeneric anim =
-                            bay.Current.part.Modules.GetModule(bay.Current.DeployModuleIndex) as ModuleAnimateGeneric;
-                        if (anim == null) continue;
-
-                        string toggleOption = anim.Events["Toggle"].guiName;
-                        if (toggleOption == "Close")
-                        {
-                            if (anim)
-                            {
-                                anim.Toggle();
-                            }
-                        }
-                    }
-                    bay.Dispose();
-                }
-            }
-            else
-            {
-                List<ModuleCargoBay>.Enumerator bay = vessel.FindPartModulesImplementing<ModuleCargoBay>().GetEnumerator();
-                while (bay.MoveNext())
-                {
-                    if (bay.Current == null) continue;
-                    ModuleAnimateGeneric anim = bay.Current.part.Modules.GetModule(bay.Current.DeployModuleIndex) as ModuleAnimateGeneric;
-                    if (anim == null) continue;
-
-                    string toggleOption = anim.Events["Toggle"].guiName;
-                    if (toggleOption == "Close")
-                    {
-                        if (anim)
-                        {
-                            anim.Toggle();
-                        }
-                    }
-                }
-                bay.Dispose();
-            }
-
-            return openingBays;
-        }
-
-        void SetRotaryRails()
-        {
-            if (weaponIndex == 0) return;
-
-            if (selectedWeapon == null) return;
-
-            if (
-                !(selectedWeapon.GetWeaponClass() == WeaponClasses.Missile ||
-                  selectedWeapon.GetWeaponClass() == WeaponClasses.Bomb ||
-                  selectedWeapon.GetWeaponClass() == WeaponClasses.SLW)) return;
-
-            if (!CurrentMissile) return;
-
-            //TODO BDModularGuidance: Rotatory Rail?
-            MissileLauncher cm = CurrentMissile as MissileLauncher;
-            if (cm == null) return;
-            List<BDRotaryRail>.Enumerator rotRail = vessel.FindPartModulesImplementing<BDRotaryRail>().GetEnumerator();
-            while (rotRail.MoveNext())
-            {
-                if (rotRail.Current == null) continue;
-                if (rotRail.Current.missileCount == 0)
-                {
-                    //Debug.Log("SetRotaryRails(): rail has no missiles");
-                    continue;
-                }
-
-                //Debug.Log("[BDArmory]: SetRotaryRails(): rotRail.Current.readyToFire: " + rotRail.Current.readyToFire + ", rotRail.Current.readyMissile: " + ((rotRail.Current.readyMissile != null) ? rotRail.Current.readyMissile.part.name : "null") + ", rotRail.Current.nextMissile: " + ((rotRail.Current.nextMissile != null) ? rotRail.Current.nextMissile.part.name : "null"));
-
-                //Debug.Log("[BDArmory]: current missile: " + cm.part.name);
-
-                if (rotRail.Current.readyToFire)
-                {
-                    if (!rotRail.Current.readyMissile)
-                    {
-                        rotRail.Current.RotateToMissile(cm);
-                        return;
-                    }
-
-                    if (rotRail.Current.readyMissile.part.name != cm.part.name)
-                    {
-                        rotRail.Current.RotateToMissile(cm);
-                    }
-                }
-                else
-                {
-                    if (!rotRail.Current.nextMissile)
-                    {
-                        rotRail.Current.RotateToMissile(cm);
-                    }
-                    else if (rotRail.Current.nextMissile.part.name != cm.part.name)
-                    {
-                        rotRail.Current.RotateToMissile(cm);
-                    }
-                }
-            }
-            rotRail.Dispose();
-        }
-
-        void SetMissileTurrets()
-        {
-            MissileLauncher cm = CurrentMissile as MissileLauncher;
-            if (cm == null) return;
-            List<MissileTurret>.Enumerator mt = vessel.FindPartModulesImplementing<MissileTurret>().GetEnumerator();
-            while (mt.MoveNext())
-            {
-                if (mt.Current == null) continue;
-                if (weaponIndex > 0 && cm && mt.Current.ContainsMissileOfType(cm))
-                {
-                    if (!mt.Current.activeMissileOnly || cm.missileTurret == mt.Current)
-                    {
-                        mt.Current.EnableTurret();
-                    }
-                    else
-                    {
-                        mt.Current.DisableTurret();
-                    }
-                }
-                else
-                {
-                    mt.Current.DisableTurret();
-                }
-            }
-            mt.Dispose();
-        }
-
-        void SetRocketTurrets()
-        {
-            RocketLauncher currentTurret = null;
-            if (selectedWeapon != null && selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket)
-            {
-                RocketLauncher srl = selectedWeapon.GetPart().FindModuleImplementing<RocketLauncher>();
-                if (srl && srl.turret)
-                {
-                    currentTurret = srl;
-                }
-            }
-
-            List<RocketLauncher>.Enumerator rl = vessel.FindPartModulesImplementing<RocketLauncher>().GetEnumerator();
-            while (rl.MoveNext())
-            {
-                if (rl.Current == null) continue;
-                rl.Current.weaponManager = this;
-                if (rl.Current.turret)
-                {
-                    if (currentTurret && rl.Current.part.name == currentTurret.part.name)
-                    {
-                        rl.Current.EnableTurret();
-                    }
-                    else
-                    {
-                        rl.Current.DisableTurret();
-                    }
-                }
-            }
-            rl.Dispose();
-        }
-
-        void FindNextRocket(RocketLauncher lastFired)
-        {
-            if (weaponIndex > 0 && selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket)
-            {
-                disabledRocketAimers = false;
-
-                //first check sym of last fired
-                if (lastFired && lastFired.part.name == selectedWeapon.GetPart().name)
-                {
-                    List<Part>.Enumerator pSym = lastFired.part.symmetryCounterparts.GetEnumerator();
-                    while (pSym.MoveNext())
-                    {
-                        if (pSym.Current == null) continue;
-                        bool hasRocket = false;
-                        RocketLauncher rl = pSym.Current.FindModuleImplementing<RocketLauncher>();
-                        IEnumerator<PartResource> r = rl.part.Resources.GetEnumerator();
-                        while (r.MoveNext())
-                        {
-                            if (r.Current == null) continue;
-                            if ((r.Current.resourceName != rl.rocketType || !(r.Current.amount > 0)) 
-                                && !BDArmorySettings.INFINITE_AMMO) continue;
-                            hasRocket = true;
-                            break;
-                        }
-                        r.Dispose();
-
-                        if (!hasRocket) continue;
-                        if (currentRocket) currentRocket.drawAimer = false;
-
-                        rl.drawAimer = true;
-                        currentRocket = rl;
-                        selectedWeapon = currentRocket;
-                        return;
-                    }
-                }
-
-                if (!lastFired && currentRocket && currentRocket.part.name == selectedWeapon.GetPart().name)
-                {
-                    currentRocket.drawAimer = true;
-                    selectedWeapon = currentRocket;
-                    return;
-                }
-
-                //then check for other rocket
-                bool foundRocket = false;
-                List<RocketLauncher>.Enumerator orl = vessel.FindPartModulesImplementing<RocketLauncher>().GetEnumerator();
-                while (orl.MoveNext())
-                {
-                    if (orl.Current == null) continue;
-                    if (!foundRocket && orl.Current.part.partInfo.title == selectedWeapon.GetPart().partInfo.title)
-                    {
-                        bool hasRocket = false;
-                        IEnumerator<PartResource> r = orl.Current.part.Resources.GetEnumerator();
-                        while (r.MoveNext())
-                        {
-                            if (r.Current == null) continue;
-                            if (r.Current.amount > 0 || BDArmorySettings.INFINITE_AMMO) hasRocket = true;
-                            else orl.Current.drawAimer = false;
-                        }
-                        r.Dispose();
-
-                        if (!hasRocket) continue;
-                        if (currentRocket != null) currentRocket.drawAimer = false;
-                        orl.Current.drawAimer = true;
-                        currentRocket = orl.Current;
-                        selectedWeapon = currentRocket;
-                        //return;
-                        foundRocket = true;
-                    }
-                    else
-                    {
-                        orl.Current.drawAimer = false;
-                    }
-                }
-                orl.Dispose();
-            }
-            //not using a rocket, disable reticles.
-            else if (!disabledRocketAimers)
-            {
-                List<RocketLauncher>.Enumerator rl = vessel.FindPartModulesImplementing<RocketLauncher>().GetEnumerator();
-                while (rl.MoveNext())
-                {
-                    if (rl.Current == null) continue;
-                    rl.Current.drawAimer = false;
-                    currentRocket = null;
-                }
-                rl.Dispose();
-                disabledRocketAimers = true;
-            }
-        }
-
-        public void CycleWeapon(bool forward)
-        {
-            if (forward) weaponIndex++;
-            else weaponIndex--;
-            weaponIndex = (int)Mathf.Repeat(weaponIndex, weaponArray.Length);
-
-            hasSingleFired = true;
-            triggerTimer = 0;
-
-            UpdateList();
-
-            DisplaySelectedWeaponMessage();
-
-            if (vessel.isActiveVessel && !guardMode)
-            {
-                audioSource.PlayOneShot(clickSound);
-            }
-        }
-
-        public void CycleWeapon(int index)
-        {
-            if (index >= weaponArray.Length)
-            {
-                index = 0;
-            }
-            weaponIndex = index;
-
-            UpdateList();
-
-            if (vessel.isActiveVessel && !guardMode)
-            {
-                audioSource.PlayOneShot(clickSound);
-
-                DisplaySelectedWeaponMessage();
-            }
-        }
-
-        public Part FindSym(Part p)
-        {
-            List<Part>.Enumerator pSym = p.symmetryCounterparts.GetEnumerator();
-            while (pSym.MoveNext())
-            {
-                if (pSym.Current == null) continue;
-                if (pSym.Current != p && pSym.Current.vessel == vessel)
-                {
-                    return pSym.Current;
-                }
-            }
-            pSym.Dispose();
-
-            return null;
-        }
-
-        private MissileBase GetAsymMissile()
-        {
-            if (weaponIndex == 0) return null;
-            if (weaponArray[weaponIndex].GetWeaponClass() == WeaponClasses.Bomb ||
-                weaponArray[weaponIndex].GetWeaponClass() == WeaponClasses.Missile ||
-                weaponArray[weaponIndex].GetWeaponClass() ==WeaponClasses.SLW)
-            {
-                MissileBase firstMl = null;
-                List<MissileBase>.Enumerator ml = vessel.FindPartModulesImplementing<MissileBase>().GetEnumerator();
-                while (ml.MoveNext())
-                {
-                    if (ml.Current == null) continue;
-                    MissileLauncher launcher = ml.Current as MissileLauncher;
-                    if (launcher != null)
-                    {
-                        if (launcher.part.name != weaponArray[weaponIndex].GetPart()?.name) continue;
-                    }
-                    else
-                    {
-                        BDModularGuidance guidance = ml.Current as BDModularGuidance;
-                        if (guidance != null)
-                        { //We have set of parts not only a part
-                            if (guidance.GetShortName() != weaponArray[weaponIndex]?.GetShortName()) continue;
-                        }
-                    }
-                    if (firstMl == null) firstMl = ml.Current;
-
-                    if (!FindSym(ml.Current.part))
-                    {
-                        return ml.Current;
-                    }
-                }
-                ml.Dispose();
-                return firstMl;
-            }
-            return null;
-        }
-
-        private MissileBase GetRotaryReadyMissile()
-        {
-            if (weaponIndex == 0) return null;
-            if (weaponArray[weaponIndex].GetWeaponClass() == WeaponClasses.Bomb ||
-                weaponArray[weaponIndex].GetWeaponClass() == WeaponClasses.Missile ||
-                weaponArray[weaponIndex].GetWeaponClass() == WeaponClasses.SLW)
-            {
-                //TODO BDModularGuidance: Implemente rotaryRail support
-                MissileLauncher missile = CurrentMissile as MissileLauncher;
-                if (missile == null) return null;
-                if (missile && missile.part.name == weaponArray[weaponIndex].GetPart().name)
-                {
-                    if (!missile.rotaryRail)
-                    {
-                        return missile;
-                    }
-                    if (missile.rotaryRail.readyToFire && missile.rotaryRail.readyMissile == CurrentMissile)
-                    {
-                        return missile;
-                    }
-                }
-                List<MissileLauncher>.Enumerator ml = vessel.FindPartModulesImplementing<MissileLauncher>().GetEnumerator();
-                while (ml.MoveNext())
-                {
-                    if (ml.Current == null) continue;
-                    if (ml.Current.part.name != weaponArray[weaponIndex].GetPart().name) continue;
-
-                    if (!ml.Current.rotaryRail)
-                    {
-                        return ml.Current;
-                    }
-                    if (ml.Current.rotaryRail.readyToFire && ml.Current.rotaryRail.readyMissile.part.name == weaponArray[weaponIndex].GetPart().name)
-                    {
-                        return ml.Current.rotaryRail.readyMissile;
-                    }
-                }
-                ml.Dispose();
-                return null;
-            }
-            return null;
-        }
-
-        bool CheckBombClearance(MissileBase ml)
-        {
-            if (!BDArmorySettings.BOMB_CLEARANCE_CHECK) return true;
-
-            if (ml.part.ShieldedFromAirstream)
-            {
-                return false;
-            }
-
-            //TODO BDModularGuidance: Bombs and turrents
-            MissileLauncher launcher = ml as MissileLauncher;
-            if (launcher != null)
-            {
-                if (launcher.rotaryRail && launcher.rotaryRail.readyMissile != ml)
-                {
-                    return false;
-                }
-
-                if (launcher.missileTurret && !launcher.missileTurret.turretEnabled)
-                {
-                    return false;
-                }
-
-                if (ml.dropTime > 0.3f)
-                {
-                    //debug lines
-                    LineRenderer lr = null;
-                    if (BDArmorySettings.DRAW_DEBUG_LINES && BDArmorySettings.DRAW_AIMERS)
-                    {
-                        lr = GetComponent<LineRenderer>();
-                        if (!lr)
-                        {
-                            lr = gameObject.AddComponent<LineRenderer>();
-                        }
-                        lr.enabled = true;
-                        lr.startWidth = .1f;
-                        lr.endWidth = .1f;
-                    }
-                    else
-                    {
-                        if (gameObject.GetComponent<LineRenderer>())
-                        {
-                            gameObject.GetComponent<LineRenderer>().enabled = false;
-                        }
-                    }
-
-
-                    float radius = 0.28f / 2;
-                    float time = ml.dropTime;
-                    Vector3 direction = ((launcher.decoupleForward
-                        ? ml.MissileReferenceTransform.transform.forward
-                        : -ml.MissileReferenceTransform.transform.up) * launcher.decoupleSpeed * time) +
-                                        ((FlightGlobals.getGeeForceAtPosition(transform.position) - vessel.acceleration) *
-                                         0.5f * time * time);
-                    Vector3 crossAxis = Vector3.Cross(direction, ml.GetForwardTransform()).normalized;
-
-                    float rayDistance;
-                    if (launcher.thrust == 0 || launcher.cruiseThrust == 0)
-                    {
-                        rayDistance = 8;
-                    }
-                    else
-                    {
-                        //distance till engine starts based on grav accel and vessel accel
-                        rayDistance = direction.magnitude;
-                    }
-
-                    Ray[] rays =
-                    {
-                        new Ray(ml.MissileReferenceTransform.position - (radius*crossAxis), direction),
-                        new Ray(ml.MissileReferenceTransform.position + (radius*crossAxis), direction),
-                        new Ray(ml.MissileReferenceTransform.position, direction)
-                    };
-
-                    if (lr)
-                    {
-                        lr.useWorldSpace = false;
-                        lr.positionCount = 4;
-                        lr.SetPosition(0, transform.InverseTransformPoint(rays[0].origin));
-                        lr.SetPosition(1, transform.InverseTransformPoint(rays[0].GetPoint(rayDistance)));
-                        lr.SetPosition(2, transform.InverseTransformPoint(rays[1].GetPoint(rayDistance)));
-                        lr.SetPosition(3, transform.InverseTransformPoint(rays[1].origin));
-                    }
-
-                    IEnumerator<Ray> rt = rays.AsEnumerable().GetEnumerator();
-                    while (rt.MoveNext())
-                    {
-                        RaycastHit[] hits = Physics.RaycastAll(rt.Current, rayDistance, 557057);
-                        IEnumerator<RaycastHit> t1 = hits.AsEnumerable().GetEnumerator();
-                        while (t1.MoveNext() )
-                        {
-                            Part p = t1.Current.collider.GetComponentInParent<Part>();
-
-                            if ((p == null || p == ml.part) && p != null) continue;
-                            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                                Debug.Log("[BDArmory]: RAYCAST HIT, clearance is FALSE! part=" + p?.name + ", collider=" + p?.collider);
-                            return false;
-                        }
-                        t1.Dispose();
-                    }
-                    rt.Dispose();
-                    return true;
-                }
-
-                //forward check for no-drop missiles
-                RaycastHit[] hitparts = Physics.RaycastAll(new Ray(ml.MissileReferenceTransform.position, ml.GetForwardTransform()), 50, 557057);
-                IEnumerator<RaycastHit> t = hitparts.AsEnumerable().GetEnumerator();
-                while (t.MoveNext())
-                {
-                    Part p = t.Current.collider.GetComponentInParent<Part>();
-                    if ((p == null || p == ml.part) && p != null) continue;
-                    if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                        Debug.Log("[BDArmory]: RAYCAST HIT, clearance is FALSE! part=" + p?.name + ", collider=" + p?.collider);
-                    return false;
-                }
-                t.Dispose();
-            }
-            return true;
-        }
-
-        void RefreshModules()
-        {
-            radars = vessel.FindPartModulesImplementing<ModuleRadar>();
-
-            List<ModuleRadar>.Enumerator rad = radars.GetEnumerator();
-            while (rad.MoveNext())
-            {
-                if (rad.Current == null) continue;
-                rad.Current.EnsureVesselRadarData();
-                if (rad.Current.radarEnabled) rad.Current.EnableRadar();
-            }
-            rad.Dispose();
-
-            jammers = vessel.FindPartModulesImplementing<ModuleECMJammer>();
-            targetingPods = vessel.FindPartModulesImplementing<ModuleTargetingCamera>();
-            wmModules = vessel.FindPartModulesImplementing<IBDWMModule>();
-        }
-
-        #endregion
-
-        #region Weapon Choice
-
-        bool TryPickAntiRad(TargetInfo target)
-        {
-            CycleWeapon(0); //go to start of array
-            while (true)
-            {
-                CycleWeapon(true);
-                if (selectedWeapon == null) return false;
-                if (selectedWeapon.GetWeaponClass() != WeaponClasses.Missile) continue;
-                List<MissileBase>.Enumerator ml = selectedWeapon.GetPart().FindModulesImplementing<MissileBase>().GetEnumerator();
-                while (ml.MoveNext())
-                {
-                    if (ml.Current == null) continue;
-                    if (ml.Current.TargetingMode == MissileBase.TargetingModes.AntiRad)
-                    {
-                        return true;
-                    }
-                    break;
-                }
-                ml.Dispose();
-                //return;
-            }
-        }
-        #endregion
-
-        #region Targeting
-
-        #region Smart Targeting
-            
-        void SmartFindTarget()
-        {
-            List<TargetInfo> targetsTried = new List<TargetInfo>();
-
-            if (overrideTarget) //begin by checking the override target, since that takes priority
-            {
-                targetsTried.Add(overrideTarget);
-                SetTarget(overrideTarget);
-                if (SmartPickWeapon_EngagementEnvelope(overrideTarget))
-                {
-                    if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                    {
-                        Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging an override target with " + selectedWeapon);
-                    }
-                    overrideTimer = 15f;
-                    return;
-                }
-                else if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                {
-                    Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging an override target with failed to engage its override target!");
-                }
-            }
-            overrideTarget = null; //null the override target if it cannot be used
-
-            //if AIRBORNE, try to engage airborne target first
-            if (!vessel.LandedOrSplashed && !targetMissiles)
-            {
-                if (pilotAI && pilotAI.IsExtending)
-                {
-                    TargetInfo potentialAirTarget = BDATargetManager.GetAirToAirTargetAbortExtend(this, 1500, 0.2f);
-                    if (potentialAirTarget)
-                    {
-                        targetsTried.Add(potentialAirTarget);
-                        SetTarget(potentialAirTarget);
-                        if (SmartPickWeapon_EngagementEnvelope(potentialAirTarget))
-                        {
-                            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                            {
-                                Debug.Log("[BDArmory]: " + vessel.vesselName + " is aborting extend and engaging an incoming airborne target with " + selectedWeapon);
-                            }
-                            return;
-                        }
-                    }
-                }
-                else
-                {
-                    TargetInfo potentialAirTarget = BDATargetManager.GetAirToAirTarget(this);
-                    if (potentialAirTarget)
-                    {
-                        targetsTried.Add(potentialAirTarget);
-                        SetTarget(potentialAirTarget);
-                        if (SmartPickWeapon_EngagementEnvelope(potentialAirTarget))
-                        {
-                            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                            {
-                                Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging an airborne target with " + selectedWeapon);
-                            }
-                            return;
-                        }
-                    }
-                }
-            }
-
-            TargetInfo potentialTarget = null;
-            //=========HIGH PRIORITY MISSILES=============
-            //first engage any missiles targeting this vessel
-            potentialTarget = BDATargetManager.GetMissileTarget(this, true);
-            if (potentialTarget)
-            {
-                targetsTried.Add(potentialTarget);
-                SetTarget(potentialTarget);
-                if (SmartPickWeapon_EngagementEnvelope(potentialTarget))
-                {
-                    if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                    {
-                        Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging incoming missile with " + selectedWeapon);
-                    }
-                    return;
-                }
-            }
-
-            //then engage any missiles that are not engaged
-            potentialTarget = BDATargetManager.GetUnengagedMissileTarget(this);
-            if (potentialTarget)
-            {
-                targetsTried.Add(potentialTarget);
-                SetTarget(potentialTarget);
-                if (SmartPickWeapon_EngagementEnvelope(potentialTarget))
-                {
-                    if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                    {
-                        Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging unengaged missile with " + selectedWeapon);
-                    }
-                    return;
-                }
-            }
-
-
-            //=========END HIGH PRIORITY MISSILES=============
-
-            //============VESSEL THREATS============
-            if (!targetMissiles)
-            {
-                //then try to engage enemies with least friendlies already engaging them 
-                potentialTarget = BDATargetManager.GetLeastEngagedTarget(this);
-                if (potentialTarget)
-                {
-                    targetsTried.Add(potentialTarget);
-                    SetTarget(potentialTarget);
-                    if (!BDArmorySettings.ALLOW_LEGACY_TARGETING)
-                    {
-                        if (CrossCheckWithRWR(potentialTarget) && TryPickAntiRad(potentialTarget))
-                        {
-                            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                            {
-                                Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging the least engaged radar target with " +
-                                          selectedWeapon.GetShortName());
-                            }
-                            return;
-                        }
-                    }
-                    if (SmartPickWeapon_EngagementEnvelope(potentialTarget))
-                    {
-                        if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                        {
-                            Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging the least engaged target with " +
-                                      selectedWeapon.GetShortName());
-                        }
-                        return;
-                    }
-                }
-
-                //then engage the closest enemy
-                potentialTarget = BDATargetManager.GetClosestTarget(this);
-                if (potentialTarget)
-                {
-                    targetsTried.Add(potentialTarget);
-                    SetTarget(potentialTarget);
-                    if (!BDArmorySettings.ALLOW_LEGACY_TARGETING)
-                    {
-                        if (CrossCheckWithRWR(potentialTarget) && TryPickAntiRad(potentialTarget))
-                        {
-                            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                            {
-                                Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging the closest radar target with " +
-                                          selectedWeapon.GetShortName());
-                            }
-                            return;
-                        }
-                    }
-                    if (SmartPickWeapon_EngagementEnvelope(potentialTarget))
-                    {
-                        if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                        {
-                            Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging the closest target with " +
-                                      selectedWeapon.GetShortName());
-                        }
-                        return;
-                    }
-                }
-            }
-            //============END VESSEL THREATS============
-
-
-            //============LOW PRIORITY MISSILES=========
-            //try to engage least engaged hostile missiles first
-            potentialTarget = BDATargetManager.GetMissileTarget(this);
-            if (potentialTarget)
-            {
-                targetsTried.Add(potentialTarget);
-                SetTarget(potentialTarget);
-                if (SmartPickWeapon_EngagementEnvelope(potentialTarget))
-                {
-                    if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                    {
-                        Debug.Log("[BDArmory]:" + vessel.vesselName + " is engaging a missile with " + selectedWeapon.GetShortName());
-                    }
-                    return;
-                }
-            }
-
-            //then try to engage closest hostile missile
-            potentialTarget = BDATargetManager.GetClosestMissileTarget(this);
-            if (potentialTarget)
-            {
-                targetsTried.Add(potentialTarget);
-                SetTarget(potentialTarget);
-                if (SmartPickWeapon_EngagementEnvelope(potentialTarget))
-                {
-                    if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                    {
-                        Debug.Log("[BDArmory]:" + vessel.vesselName + " is engaging a missile with " + selectedWeapon.GetShortName());
-                    }
-                    return;
-                }
-            }
-            //==========END LOW PRIORITY MISSILES=============
-
-            if (targetMissiles) //NO MISSILES BEYOND THIS POINT//
-            {
-                if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                {
-                    Debug.Log("[BDArmory]:" + vessel.vesselName + " is disengaging - no valid weapons");
-                }
-                CycleWeapon(0);
-                SetTarget(null);
-                return;
-            }
-
-            //if nothing works, get all remaining targets and try weapons against them
-            List<TargetInfo>.Enumerator finalTargets = BDATargetManager.GetAllTargetsExcluding(targetsTried, this).GetEnumerator();
-            while (finalTargets.MoveNext())
-            {
-                if (finalTargets.Current == null) continue;
-                SetTarget(finalTargets.Current);
-                if (!SmartPickWeapon_EngagementEnvelope(finalTargets.Current)) continue;
-                if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                {
-                    Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging a final target with " +
-                              selectedWeapon.GetShortName());
-                }
-                return;
-            }
-
-
-            //no valid targets found
-            if (potentialTarget == null || selectedWeapon == null)
-            {
-                if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                {
-                    Debug.Log("[BDArmory]: " + vessel.vesselName + " is disengaging - no valid weapons - no valid targets");
-                }
-                CycleWeapon(0);
-                SetTarget(null);
-                if (vesselRadarData && vesselRadarData.locked)
-                {
-                    vesselRadarData.UnlockAllTargets();
-                }
-                return;
-            }
-
-            Debug.Log("[BDArmory]: Unhandled target case");
-        }
-
-        // extension for feature_engagementenvelope: new smartpickweapon method
-        bool SmartPickWeapon_EngagementEnvelope(TargetInfo target)
-        {
-            // Part 1: Guard conditions (when not to pick a weapon)
-            // ------
-            if (!target)
-                return false;
-
-            if (AI != null && AI.pilotEnabled && !AI.CanEngage())
-                return false;
-
-            // Part 2: check weapons against individual target types
-            // ------
-
-            float distance = Vector3.Distance(transform.position + vessel.Velocity(), target.position + target.velocity);
-            IBDWeapon targetWeapon = null;
-            float targetWeaponRPM = 0;
-            float targetWeaponTDPS = 0;
-            float targetWeaponImpact = 0;
-
-            if (target.isMissile)
-            {
-                // iterate over weaponTypesMissile and pick suitable one based on engagementRange (and dynamic launch zone for missiles)
-                // Prioritize by:
-                // 1. Lasers
-                // 2. Guns
-                // 3. AA missiles
-                List<IBDWeapon>.Enumerator item = weaponTypesMissile.GetEnumerator();
-                while (item.MoveNext())
-                {
-                    if (item.Current == null) continue;
-                    // candidate, check engagement envelope
-                    if (!CheckEngagementEnvelope(item.Current, distance)) continue;
-                    // weapon usable, if missile continue looking for lasers/guns, else take it
-                    WeaponClasses candidateClass = item.Current.GetWeaponClass();
-
-                    if (candidateClass == WeaponClasses.DefenseLaser)
-                    {
-                        // TODO: compare lasers which one is better for AA
-                        targetWeapon = item.Current;
-                        break; //always favour laser
-                    }
-
-                    if (candidateClass == WeaponClasses.Gun)
-                    {
-                        // For AAA, favour higher RPM
-                        float candidateRPM = ((ModuleWeapon)item.Current).roundsPerMinute;
-
-                        if ((targetWeapon != null) && (targetWeaponRPM > candidateRPM))
-                            continue; //dont replace better guns (but do replace missiles)
-
-                        targetWeapon = item.Current;
-                        targetWeaponRPM = candidateRPM;
-                    }
-
-                    if (candidateClass != WeaponClasses.Missile) continue;
-                    // TODO: for AA, favour higher thrust+turnDPS
-
-                    MissileLauncher mlauncher = item.Current as MissileLauncher;
-                    float candidateTDPS = 0f;
-                        
-                    if (mlauncher != null)
-                    {
-                        candidateTDPS = mlauncher.thrust + mlauncher.maxTurnRateDPS;
-                    }
-                    else
-                    { //is modular missile
-                        BDModularGuidance mm = item.Current as BDModularGuidance;
-                        candidateTDPS = 5000;                                                     
-                    }
-
-                    if ((targetWeapon != null) && ((targetWeapon.GetWeaponClass() == WeaponClasses.Gun) || (targetWeaponTDPS > candidateTDPS)))
-                        continue; //dont replace guns or better missiles
-
-                    targetWeapon = item.Current;
-                    targetWeaponTDPS = candidateTDPS;
-                }
-                item.Dispose();
-
-            }
-
-            //else if (!target.isLanded)
-            else if (target.isFlying)
-            {
-                // iterate over weaponTypesAir and pick suitable one based on engagementRange (and dynamic launch zone for missiles)
-                // Prioritize by:
-                // 1. AA missiles, if range > gunRange
-                // 1. Lasers
-                // 2. Guns
-                // 
-                List<IBDWeapon>.Enumerator item = weaponTypesAir.GetEnumerator();
-                while (item.MoveNext())
-                {
-                    if (item.Current == null) continue;
-                    // candidate, check engagement envelope
-                    if (!CheckEngagementEnvelope(item.Current, distance)) continue;
-                    // weapon usable, if missile continue looking for lasers/guns, else take it
-                    WeaponClasses candidateClass = item.Current.GetWeaponClass();
-
-                    if (candidateClass == WeaponClasses.DefenseLaser)
-                    {
-                        // TODO: compare lasers which one is better for AA
-                        targetWeapon = item.Current;
-                        if (distance <= gunRange)
-                            break;
-                    }
-
-                    if (candidateClass == WeaponClasses.Gun)
-                    {
-                        // For AAA, favour higher RPM
-                        float candidateRPM = ((ModuleWeapon)item.Current).roundsPerMinute;
-
-                        if ((targetWeapon != null) && (targetWeaponRPM > candidateRPM))
-                            continue; //dont replace better guns (but do replace missiles)
-
-                        targetWeapon = item.Current;
-                        targetWeaponRPM = candidateRPM;
-                    }
-
-                    if (candidateClass != WeaponClasses.Missile) continue;
-                    MissileLauncher mlauncher = item.Current as MissileLauncher;
-                    float candidateTDPS = 0f;
-
-                    if (mlauncher != null)
-                    {
-                        candidateTDPS = mlauncher.thrust + mlauncher.maxTurnRateDPS;
-                    }
-                    else
-                    { //is modular missile
-                        BDModularGuidance mm = item.Current as BDModularGuidance;
-                        candidateTDPS = 5000;
-                    }		
-
-			if (targetWeapon == null)
-                    {
-                        targetWeapon = item.Current;
-                        targetWeaponTDPS = candidateTDPS;
-                    }
-                    else if (distance > gunRange)
-                    {
-                        if (targetWeapon.GetWeaponClass() == WeaponClasses.Gun || targetWeaponTDPS > candidateTDPS)
-                            continue; //dont replace guns or better missiles
-
-                        targetWeapon = item.Current;
-                        targetWeaponTDPS = candidateTDPS;
-                    }
-                }
-                item.Dispose();
-            }
-
-            else if (target.isLanded)
-            {
-                // iterate over weaponTypesGround and pick suitable one based on engagementRange (and dynamic launch zone for missiles)
-                // Prioritize by:
-                // 1. ground attack missiles (cruise, gps, unguided) if target not moving
-                // 2. ground attack missiles (guided) if target is moving
-                // 3. Bombs / Rockets
-                // 4. Guns
-                List<IBDWeapon>.Enumerator item = weaponTypesGround.GetEnumerator();
-                while (item.MoveNext())
-                {
-                    if (item.Current == null) continue;
-                    // candidate, check engagement envelope
-                    if (!CheckEngagementEnvelope(item.Current, distance)) continue;
-                    // weapon usable, if missile continue looking for lasers/guns, else take it
-                    WeaponClasses candidateClass = item.Current.GetWeaponClass();
-
-                    if (candidateClass == WeaponClasses.Missile)
-                    {
-                        // TODO: compare missiles which one is better for ground attack
-                        // Priority Sequence:
-                        // - Antiradiation
-                        // - guided missiles
-                        // - by blast strength
-                        targetWeapon = item.Current;
-                        if (distance > gunRange)
-                            break;  //definitely use missiles
-                    }
-
-                    if (candidateClass == WeaponClasses.Bomb)
-                    {
-                        // only useful if we are flying
-                        if (!vessel.LandedOrSplashed)
-                        {
-                            if ((targetWeapon != null) && (targetWeapon.GetWeaponClass() == WeaponClasses.Bomb))
-                                // dont replace bombs
-                                break;
-                            else
-                                // TODO: compare bombs which one is better for ground attack
-                                // Priority Sequence:
-                                // - guided (JDAM)
-                                // - by blast strength
-                                targetWeapon = item.Current;
-                        }
-                    }
-
-                    if (candidateClass == WeaponClasses.Rocket)
-                    {
-
-                        if ((targetWeapon != null) && (targetWeapon.GetWeaponClass() == WeaponClasses.Bomb))
-                            // dont replace bombs
-                            continue;
-                        else
-                            // TODO: compare bombs which one is better for ground attack
-                            // Priority Sequence:
-                            // - by blast strength
-                            targetWeapon = item.Current;
-                    }
-
-
-                    if ((candidateClass != WeaponClasses.Gun)) continue;
-                    // Flying: prefer bombs/rockets/missiles
-                    if (!vessel.LandedOrSplashed)
-                        if (targetWeapon != null)
-                            // dont replace bombs/rockets
-                            continue;
-                    // else:
-                    if ((distance > gunRange) && (targetWeapon != null))
-                        continue;
-                    // For Ground Attack, favour higher blast strength
-                    float candidateImpact = ((ModuleWeapon)item.Current).cannonShellPower * ((ModuleWeapon)item.Current).cannonShellRadius + ((ModuleWeapon)item.Current).cannonShellHeat;
-
-                    if ((targetWeapon != null) && (targetWeaponImpact > candidateImpact))
-                        continue; //dont replace better guns
-
-                    targetWeapon = item.Current;
-                    targetWeaponImpact = candidateImpact;
-                }
-
-            }
-                //if we have a torpedo use it
-            else if (target.isSplashed)
-            { 
-                List<IBDWeapon>.Enumerator item = weaponTypesSLW.GetEnumerator();
-                while (item.MoveNext())
-                {
-                    if (item.Current == null) continue;
-                    if (CheckEngagementEnvelope(item.Current, distance))
-                    {
-                        if (item.Current.GetMissileType().ToLower() == "torpedo")
-                        {
-                            targetWeapon = item.Current;
-                            break;
-                        }
-                    }
-                }
-                item.Dispose();
-            }              
-            else if (target.isUnderwater)
-            {
-                // iterate over weaponTypesSLW (Ship Launched Weapons) and pick suitable one based on engagementRange
-                // Prioritize by:
-                // 1. Depth Charges
-                // 2. Torpedos
-                List<IBDWeapon>.Enumerator item = weaponTypesSLW.GetEnumerator();
-                while (item.MoveNext())
-                {
-                    if (item.Current == null) continue;
-                    if (CheckEngagementEnvelope(item.Current, distance))
-                    {
-                        if (item.Current.GetMissileType().ToLower() == "depthcharge")
-                        {
-                            targetWeapon = item.Current;
-                            break;
-                        }
-                        if (item.Current.GetMissileType().ToLower() != "torpedo") continue;
-                        targetWeapon = item.Current;
-                        break;
-                    }
-                }
-                item.Dispose();
-            }
-
-            // return result of weapon selection
-            if (targetWeapon != null)
-            {
-                //update the legacy lists & arrays, especially selectedWeapon and weaponIndex
-                selectedWeapon = targetWeapon;
-                // find it in weaponArray
-                for (int i = 1; i < weaponArray.Length; i++)
-                {
-                    weaponIndex = i;
-                    if (selectedWeapon.GetShortName() == weaponArray[weaponIndex].GetShortName())
-                    {
-                        break;
-                    }
-                }
-
-                if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                {
-                    Debug.Log("[BDArmory] : " + vessel.vesselName + " - Selected weapon " + selectedWeapon.GetShortName());
-                }
-
-                PrepareWeapons();
-                DisplaySelectedWeaponMessage();
-                return true;
-            }
-            else
-            {
-
-                if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                {
-                    Debug.Log("[BDArmory] : " + vessel.vesselName + " - No weapon selected.");
-                }
-
-                selectedWeapon = null;
-                weaponIndex = 0;
-                return false;
-            }
-
-        }
-
-        // extension for feature_engagementenvelope: check engagement parameters of the weapon if it can be used against the current target
-        bool CheckEngagementEnvelope(IBDWeapon weaponCandidate, float distanceToTarget)
-        {
-            EngageableWeapon engageableWeapon = weaponCandidate as EngageableWeapon;
-
-            if (engageableWeapon == null) return true;
-            if (!engageableWeapon.engageEnabled) return true;
-            if (distanceToTarget < engageableWeapon.GetEngagementRangeMin()) return false;
-            if (distanceToTarget > engageableWeapon.GetEngagementRangeMax()) return false;
-
-            switch (weaponCandidate.GetWeaponClass())
-            {
-
-                case WeaponClasses.DefenseLaser:
-                // TODO: is laser treated like a gun?
-
-                case WeaponClasses.Gun:
-                    ModuleWeapon gun = (ModuleWeapon)weaponCandidate;
-
-                    // check yaw range of turret
-                    ModuleTurret turret = gun.turret;
-                    float gimbalTolerance = vessel.LandedOrSplashed ? 0 : 15;
-                    if (turret != null)
-                        if (!TargetInTurretRange(turret, gimbalTolerance))
-                            return false;
-
-                    // check overheat
-                    if (gun.isOverheated)
-                        return false;
-
-                    // check ammo
-                    if (CheckAmmo(gun))
-                    {
-
-                        if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                        {
-                            Debug.Log("[BDArmory] : " + vessel.vesselName + " - Firing possible with " + weaponCandidate.GetShortName());
-                        }
-                        return true;
-                    }
-                    break;
-
-
-                case WeaponClasses.Missile:
-                    MissileBase ml = (MissileBase)weaponCandidate;
-
-                    // lock radar if needed
-                    if (ml.TargetingMode == MissileBase.TargetingModes.Radar)
-                    {
-                        List<ModuleRadar>.Enumerator rd = radars.GetEnumerator();
-                        while (rd.MoveNext())
-                        {
-                            if (rd.Current == null) continue;
-                            if (!rd.Current.canLock) continue;
-                            rd.Current.EnableRadar();
-                            break;
-                        }
-                        rd.Dispose();
-                    }
-
-                    // check DLZ
-                    MissileLaunchParams dlz = MissileLaunchParams.GetDynamicLaunchParams(ml, guardTarget.Velocity(), guardTarget.transform.position);
-                    if (vessel.srfSpeed > ml.minLaunchSpeed && distanceToTarget < dlz.maxLaunchRange && distanceToTarget > dlz.minLaunchRange)
-                    {
-                            return true;
-                    }
-                    if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                    {
-                        Debug.Log("[BDArmory] : " + vessel.vesselName + " - Failed DLZ test: " + weaponCandidate.GetShortName());
-                    }
-                    break;
-
-
-                case WeaponClasses.Bomb:
-                    if (!vessel.LandedOrSplashed)
-                        return true;    // TODO: bomb always allowed?
-                    break;
-
-
-                case WeaponClasses.Rocket:
-                    RocketLauncher rocketlauncher = (RocketLauncher)weaponCandidate;
-                    // check yaw range of turret
-                    turret = rocketlauncher.turret;
-                    gimbalTolerance = vessel.LandedOrSplashed ? 0 : 15;
-                    if (turret != null)
-                        if (TargetInTurretRange(turret, gimbalTolerance))
-                            return true;
-                    break;
-
-                case WeaponClasses.SLW:
-                    return true;                    
-
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }                  
-
-            return false;
-        }
-        
-        void SetTarget(TargetInfo target)
-        {
-            if (target)
-            {
-                if (currentTarget)
-                {
-                    currentTarget.Disengage(this);
-                }
-                target.Engage(this);
-                currentTarget = target;
-                guardTarget = target.Vessel;
-            }
-            else
-            {
-                if (currentTarget)
-                {
-                    currentTarget.Disengage(this);
-                }
-                guardTarget = null;
-                currentTarget = null;
-            }
-        }
-
-        #endregion
-
-        public bool CanSeeTarget(TargetInfo target)
-        {
-            // fix cheating: we can see a target IF we either have a visual on it, OR it has been detected on radar/sonar
-            // but to prevent AI from stopping an engagement just because a target dropped behind a small hill 5 seconds ago, clamp the timeout to 30 seconds
-            // i.e. let's have at least some object permanence :)
-            // (Ideally, I'd love to have "stale targets", where AI would attack the last known position, but that's a feature for the future)
-            if (Time.time - target.detectedTime < Mathf.Max(targetScanInterval, 30))
-                return true;
-
-            // can we get a visual sight of the target?
-            if ((target.Vessel.transform.position - transform.position).sqrMagnitude < guardRange*guardRange)
-            {
-                if (RadarUtils.TerrainCheck(target.Vessel.transform.position, transform.position))
-                {
-                    return false;
-                }
-
-                return true;
-            }
-
-            return false;
-        }
-
-
-        /// <summary>
-        /// Override for legacy targeting only! Remove when removing legcy mode!
-        /// </summary>
-        /// <param name="target"></param>
-        /// <returns></returns>
-        public bool CanSeeTarget(Vessel target)
-        {
-            // can we get a visual sight of the target?
-            if ((target.transform.position - transform.position).sqrMagnitude < guardRange * guardRange)
-            {
-                if (RadarUtils.TerrainCheck(target.transform.position, transform.position))
-                {
-                    return false;
-                }
-
-                return true;
-            }
-
-            return false;
-        }
-
-
-        void ScanAllTargets()
-        {
-            //get a target.
-            //float angle = 0;
-            List<Vessel>.Enumerator v = FlightGlobals.Vessels.GetEnumerator();
-            while (v.MoveNext())
-            {
-                if (v.Current == null) continue;
-                if (!v.Current.loaded) continue;
-                float distance = (transform.position - v.Current.transform.position).sqrMagnitude;
-                if (!(distance < guardRange*guardRange) || !CanSeeTarget(v.Current)) continue;
-                float angle = Vector3.Angle(-transform.forward, v.Current.transform.position - transform.position);
-                if (!(angle < guardAngle / 2)) continue;
-                List<MissileBase>.Enumerator missile = v.Current.FindPartModulesImplementing<MissileBase>().GetEnumerator();
-                while (missile.MoveNext())
-                {
-                    if (missile.Current == null) continue;
-                    if (!missile.Current.HasFired || missile.Current.Team == team) continue;
-                    BDATargetManager.ReportVessel(v.Current, this);
-                    if (!isFlaring && missile.Current.TargetingMode == MissileBase.TargetingModes.Heat && Vector3.Angle(missile.Current.GetForwardTransform(), transform.position - missile.Current.transform.position) < 20)
-                    {
-                        StartCoroutine(FlareRoutine(targetScanInterval * 0.75f));
-                    }
-                    break;
-                }
-                missile.Dispose();
-
-                List<MissileFire>.Enumerator mF = v.Current.FindPartModulesImplementing<MissileFire>().GetEnumerator();
-                while (mF.MoveNext())
-                {
-                    if (mF.Current == null) continue;
-                    if (mF.Current.team == team || !mF.Current.vessel.IsControllable || !mF.Current.vessel.isCommandable) continue;
-                    BDATargetManager.ReportVessel(v.Current, this);
-                    break;
-                }
-                mF.Dispose();
-            }
-            v.Dispose();
-        }
-
-        void SearchForRadarSource()
-        {
-            antiRadTargetAcquired = false;
-
-            if (rwr && rwr.rwrEnabled)
-            {
-                float closestAngle = 360;
-                MissileBase missile = CurrentMissile;
-
-                if (!missile) return;
-
-                float maxOffBoresight = missile.maxOffBoresight;
-
-                if (missile.TargetingMode != MissileBase.TargetingModes.AntiRad) return;
-
-                for (int i = 0; i < rwr.pingsData.Length; i++)
-                {
-                    if (rwr.pingsData[i].exists && (rwr.pingsData[i].signalStrength == 0 || rwr.pingsData[i].signalStrength == 5))
-                    {
-                        float angle = Vector3.Angle(rwr.pingWorldPositions[i] - missile.transform.position, missile.GetForwardTransform());
-
-                        if (angle < closestAngle && angle < maxOffBoresight)
-                        {
-                            closestAngle = angle;
-                            antiRadiationTarget = rwr.pingWorldPositions[i];
-                            antiRadTargetAcquired = true;
-                        }
-                    }
-                }
-            }
-        }
-
-        void SearchForLaserPoint()
-        {
-            MissileBase ml = CurrentMissile;
-            if (!ml || ml.TargetingMode != MissileBase.TargetingModes.Laser)
-            {
-                return;
-            }
-
-            MissileLauncher launcher = ml as MissileLauncher;
-            if (launcher != null)
-            {
-                foundCam = BDATargetManager.GetLaserTarget(launcher,
-                    launcher.GuidanceMode == MissileBase.GuidanceModes.BeamRiding);
-            }
-            else
-            {
-                foundCam = BDATargetManager.GetLaserTarget((BDModularGuidance)ml, false);
-            }
-
-            if (foundCam)
-            {
-                laserPointDetected = true;
-            }
-            else
-            {
-                laserPointDetected = false;
-            }
-        }
-
-        void SearchForHeatTarget()
-        {
-            if (CurrentMissile != null)
-            {
-                if (!CurrentMissile || CurrentMissile.TargetingMode != MissileBase.TargetingModes.Heat)
-                {
-                    return;
-                }
-
-                float scanRadius = CurrentMissile.lockedSensorFOV * 2;
-                float maxOffBoresight = CurrentMissile.maxOffBoresight * 0.85f;
-
-                if (vesselRadarData && vesselRadarData.locked)
-                {
-                    heatTarget = vesselRadarData.lockedTargetData.targetData;
-                }
-
-                Vector3 direction =
-                    heatTarget.exists && Vector3.Angle(heatTarget.position - CurrentMissile.MissileReferenceTransform.position, CurrentMissile.GetForwardTransform()) < maxOffBoresight ?
-                    heatTarget.predictedPosition - CurrentMissile.MissileReferenceTransform.position
-                    : CurrentMissile.GetForwardTransform();
-
-                heatTarget = BDATargetManager.GetHeatTarget(new Ray(CurrentMissile.MissileReferenceTransform.position + (50 * CurrentMissile.GetForwardTransform()), direction), scanRadius, CurrentMissile.heatThreshold, CurrentMissile.allAspect, this);
-            }
-        }
-
-        bool CrossCheckWithRWR(TargetInfo v)
-        {
-            bool matchFound = false;
-            if (rwr && rwr.rwrEnabled)
-            {
-                for (int i = 0; i < rwr.pingsData.Length; i++)
-                {
-                    if (rwr.pingsData[i].exists && (rwr.pingWorldPositions[i] - v.position).sqrMagnitude < 20*20)
-                    {
-                        matchFound = true;
-                        break;
-                    }
-                }
-            }
-
-            return matchFound;
-        }
-                
-        public void SendTargetDataToMissile(MissileBase ml)
-        { //TODO BDModularGuidance: implement all targetings on base
-            if (ml.TargetingMode == MissileBase.TargetingModes.Laser && laserPointDetected)
-            {
-                ml.lockedCamera = foundCam;
-            }
-            else if (ml.TargetingMode == MissileBase.TargetingModes.Gps)
-            {
-                if (BDArmorySettings.ALLOW_LEGACY_TARGETING)
-                {
-                    if (vessel.targetObject != null && vessel.targetObject.GetVessel() != null)
-                    {
-                        ml.TargetAcquired = true;
-                        ml.legacyTargetVessel = vessel.targetObject.GetVessel();
-                    }
-                }
-                else if (designatedGPSCoords != Vector3d.zero)
-                {
-                    ml.targetGPSCoords = designatedGPSCoords;
-                    ml.TargetAcquired = true;
-                }
-
-            }
-            else if (ml.TargetingMode == MissileBase.TargetingModes.Heat && heatTarget.exists)
-            {
-
-                ml.heatTarget = heatTarget;
-                heatTarget = TargetSignatureData.noTarget;
-
-            }
-            else if (ml.TargetingMode == MissileBase.TargetingModes.Radar && vesselRadarData && vesselRadarData.locked)//&& radar && radar.lockedTarget.exists)
-            {                
-                ml.radarTarget = vesselRadarData.lockedTargetData.targetData;
-                ml.vrd = vesselRadarData;
-                vesselRadarData.LastMissile = ml;
-            }
-            else if (ml.TargetingMode == MissileBase.TargetingModes.AntiRad && antiRadTargetAcquired)
-            {
-                ml.TargetAcquired = true;
-                ml.targetGPSCoords = VectorUtils.WorldPositionToGeoCoords(antiRadiationTarget,
-                        vessel.mainBody);
-            }
-        }
-
-        public void TargetAcquire()
-        {
-            if (!isArmed || !BDArmorySettings.ALLOW_LEGACY_TARGETING) return;
-            Vessel acquiredTarget = null;
-            float smallestAngle = 8;
-
-            if (Time.time - targetListTimer > 1)
-            {
-                loadedVessels.Clear();
-                List<Vessel>.Enumerator v = FlightGlobals.Vessels.GetEnumerator();
-                while (v.MoveNext())
-                {
-                    if (v.Current == null) continue;
-                    float viewAngle = Vector3.Angle(-transform.forward, v.Current.transform.position - transform.position);
-                    if (!v.Current.loaded || !(viewAngle < smallestAngle)) continue;
-                    if (!v.Current.vesselName.Contains("(fired)")) loadedVessels.Add(v.Current);
-                }
-                v.Dispose();
-            }
-
-            List<Vessel>.Enumerator vl = loadedVessels.GetEnumerator();
-            while (vl.MoveNext())
-            {
-                if (vl.Current == null) continue;
-                float viewAngle = Vector3.Angle(-transform.forward, vl.Current.transform.position - transform.position);
-                //if(vl.Current!= vessel && vl.Current.loaded) Debug.Log ("view angle: " + viewAngle);
-                if (vl.Current == vessel || !vl.Current.loaded || !(viewAngle < smallestAngle) ||
-                    !CanSeeTarget(vl.Current)) continue;
-                acquiredTarget = vl.Current;
-                smallestAngle = viewAngle;
-            }
-            vl.Dispose();
-
-            if (acquiredTarget == null || acquiredTarget == (Vessel) FlightGlobals.fetch.VesselTarget) return;
-            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-            {
-                Debug.Log("[BDArmory]: found target! : " + acquiredTarget.name);
-            }
-            FlightGlobals.fetch.SetVesselTarget(acquiredTarget);
-        }
-
-        #endregion
-
-        #region Guard
-
-        public void ResetGuardInterval()
-        {
-            targetScanTimer = 0;
-        }
-
-        void GuardMode()
-        {
-            if (!gameObject.activeInHierarchy) return;
-            if (BDArmorySettings.PEACE_MODE) return;
-
-            if (!BDArmorySettings.ALLOW_LEGACY_TARGETING)
-            {
-                UpdateGuardViewScan();
-            }
-
-            //setting turrets to guard mode
-            if (selectedWeapon != null && selectedWeapon.GetWeaponClass() == WeaponClasses.Gun)
-            {
-                //make this not have to go every frame
-                List<ModuleWeapon>.Enumerator weapon = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
-                while (weapon.MoveNext())
-                {
-                    if (weapon.Current == null) continue;
+				while (weapon.MoveNext())
+				{
+					if (weapon.Current == null) continue;
+					// set the weapon ripple index just before we increment rippleGunCount.
+					weapon.Current.rippleIndex = rippleGunCount;
+					//set the time delay for moving to next index
+					weapon.Current.initialFireDelay = timeDelayPerGun;
+					weapon.Current.useRippleFire = ro.rippleFire;
+					rippleGunCount++;
+				}
+				weapon.Dispose();
+			}
+
+			ToggleTurret();
+			SetMissileTurrets();
+			SetRotaryRails();
+		}
+
+		private bool SetCargoBays()
+		{
+			if (!guardMode) return false;
+			bool openingBays = false;
+
+			if (weaponIndex > 0 && CurrentMissile && guardTarget && Vector3.Dot(guardTarget.transform.position - CurrentMissile.transform.position, CurrentMissile.GetForwardTransform()) > 0)
+			{
+				if (CurrentMissile.part.ShieldedFromAirstream)
+				{
+					List<MissileBase>.Enumerator ml = vessel.FindPartModulesImplementing<MissileBase>().GetEnumerator();
+					while (ml.MoveNext())
+					{
+						if (ml.Current == null) continue;
+						if (ml.Current.part.ShieldedFromAirstream) ml.Current.inCargoBay = true;
+					}
+					ml.Dispose();
+				}
+
+				if (CurrentMissile.inCargoBay)
+				{
+					List<ModuleCargoBay>.Enumerator bay = vessel.FindPartModulesImplementing<ModuleCargoBay>().GetEnumerator();
+					while (bay.MoveNext())
+					{
+						if (bay.Current == null) continue;
+						if (CurrentMissile.part.airstreamShields.Contains(bay.Current))
+						{
+							ModuleAnimateGeneric anim = bay.Current.part.Modules.GetModule(bay.Current.DeployModuleIndex) as ModuleAnimateGeneric;
+							if (anim == null) continue;
+
+							string toggleOption = anim.Events["Toggle"].guiName;
+							if (toggleOption == "Open")
+							{
+								if (anim)
+								{
+									anim.Toggle();
+									openingBays = true;
+								}
+							}
+						}
+						else
+						{
+							ModuleAnimateGeneric anim =
+								bay.Current.part.Modules.GetModule(bay.Current.DeployModuleIndex) as ModuleAnimateGeneric;
+							if (anim == null) continue;
+
+							string toggleOption = anim.Events["Toggle"].guiName;
+							if (toggleOption == "Close")
+							{
+								if (anim)
+								{
+									anim.Toggle();
+								}
+							}
+						}
+					}
+					bay.Dispose();
+				}
+				else
+				{
+					List<ModuleCargoBay>.Enumerator bay = vessel.FindPartModulesImplementing<ModuleCargoBay>().GetEnumerator();
+					while (bay.MoveNext())
+					{
+						if (bay.Current == null) continue;
+						ModuleAnimateGeneric anim =
+							bay.Current.part.Modules.GetModule(bay.Current.DeployModuleIndex) as ModuleAnimateGeneric;
+						if (anim == null) continue;
+
+						string toggleOption = anim.Events["Toggle"].guiName;
+						if (toggleOption == "Close")
+						{
+							if (anim)
+							{
+								anim.Toggle();
+							}
+						}
+					}
+					bay.Dispose();
+				}
+			}
+			else
+			{
+				List<ModuleCargoBay>.Enumerator bay = vessel.FindPartModulesImplementing<ModuleCargoBay>().GetEnumerator();
+				while (bay.MoveNext())
+				{
+					if (bay.Current == null) continue;
+					ModuleAnimateGeneric anim = bay.Current.part.Modules.GetModule(bay.Current.DeployModuleIndex) as ModuleAnimateGeneric;
+					if (anim == null) continue;
+
+					string toggleOption = anim.Events["Toggle"].guiName;
+					if (toggleOption == "Close")
+					{
+						if (anim)
+						{
+							anim.Toggle();
+						}
+					}
+				}
+				bay.Dispose();
+			}
+
+			return openingBays;
+		}
+
+		void SetRotaryRails()
+		{
+			if (weaponIndex == 0) return;
+
+			if (selectedWeapon == null) return;
+
+			if (
+				!(selectedWeapon.GetWeaponClass() == WeaponClasses.Missile ||
+				  selectedWeapon.GetWeaponClass() == WeaponClasses.Bomb ||
+				  selectedWeapon.GetWeaponClass() == WeaponClasses.SLW)) return;
+
+			if (!CurrentMissile) return;
+
+			//TODO BDModularGuidance: Rotatory Rail?
+			MissileLauncher cm = CurrentMissile as MissileLauncher;
+			if (cm == null) return;
+			List<BDRotaryRail>.Enumerator rotRail = vessel.FindPartModulesImplementing<BDRotaryRail>().GetEnumerator();
+			while (rotRail.MoveNext())
+			{
+				if (rotRail.Current == null) continue;
+				if (rotRail.Current.missileCount == 0)
+				{
+					//Debug.Log("SetRotaryRails(): rail has no missiles");
+					continue;
+				}
+
+				//Debug.Log("[BDArmory]: SetRotaryRails(): rotRail.Current.readyToFire: " + rotRail.Current.readyToFire + ", rotRail.Current.readyMissile: " + ((rotRail.Current.readyMissile != null) ? rotRail.Current.readyMissile.part.name : "null") + ", rotRail.Current.nextMissile: " + ((rotRail.Current.nextMissile != null) ? rotRail.Current.nextMissile.part.name : "null"));
+
+				//Debug.Log("[BDArmory]: current missile: " + cm.part.name);
+
+				if (rotRail.Current.readyToFire)
+				{
+					if (!rotRail.Current.readyMissile)
+					{
+						rotRail.Current.RotateToMissile(cm);
+						return;
+					}
+
+					if (rotRail.Current.readyMissile.part.name != cm.part.name)
+					{
+						rotRail.Current.RotateToMissile(cm);
+					}
+				}
+				else
+				{
+					if (!rotRail.Current.nextMissile)
+					{
+						rotRail.Current.RotateToMissile(cm);
+					}
+					else if (rotRail.Current.nextMissile.part.name != cm.part.name)
+					{
+						rotRail.Current.RotateToMissile(cm);
+					}
+				}
+			}
+			rotRail.Dispose();
+		}
+
+		void SetMissileTurrets()
+		{
+			MissileLauncher cm = CurrentMissile as MissileLauncher;
+			if (cm == null) return;
+			List<MissileTurret>.Enumerator mt = vessel.FindPartModulesImplementing<MissileTurret>().GetEnumerator();
+			while (mt.MoveNext())
+			{
+				if (mt.Current == null) continue;
+				if (weaponIndex > 0 && cm && mt.Current.ContainsMissileOfType(cm))
+				{
+					if (!mt.Current.activeMissileOnly || cm.missileTurret == mt.Current)
+					{
+						mt.Current.EnableTurret();
+					}
+					else
+					{
+						mt.Current.DisableTurret();
+					}
+				}
+				else
+				{
+					mt.Current.DisableTurret();
+				}
+			}
+			mt.Dispose();
+		}
+
+		public void CycleWeapon(bool forward)
+		{
+			if (forward) weaponIndex++;
+			else weaponIndex--;
+			weaponIndex = (int)Mathf.Repeat(weaponIndex, weaponArray.Length);
+
+			hasSingleFired = true;
+			triggerTimer = 0;
+
+			UpdateList();
+
+			DisplaySelectedWeaponMessage();
+
+			if (vessel.isActiveVessel && !guardMode)
+			{
+				audioSource.PlayOneShot(clickSound);
+			}
+		}
+
+		public void CycleWeapon(int index)
+		{
+			if (index >= weaponArray.Length)
+			{
+				index = 0;
+			}
+			weaponIndex = index;
+
+			UpdateList();
+
+			if (vessel.isActiveVessel && !guardMode)
+			{
+				audioSource.PlayOneShot(clickSound);
+
+				DisplaySelectedWeaponMessage();
+			}
+		}
+
+		public Part FindSym(Part p)
+		{
+			List<Part>.Enumerator pSym = p.symmetryCounterparts.GetEnumerator();
+			while (pSym.MoveNext())
+			{
+				if (pSym.Current == null) continue;
+				if (pSym.Current != p && pSym.Current.vessel == vessel)
+				{
+					return pSym.Current;
+				}
+			}
+			pSym.Dispose();
+
+			return null;
+		}
+
+		private MissileBase GetAsymMissile()
+		{
+			if (weaponIndex == 0) return null;
+			if (weaponArray[weaponIndex].GetWeaponClass() == WeaponClasses.Bomb ||
+				weaponArray[weaponIndex].GetWeaponClass() == WeaponClasses.Missile ||
+				weaponArray[weaponIndex].GetWeaponClass() == WeaponClasses.SLW)
+			{
+				MissileBase firstMl = null;
+				List<MissileBase>.Enumerator ml = vessel.FindPartModulesImplementing<MissileBase>().GetEnumerator();
+				while (ml.MoveNext())
+				{
+					if (ml.Current == null) continue;
+					MissileLauncher launcher = ml.Current as MissileLauncher;
+					if (launcher != null)
+					{
+						if (launcher.part.name != weaponArray[weaponIndex].GetPart()?.name) continue;
+					}
+					else
+					{
+						BDModularGuidance guidance = ml.Current as BDModularGuidance;
+						if (guidance != null)
+						{ //We have set of parts not only a part
+							if (guidance.GetShortName() != weaponArray[weaponIndex]?.GetShortName()) continue;
+						}
+					}
+					if (firstMl == null) firstMl = ml.Current;
+
+					if (!FindSym(ml.Current.part))
+					{
+						return ml.Current;
+					}
+				}
+				ml.Dispose();
+				return firstMl;
+			}
+			return null;
+		}
+
+		private MissileBase GetRotaryReadyMissile()
+		{
+			if (weaponIndex == 0) return null;
+			if (weaponArray[weaponIndex].GetWeaponClass() == WeaponClasses.Bomb ||
+				weaponArray[weaponIndex].GetWeaponClass() == WeaponClasses.Missile ||
+				weaponArray[weaponIndex].GetWeaponClass() == WeaponClasses.SLW)
+			{
+				//TODO BDModularGuidance: Implemente rotaryRail support
+				MissileLauncher missile = CurrentMissile as MissileLauncher;
+				if (missile == null) return null;
+				if (missile && missile.part.name == weaponArray[weaponIndex].GetPart().name)
+				{
+					if (!missile.rotaryRail)
+					{
+						return missile;
+					}
+					if (missile.rotaryRail.readyToFire && missile.rotaryRail.readyMissile == CurrentMissile)
+					{
+						return missile;
+					}
+				}
+				List<MissileLauncher>.Enumerator ml = vessel.FindPartModulesImplementing<MissileLauncher>().GetEnumerator();
+				while (ml.MoveNext())
+				{
+					if (ml.Current == null) continue;
+					if (ml.Current.part.name != weaponArray[weaponIndex].GetPart().name) continue;
+
+					if (!ml.Current.rotaryRail)
+					{
+						return ml.Current;
+					}
+					if (ml.Current.rotaryRail.readyToFire && ml.Current.rotaryRail.readyMissile.part.name == weaponArray[weaponIndex].GetPart().name)
+					{
+						return ml.Current.rotaryRail.readyMissile;
+					}
+				}
+				ml.Dispose();
+				return null;
+			}
+			return null;
+		}
+
+		bool CheckBombClearance(MissileBase ml)
+		{
+			if (!BDArmorySettings.BOMB_CLEARANCE_CHECK) return true;
+
+			if (ml.part.ShieldedFromAirstream)
+			{
+				return false;
+			}
+
+			//TODO BDModularGuidance: Bombs and turrents
+			MissileLauncher launcher = ml as MissileLauncher;
+			if (launcher != null)
+			{
+				if (launcher.rotaryRail && launcher.rotaryRail.readyMissile != ml)
+				{
+					return false;
+				}
+
+				if (launcher.missileTurret && !launcher.missileTurret.turretEnabled)
+				{
+					return false;
+				}
+
+				if (ml.dropTime > 0.3f)
+				{
+					//debug lines
+					LineRenderer lr = null;
+					if (BDArmorySettings.DRAW_DEBUG_LINES && BDArmorySettings.DRAW_AIMERS)
+					{
+						lr = GetComponent<LineRenderer>();
+						if (!lr)
+						{
+							lr = gameObject.AddComponent<LineRenderer>();
+						}
+						lr.enabled = true;
+						lr.startWidth = .1f;
+						lr.endWidth = .1f;
+					}
+					else
+					{
+						if (gameObject.GetComponent<LineRenderer>())
+						{
+							gameObject.GetComponent<LineRenderer>().enabled = false;
+						}
+					}
+
+
+					float radius = 0.28f / 2;
+					float time = ml.dropTime;
+					Vector3 direction = ((launcher.decoupleForward
+						? ml.MissileReferenceTransform.transform.forward
+						: -ml.MissileReferenceTransform.transform.up) * launcher.decoupleSpeed * time) +
+										((FlightGlobals.getGeeForceAtPosition(transform.position) - vessel.acceleration) *
+										 0.5f * time * time);
+					Vector3 crossAxis = Vector3.Cross(direction, ml.GetForwardTransform()).normalized;
+
+					float rayDistance;
+					if (launcher.thrust == 0 || launcher.cruiseThrust == 0)
+					{
+						rayDistance = 8;
+					}
+					else
+					{
+						//distance till engine starts based on grav accel and vessel accel
+						rayDistance = direction.magnitude;
+					}
+
+					Ray[] rays =
+					{
+						new Ray(ml.MissileReferenceTransform.position - (radius*crossAxis), direction),
+						new Ray(ml.MissileReferenceTransform.position + (radius*crossAxis), direction),
+						new Ray(ml.MissileReferenceTransform.position, direction)
+					};
+
+					if (lr)
+					{
+						lr.useWorldSpace = false;
+						lr.positionCount = 4;
+						lr.SetPosition(0, transform.InverseTransformPoint(rays[0].origin));
+						lr.SetPosition(1, transform.InverseTransformPoint(rays[0].GetPoint(rayDistance)));
+						lr.SetPosition(2, transform.InverseTransformPoint(rays[1].GetPoint(rayDistance)));
+						lr.SetPosition(3, transform.InverseTransformPoint(rays[1].origin));
+					}
+
+					IEnumerator<Ray> rt = rays.AsEnumerable().GetEnumerator();
+					while (rt.MoveNext())
+					{
+						RaycastHit[] hits = Physics.RaycastAll(rt.Current, rayDistance, 557057);
+						IEnumerator<RaycastHit> t1 = hits.AsEnumerable().GetEnumerator();
+						while (t1.MoveNext())
+						{
+							Part p = t1.Current.collider.GetComponentInParent<Part>();
+
+							if ((p == null || p == ml.part) && p != null) continue;
+							if (BDArmorySettings.DRAW_DEBUG_LABELS)
+								Debug.Log("[BDArmory]: RAYCAST HIT, clearance is FALSE! part=" + p?.name + ", collider=" + p?.collider);
+							return false;
+						}
+						t1.Dispose();
+					}
+					rt.Dispose();
+					return true;
+				}
+
+				//forward check for no-drop missiles
+				RaycastHit[] hitparts = Physics.RaycastAll(new Ray(ml.MissileReferenceTransform.position, ml.GetForwardTransform()), 50, 557057);
+				IEnumerator<RaycastHit> t = hitparts.AsEnumerable().GetEnumerator();
+				while (t.MoveNext())
+				{
+					Part p = t.Current.collider.GetComponentInParent<Part>();
+					if ((p == null || p == ml.part) && p != null) continue;
+					if (BDArmorySettings.DRAW_DEBUG_LABELS)
+						Debug.Log("[BDArmory]: RAYCAST HIT, clearance is FALSE! part=" + p?.name + ", collider=" + p?.collider);
+					return false;
+				}
+				t.Dispose();
+			}
+			return true;
+		}
+
+		void RefreshModules()
+		{
+			radars = vessel.FindPartModulesImplementing<ModuleRadar>();
+
+			List<ModuleRadar>.Enumerator rad = radars.GetEnumerator();
+			while (rad.MoveNext())
+			{
+				if (rad.Current == null) continue;
+				rad.Current.EnsureVesselRadarData();
+				if (rad.Current.radarEnabled) rad.Current.EnableRadar();
+			}
+			rad.Dispose();
+
+			jammers = vessel.FindPartModulesImplementing<ModuleECMJammer>();
+			targetingPods = vessel.FindPartModulesImplementing<ModuleTargetingCamera>();
+			wmModules = vessel.FindPartModulesImplementing<IBDWMModule>();
+		}
+
+		#endregion
+
+		#region Weapon Choice
+
+		bool TryPickAntiRad(TargetInfo target)
+		{
+			CycleWeapon(0); //go to start of array
+			while (true)
+			{
+				CycleWeapon(true);
+				if (selectedWeapon == null) return false;
+				if (selectedWeapon.GetWeaponClass() != WeaponClasses.Missile) continue;
+				List<MissileBase>.Enumerator ml = selectedWeapon.GetPart().FindModulesImplementing<MissileBase>().GetEnumerator();
+				while (ml.MoveNext())
+				{
+					if (ml.Current == null) continue;
+					if (ml.Current.TargetingMode == MissileBase.TargetingModes.AntiRad)
+					{
+						return true;
+					}
+					break;
+				}
+				ml.Dispose();
+				//return;
+			}
+		}
+		#endregion
+
+		#region Targeting
+
+		#region Smart Targeting
+
+		void SmartFindTarget()
+		{
+			List<TargetInfo> targetsTried = new List<TargetInfo>();
+
+			if (overrideTarget) //begin by checking the override target, since that takes priority
+			{
+				targetsTried.Add(overrideTarget);
+				SetTarget(overrideTarget);
+				if (SmartPickWeapon_EngagementEnvelope(overrideTarget))
+				{
+					if (BDArmorySettings.DRAW_DEBUG_LABELS)
+					{
+						Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging an override target with " + selectedWeapon);
+					}
+					overrideTimer = 15f;
+					return;
+				}
+				else if (BDArmorySettings.DRAW_DEBUG_LABELS)
+				{
+					Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging an override target with failed to engage its override target!");
+				}
+			}
+			overrideTarget = null; //null the override target if it cannot be used
+
+			//if AIRBORNE, try to engage airborne target first
+			if (!vessel.LandedOrSplashed && !targetMissiles)
+			{
+				if (pilotAI && pilotAI.IsExtending)
+				{
+					TargetInfo potentialAirTarget = BDATargetManager.GetAirToAirTargetAbortExtend(this, 1500, 0.2f);
+					if (potentialAirTarget)
+					{
+						targetsTried.Add(potentialAirTarget);
+						SetTarget(potentialAirTarget);
+						if (SmartPickWeapon_EngagementEnvelope(potentialAirTarget))
+						{
+							if (BDArmorySettings.DRAW_DEBUG_LABELS)
+							{
+								Debug.Log("[BDArmory]: " + vessel.vesselName + " is aborting extend and engaging an incoming airborne target with " + selectedWeapon);
+							}
+							return;
+						}
+					}
+				}
+				else
+				{
+					TargetInfo potentialAirTarget = BDATargetManager.GetAirToAirTarget(this);
+					if (potentialAirTarget)
+					{
+						targetsTried.Add(potentialAirTarget);
+						SetTarget(potentialAirTarget);
+						if (SmartPickWeapon_EngagementEnvelope(potentialAirTarget))
+						{
+							if (BDArmorySettings.DRAW_DEBUG_LABELS)
+							{
+								Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging an airborne target with " + selectedWeapon);
+							}
+							return;
+						}
+					}
+				}
+			}
+
+			TargetInfo potentialTarget = null;
+			//=========HIGH PRIORITY MISSILES=============
+			//first engage any missiles targeting this vessel
+			potentialTarget = BDATargetManager.GetMissileTarget(this, true);
+			if (potentialTarget)
+			{
+				targetsTried.Add(potentialTarget);
+				SetTarget(potentialTarget);
+				if (SmartPickWeapon_EngagementEnvelope(potentialTarget))
+				{
+					if (BDArmorySettings.DRAW_DEBUG_LABELS)
+					{
+						Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging incoming missile with " + selectedWeapon);
+					}
+					return;
+				}
+			}
+
+			//then engage any missiles that are not engaged
+			potentialTarget = BDATargetManager.GetUnengagedMissileTarget(this);
+			if (potentialTarget)
+			{
+				targetsTried.Add(potentialTarget);
+				SetTarget(potentialTarget);
+				if (SmartPickWeapon_EngagementEnvelope(potentialTarget))
+				{
+					if (BDArmorySettings.DRAW_DEBUG_LABELS)
+					{
+						Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging unengaged missile with " + selectedWeapon);
+					}
+					return;
+				}
+			}
+
+
+			//=========END HIGH PRIORITY MISSILES=============
+
+			//============VESSEL THREATS============
+			if (!targetMissiles)
+			{
+				//then try to engage enemies with least friendlies already engaging them 
+				potentialTarget = BDATargetManager.GetLeastEngagedTarget(this);
+				if (potentialTarget)
+				{
+					targetsTried.Add(potentialTarget);
+					SetTarget(potentialTarget);
+					if (!BDArmorySettings.ALLOW_LEGACY_TARGETING)
+					{
+						if (CrossCheckWithRWR(potentialTarget) && TryPickAntiRad(potentialTarget))
+						{
+							if (BDArmorySettings.DRAW_DEBUG_LABELS)
+							{
+								Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging the least engaged radar target with " +
+										  selectedWeapon.GetShortName());
+							}
+							return;
+						}
+					}
+					if (SmartPickWeapon_EngagementEnvelope(potentialTarget))
+					{
+						if (BDArmorySettings.DRAW_DEBUG_LABELS)
+						{
+							Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging the least engaged target with " +
+									  selectedWeapon.GetShortName());
+						}
+						return;
+					}
+				}
+
+				//then engage the closest enemy
+				potentialTarget = BDATargetManager.GetClosestTarget(this);
+				if (potentialTarget)
+				{
+					targetsTried.Add(potentialTarget);
+					SetTarget(potentialTarget);
+					if (!BDArmorySettings.ALLOW_LEGACY_TARGETING)
+					{
+						if (CrossCheckWithRWR(potentialTarget) && TryPickAntiRad(potentialTarget))
+						{
+							if (BDArmorySettings.DRAW_DEBUG_LABELS)
+							{
+								Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging the closest radar target with " +
+										  selectedWeapon.GetShortName());
+							}
+							return;
+						}
+					}
+					if (SmartPickWeapon_EngagementEnvelope(potentialTarget))
+					{
+						if (BDArmorySettings.DRAW_DEBUG_LABELS)
+						{
+							Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging the closest target with " +
+									  selectedWeapon.GetShortName());
+						}
+						return;
+					}
+				}
+			}
+			//============END VESSEL THREATS============
+
+
+			//============LOW PRIORITY MISSILES=========
+			//try to engage least engaged hostile missiles first
+			potentialTarget = BDATargetManager.GetMissileTarget(this);
+			if (potentialTarget)
+			{
+				targetsTried.Add(potentialTarget);
+				SetTarget(potentialTarget);
+				if (SmartPickWeapon_EngagementEnvelope(potentialTarget))
+				{
+					if (BDArmorySettings.DRAW_DEBUG_LABELS)
+					{
+						Debug.Log("[BDArmory]:" + vessel.vesselName + " is engaging a missile with " + selectedWeapon.GetShortName());
+					}
+					return;
+				}
+			}
+
+			//then try to engage closest hostile missile
+			potentialTarget = BDATargetManager.GetClosestMissileTarget(this);
+			if (potentialTarget)
+			{
+				targetsTried.Add(potentialTarget);
+				SetTarget(potentialTarget);
+				if (SmartPickWeapon_EngagementEnvelope(potentialTarget))
+				{
+					if (BDArmorySettings.DRAW_DEBUG_LABELS)
+					{
+						Debug.Log("[BDArmory]:" + vessel.vesselName + " is engaging a missile with " + selectedWeapon.GetShortName());
+					}
+					return;
+				}
+			}
+			//==========END LOW PRIORITY MISSILES=============
+
+			if (targetMissiles) //NO MISSILES BEYOND THIS POINT//
+			{
+				if (BDArmorySettings.DRAW_DEBUG_LABELS)
+				{
+					Debug.Log("[BDArmory]:" + vessel.vesselName + " is disengaging - no valid weapons");
+				}
+				CycleWeapon(0);
+				SetTarget(null);
+				return;
+			}
+
+			//if nothing works, get all remaining targets and try weapons against them
+			List<TargetInfo>.Enumerator finalTargets = BDATargetManager.GetAllTargetsExcluding(targetsTried, this).GetEnumerator();
+			while (finalTargets.MoveNext())
+			{
+				if (finalTargets.Current == null) continue;
+				SetTarget(finalTargets.Current);
+				if (!SmartPickWeapon_EngagementEnvelope(finalTargets.Current)) continue;
+				if (BDArmorySettings.DRAW_DEBUG_LABELS)
+				{
+					Debug.Log("[BDArmory]: " + vessel.vesselName + " is engaging a final target with " +
+							  selectedWeapon.GetShortName());
+				}
+				return;
+			}
+
+
+			//no valid targets found
+			if (potentialTarget == null || selectedWeapon == null)
+			{
+				if (BDArmorySettings.DRAW_DEBUG_LABELS)
+				{
+					Debug.Log("[BDArmory]: " + vessel.vesselName + " is disengaging - no valid weapons - no valid targets");
+				}
+				CycleWeapon(0);
+				SetTarget(null);
+				if (vesselRadarData && vesselRadarData.locked)
+				{
+					vesselRadarData.UnlockAllTargets();
+				}
+				return;
+			}
+
+			Debug.Log("[BDArmory]: Unhandled target case");
+		}
+
+		// extension for feature_engagementenvelope: new smartpickweapon method
+		bool SmartPickWeapon_EngagementEnvelope(TargetInfo target)
+		{
+			// Part 1: Guard conditions (when not to pick a weapon)
+			// ------
+			if (!target)
+				return false;
+
+			if (AI != null && AI.pilotEnabled && !AI.CanEngage())
+				return false;
+
+			// Part 2: check weapons against individual target types
+			// ------
+
+			float distance = Vector3.Distance(transform.position + vessel.Velocity(), target.position + target.velocity);
+			IBDWeapon targetWeapon = null;
+			float targetWeaponRPM = 0;
+			float targetWeaponTDPS = 0;
+			float targetWeaponImpact = 0;
+			float targetLaserDamage = 0;
+			float targetTraverseSpeed = 0;
+			float targetRange = 0;
+			float targetRocketThrust = 0;
+			float targetRocketPower = 0;
+
+			if (target.isMissile)
+			{
+				// iterate over weaponTypesMissile and pick suitable one based on engagementRange (and dynamic launch zone for missiles)
+				// Prioritize by:
+				// 1. Lasers
+				// 2. Guns
+				// 3. AA missiles
+				List<IBDWeapon>.Enumerator item = weaponTypesMissile.GetEnumerator();
+				while (item.MoveNext())
+				{
+					if (item.Current == null) continue;
+					// candidate, check engagement envelope
+					if (!CheckEngagementEnvelope(item.Current, distance)) continue;
+					// weapon usable, if missile continue looking for lasers/guns, else take it
+					WeaponClasses candidateClass = item.Current.GetWeaponClass();
+
+					if (candidateClass == WeaponClasses.DefenseLaser)
+					{
+						float candidateRange = ((ModuleWeapon)item.Current).engageRangeMax;
+						bool canidateGimbal = ((ModuleWeapon)item.Current).turret;
+						float canidateTraverse = ((ModuleTurret)item.Current).yawRange;
+						float canidateTraverseSpeed = ((ModuleTurret)item.Current).yawSpeedDPS;
+
+						if ((targetWeapon != null) && (canidateGimbal = true && canidateTraverse > 0)) //prioritize turreted lasers
+						{
+							if (targetTraverseSpeed > canidateTraverseSpeed) continue; //with the highest traverse speed
+							targetWeapon = item.Current;
+							targetTraverseSpeed = canidateTraverseSpeed;
+							if (distance <= targetRange)
+								break;
+						}
+						if ((targetWeapon != null) && (targetRange > candidateRange))// else go for longest range
+							continue; 
+							targetRange = candidateRange;
+							if (distance <= targetRange)
+								break;
+					}
+					if (candidateClass == WeaponClasses.Gun)
+					{
+						// For Point Defense, favor turreted high RPM
+						float candidateRPM = ((ModuleWeapon)item.Current).roundsPerMinute;
+						float canidateTraverseSpeed = ((ModuleTurret)item.Current).yawSpeedDPS;
+						float canidateTraverse = ((ModuleTurret)item.Current).yawRange;
+						bool canidateGimbal = ((ModuleWeapon)item.Current).turret;
+
+						if (targetWeapon != null)
+						{
+							if (canidateGimbal = true && canidateTraverse > 0) //prioritize turreted ciws
+							{
+								if ((targetTraverseSpeed > canidateTraverseSpeed) || (targetWeaponRPM > candidateRPM)) continue; //with best traverse speed and RoF
+								targetTraverseSpeed = canidateTraverseSpeed;
+								targetWeaponRPM = candidateRPM;
+								targetWeapon = item.Current;
+							}
+							else
+							{
+								if (targetWeaponRPM > candidateRPM)
+									continue; //dont replace better guns (but do replace missiles)
+								targetWeapon = item.Current;
+								targetWeaponRPM = candidateRPM;
+							}
+						}						
+					}
+
+					if (candidateClass != WeaponClasses.Missile) continue;
+					// TODO: for AA, favour higher thrust+turnDPS
+
+					MissileLauncher mlauncher = item.Current as MissileLauncher;
+					float candidateTDPS = 0f;
+
+					if (mlauncher != null)
+					{
+						candidateTDPS = mlauncher.thrust + mlauncher.maxTurnRateDPS;
+					}
+					else
+					{ //is modular missile
+						BDModularGuidance mm = item.Current as BDModularGuidance;
+						candidateTDPS = 5000;
+					}
+
+					if ((targetWeapon != null) && ((targetWeapon.GetWeaponClass() == WeaponClasses.Gun) || (targetWeaponTDPS > candidateTDPS)))
+						continue; //dont replace guns or better missiles
+
+					targetWeapon = item.Current;
+					targetWeaponTDPS = candidateTDPS;
+				}
+				item.Dispose();
+
+			}
+
+			//else if (!target.isLanded)
+			else if (target.isFlying)
+			{
+				// iterate over weaponTypesAir and pick suitable one based on engagementRange (and dynamic launch zone for missiles)
+				// Prioritize by:
+				// 1. AA missiles, if range > gunRange
+				// 1. Lasers
+				// 2. Guns
+				// 
+				List<IBDWeapon>.Enumerator item = weaponTypesAir.GetEnumerator();
+				while (item.MoveNext())
+				{
+					if (item.Current == null) continue;
+					// candidate, check engagement envelope
+					if (!CheckEngagementEnvelope(item.Current, distance)) continue;
+					// weapon usable, if missile continue looking for lasers/guns, else take it
+					WeaponClasses candidateClass = item.Current.GetWeaponClass();
+
+					if (candidateClass == WeaponClasses.DefenseLaser)
+					{
+						float candidatePower = ((ModuleWeapon)item.Current).laserDamage;
+						bool canidateGimbal = ((ModuleWeapon)item.Current).turret;
+						float canidateTraverse = ((ModuleTurret)item.Current).yawRange;
+						float canidateTraverseSpeed = ((ModuleTurret)item.Current).yawSpeedDPS;
+
+						if ((targetWeapon != null) && (canidateGimbal = true && canidateTraverse > 0))
+						{
+							candidatePower *= 1.5f; // weight selection towards turreted lasers
+						}
+						if ((targetWeapon != null) && (targetLaserDamage > candidatePower))
+							continue; //don't replace more powerful lasers
+						targetWeapon = item.Current;
+						targetLaserDamage = candidatePower;
+						if (distance <= gunRange)
+							break;
+					}
+					if (candidateClass == WeaponClasses.Gun)
+					{
+						// For AAA, favour higher RPM
+						float candidateRPM = ((ModuleWeapon)item.Current).roundsPerMinute;
+						bool canidateFuzed = ((ModuleWeapon)item.Current).proximityDetonation;
+						if (targetWeapon != null && canidateFuzed)
+						{
+							candidateRPM *= 1.25f; // weight selection towards fuzed rounds
+						}
+						if ((targetWeapon != null) && (targetWeaponRPM > candidateRPM))
+							continue; //dont replace better guns (but do replace missiles)
+
+						targetWeapon = item.Current;
+						targetWeaponRPM = candidateRPM;
+					}
+					if (candidateClass == WeaponClasses.Rocket)
+					{
+						float canidateRocketThrust = ((((ModuleWeapon)item.Current).thrust) / (((ModuleWeapon)item.Current).rocketMass));
+						bool canidateFuzed = ((ModuleWeapon)item.Current).proximityDetonation;
+						if ((targetWeapon != null) && (targetWeapon.GetWeaponClass() == WeaponClasses.Gun))
+							// dont replace guns
+							continue;
+						else
+						if (targetWeapon != null && canidateFuzed)
+						{
+							canidateRocketThrust *= 1.5f; // weight selection towards proximity warheads
+						}
+						if ((targetWeapon != null) && (targetRocketThrust > canidateRocketThrust))
+							continue; //don't replace faster rockets
+						targetWeapon = item.Current;
+						targetRocketThrust = canidateRocketThrust;
+					}
+					if (candidateClass != WeaponClasses.Missile) continue;
+					MissileLauncher mlauncher = item.Current as MissileLauncher;
+					float candidateTDPS = 0f;
+
+					if (mlauncher != null)
+					{
+						candidateTDPS = mlauncher.thrust + mlauncher.maxTurnRateDPS;
+					}
+					else
+					{ //is modular missile
+						BDModularGuidance mm = item.Current as BDModularGuidance;
+						candidateTDPS = 5000;
+					}
+
+					if (targetWeapon == null)
+					{
+						targetWeapon = item.Current;
+						targetWeaponTDPS = candidateTDPS;
+					}
+					else if (distance > gunRange)
+					{
+						if ((targetWeapon.GetWeaponClass() == WeaponClasses.Gun || targetWeapon.GetWeaponClass() == WeaponClasses.Rocket) || targetWeaponTDPS > candidateTDPS)
+							continue; //dont replace guns or better missiles
+
+						targetWeapon = item.Current;
+						targetWeaponTDPS = candidateTDPS;
+					}
+				}
+				item.Dispose();
+			}
+
+			else if (target.isLanded)
+			{
+				// iterate over weaponTypesGround and pick suitable one based on engagementRange (and dynamic launch zone for missiles)
+				// Prioritize by:
+				// 1. ground attack missiles (cruise, gps, unguided) if target not moving
+				// 2. ground attack missiles (guided) if target is moving
+				// 3. Bombs / Rockets
+				// 4. Guns
+				List<IBDWeapon>.Enumerator item = weaponTypesGround.GetEnumerator();
+				while (item.MoveNext())
+				{
+					if (item.Current == null) continue;
+					// candidate, check engagement envelope
+					if (!CheckEngagementEnvelope(item.Current, distance)) continue;
+					// weapon usable, if missile continue looking for lasers/guns, else take it
+					WeaponClasses candidateClass = item.Current.GetWeaponClass();
+
+					if (candidateClass == WeaponClasses.Missile)
+					{
+						// TODO: compare missiles which one is better for ground attack
+						// Priority Sequence:
+						// - Antiradiation
+						// - guided missiles
+						// - by blast strength
+						targetWeapon = item.Current;
+						if (distance > gunRange)
+							break;  //definitely use missiles
+					}
+
+					if (candidateClass == WeaponClasses.Bomb)
+					{
+						// only useful if we are flying
+						if (!vessel.LandedOrSplashed)
+						{
+							if ((targetWeapon != null) && (targetWeapon.GetWeaponClass() == WeaponClasses.Bomb))
+								// dont replace bombs
+								break;
+							else
+								// TODO: compare bombs which one is better for ground attack
+								// Priority Sequence:
+								// - guided (JDAM)
+								// - by blast strength
+								targetWeapon = item.Current;
+						}
+					}
+					if (candidateClass == WeaponClasses.Rocket)
+					{
+						float canidateRocketPower = ((ModuleWeapon)item.Current).blastForce;
+						
+						if ((targetWeapon != null) && (targetWeapon.GetWeaponClass() == WeaponClasses.Bomb))
+							// dont replace bombs
+							continue;
+						else
+
+						if ((targetWeapon != null) && (targetRocketPower > canidateRocketPower))
+							continue; //don't replace faster rockets
+						targetWeapon = item.Current;
+						targetRocketPower = canidateRocketPower;
+					}
+
+					if ((candidateClass != WeaponClasses.Gun)) continue;
+					// Flying: prefer bombs/rockets/missiles
+					if (!vessel.LandedOrSplashed)
+						if (targetWeapon != null)
+							// dont replace bombs/rockets
+							continue;
+					// else:
+					if ((distance > gunRange) && (targetWeapon != null))
+						continue;
+					// For Ground Attack, favour higher blast strength
+					float candidateImpact = ((ModuleWeapon)item.Current).cannonShellPower * ((ModuleWeapon)item.Current).cannonShellRadius + ((ModuleWeapon)item.Current).cannonShellHeat;
+
+					if ((targetWeapon != null) && (targetWeaponImpact > candidateImpact))
+						continue; //dont replace better guns
+
+					targetWeapon = item.Current;
+					targetWeaponImpact = candidateImpact;
+				}
+
+			}
+			//if we have a torpedo use it
+			else if (target.isSplashed)
+			{
+				List<IBDWeapon>.Enumerator item = weaponTypesSLW.GetEnumerator();
+				while (item.MoveNext())
+				{
+					if (item.Current == null) continue;
+					if (CheckEngagementEnvelope(item.Current, distance))
+					{
+						if (item.Current.GetMissileType().ToLower() == "torpedo")
+						{
+							targetWeapon = item.Current;
+							break;
+						}
+					}
+				}
+				item.Dispose();
+			}
+			else if (target.isUnderwater)
+			{
+				// iterate over weaponTypesSLW (Ship Launched Weapons) and pick suitable one based on engagementRange
+				// Prioritize by:
+				// 1. Depth Charges
+				// 2. Torpedos
+				List<IBDWeapon>.Enumerator item = weaponTypesSLW.GetEnumerator();
+				while (item.MoveNext())
+				{
+					if (item.Current == null) continue;
+					if (CheckEngagementEnvelope(item.Current, distance))
+					{
+						if (item.Current.GetMissileType().ToLower() == "depthcharge")
+						{
+							targetWeapon = item.Current;
+							break;
+						}
+						if (item.Current.GetMissileType().ToLower() != "torpedo") continue;
+						targetWeapon = item.Current;
+						break;
+					}
+				}
+				item.Dispose();
+			}
+
+			// return result of weapon selection
+			if (targetWeapon != null)
+			{
+				//update the legacy lists & arrays, especially selectedWeapon and weaponIndex
+				selectedWeapon = targetWeapon;
+				// find it in weaponArray
+				for (int i = 1; i < weaponArray.Length; i++)
+				{
+					weaponIndex = i;
+					if (selectedWeapon.GetShortName() == weaponArray[weaponIndex].GetShortName())
+					{
+						break;
+					}
+				}
+
+				if (BDArmorySettings.DRAW_DEBUG_LABELS)
+				{
+					Debug.Log("[BDArmory] : " + vessel.vesselName + " - Selected weapon " + selectedWeapon.GetShortName());
+				}
+
+				PrepareWeapons();
+				DisplaySelectedWeaponMessage();
+				return true;
+			}
+			else
+			{
+
+				if (BDArmorySettings.DRAW_DEBUG_LABELS)
+				{
+					Debug.Log("[BDArmory] : " + vessel.vesselName + " - No weapon selected.");
+				}
+
+				selectedWeapon = null;
+				weaponIndex = 0;
+				return false;
+			}
+
+		}
+
+		// extension for feature_engagementenvelope: check engagement parameters of the weapon if it can be used against the current target
+		bool CheckEngagementEnvelope(IBDWeapon weaponCandidate, float distanceToTarget)
+		{
+			EngageableWeapon engageableWeapon = weaponCandidate as EngageableWeapon;
+
+			if (engageableWeapon == null) return true;
+			if (!engageableWeapon.engageEnabled) return true;
+			if (distanceToTarget < engageableWeapon.GetEngagementRangeMin()) return false;
+			if (distanceToTarget > engageableWeapon.GetEngagementRangeMax()) return false;
+
+			switch (weaponCandidate.GetWeaponClass())
+			{
+
+				case WeaponClasses.DefenseLaser:
+				// TODO: is laser treated like a gun?
+
+				case WeaponClasses.Gun:
+					ModuleWeapon gun = (ModuleWeapon)weaponCandidate;
+
+					// check yaw range of turret
+					ModuleTurret turret = gun.turret;
+					float gimbalTolerance = vessel.LandedOrSplashed ? 0 : 15;
+					if (turret != null)
+						if (!TargetInTurretRange(turret, gimbalTolerance))
+							return false;
+
+					// check overheat
+					if (gun.isOverheated)
+						return false;
+
+					// check ammo
+					if (CheckAmmo(gun))
+					{
+
+						if (BDArmorySettings.DRAW_DEBUG_LABELS)
+						{
+							Debug.Log("[BDArmory] : " + vessel.vesselName + " - Firing possible with " + weaponCandidate.GetShortName());
+						}
+						return true;
+					}
+					break;
+
+				case WeaponClasses.Rocket:
+					ModuleWeapon rocket = (ModuleWeapon)weaponCandidate;
+
+					// check yaw range of turret
+					ModuleTurret turretRocket = rocket.turret;
+					float gimbalAllowance = vessel.LandedOrSplashed ? 0 : 15;
+					if (turretRocket != null)
+						if (!TargetInTurretRange(turretRocket, gimbalAllowance))
+							return false;
+					// check ammo
+					if (CheckAmmo(rocket))
+					{
+						if (BDArmorySettings.DRAW_DEBUG_LABELS)
+						{
+							Debug.Log("[BDArmory] : " + vessel.vesselName + " - Firing possible with " + weaponCandidate.GetShortName());
+						}
+						return true;
+					}
+					break;
+
+				case WeaponClasses.Missile:
+					MissileBase ml = (MissileBase)weaponCandidate;
+
+					// lock radar if needed
+					if (ml.TargetingMode == MissileBase.TargetingModes.Radar)
+					{
+						List<ModuleRadar>.Enumerator rd = radars.GetEnumerator();
+						while (rd.MoveNext())
+						{
+							if (rd.Current == null) continue;
+							if (!rd.Current.canLock) continue;
+							rd.Current.EnableRadar();
+							break;
+						}
+						rd.Dispose();
+					}
+
+					// check DLZ
+					MissileLaunchParams dlz = MissileLaunchParams.GetDynamicLaunchParams(ml, guardTarget.Velocity(), guardTarget.transform.position);
+					if (vessel.srfSpeed > ml.minLaunchSpeed && distanceToTarget < dlz.maxLaunchRange && distanceToTarget > dlz.minLaunchRange)
+					{
+						return true;
+					}
+					if (BDArmorySettings.DRAW_DEBUG_LABELS)
+					{
+						Debug.Log("[BDArmory] : " + vessel.vesselName + " - Failed DLZ test: " + weaponCandidate.GetShortName());
+					}
+					break;
+
+
+				case WeaponClasses.Bomb:
+					if (!vessel.LandedOrSplashed)
+						return true;    // TODO: bomb always allowed?
+					break;
+
+				case WeaponClasses.SLW:
+					return true;
+
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
+
+			return false;
+		}
+
+		void SetTarget(TargetInfo target)
+		{
+			if (target)
+			{
+				if (currentTarget)
+				{
+					currentTarget.Disengage(this);
+				}
+				target.Engage(this);
+				currentTarget = target;
+				guardTarget = target.Vessel;
+			}
+			else
+			{
+				if (currentTarget)
+				{
+					currentTarget.Disengage(this);
+				}
+				guardTarget = null;
+				currentTarget = null;
+			}
+		}
+
+		#endregion
+
+		public bool CanSeeTarget(TargetInfo target)
+		{
+			// fix cheating: we can see a target IF we either have a visual on it, OR it has been detected on radar/sonar
+			// but to prevent AI from stopping an engagement just because a target dropped behind a small hill 5 seconds ago, clamp the timeout to 30 seconds
+			// i.e. let's have at least some object permanence :)
+			// (Ideally, I'd love to have "stale targets", where AI would attack the last known position, but that's a feature for the future)
+			if (Time.time - target.detectedTime < Mathf.Max(targetScanInterval, 30))
+				return true;
+
+			// can we get a visual sight of the target?
+			if ((target.Vessel.transform.position - transform.position).sqrMagnitude < guardRange * guardRange)
+			{
+				if (RadarUtils.TerrainCheck(target.Vessel.transform.position, transform.position))
+				{
+					return false;
+				}
+
+				return true;
+			}
+
+			return false;
+		}
+
+
+		/// <summary>
+		/// Override for legacy targeting only! Remove when removing legcy mode!
+		/// </summary>
+		/// <param name="target"></param>
+		/// <returns></returns>
+		public bool CanSeeTarget(Vessel target)
+		{
+			// can we get a visual sight of the target?
+			if ((target.transform.position - transform.position).sqrMagnitude < guardRange * guardRange)
+			{
+				if (RadarUtils.TerrainCheck(target.transform.position, transform.position))
+				{
+					return false;
+				}
+
+				return true;
+			}
+
+			return false;
+		}
+
+
+		void ScanAllTargets()
+		{
+			//get a target.
+			//float angle = 0;
+			List<Vessel>.Enumerator v = FlightGlobals.Vessels.GetEnumerator();
+			while (v.MoveNext())
+			{
+				if (v.Current == null) continue;
+				if (!v.Current.loaded) continue;
+				float distance = (transform.position - v.Current.transform.position).sqrMagnitude;
+				if (!(distance < guardRange * guardRange) || !CanSeeTarget(v.Current)) continue;
+				float angle = Vector3.Angle(-transform.forward, v.Current.transform.position - transform.position);
+				if (!(angle < guardAngle / 2)) continue;
+				List<MissileBase>.Enumerator missile = v.Current.FindPartModulesImplementing<MissileBase>().GetEnumerator();
+				while (missile.MoveNext())
+				{
+					if (missile.Current == null) continue;
+					if (!missile.Current.HasFired || missile.Current.Team == team) continue;
+					BDATargetManager.ReportVessel(v.Current, this);
+					if (!isFlaring && missile.Current.TargetingMode == MissileBase.TargetingModes.Heat && Vector3.Angle(missile.Current.GetForwardTransform(), transform.position - missile.Current.transform.position) < 20)
+					{
+						StartCoroutine(FlareRoutine(targetScanInterval * 0.75f));
+					}
+					break;
+				}
+				missile.Dispose();
+
+				List<MissileFire>.Enumerator mF = v.Current.FindPartModulesImplementing<MissileFire>().GetEnumerator();
+				while (mF.MoveNext())
+				{
+					if (mF.Current == null) continue;
+					if (mF.Current.team == team || !mF.Current.vessel.IsControllable || !mF.Current.vessel.isCommandable) continue;
+					BDATargetManager.ReportVessel(v.Current, this);
+					break;
+				}
+				mF.Dispose();
+			}
+			v.Dispose();
+		}
+
+		void SearchForRadarSource()
+		{
+			antiRadTargetAcquired = false;
+
+			if (rwr && rwr.rwrEnabled)
+			{
+				float closestAngle = 360;
+				MissileBase missile = CurrentMissile;
+
+				if (!missile) return;
+
+				float maxOffBoresight = missile.maxOffBoresight;
+
+				if (missile.TargetingMode != MissileBase.TargetingModes.AntiRad) return;
+
+				for (int i = 0; i < rwr.pingsData.Length; i++)
+				{
+					if (rwr.pingsData[i].exists && (rwr.pingsData[i].signalStrength == 0 || rwr.pingsData[i].signalStrength == 5))
+					{
+						float angle = Vector3.Angle(rwr.pingWorldPositions[i] - missile.transform.position, missile.GetForwardTransform());
+
+						if (angle < closestAngle && angle < maxOffBoresight)
+						{
+							closestAngle = angle;
+							antiRadiationTarget = rwr.pingWorldPositions[i];
+							antiRadTargetAcquired = true;
+						}
+					}
+				}
+			}
+		}
+
+		void SearchForLaserPoint()
+		{
+			MissileBase ml = CurrentMissile;
+			if (!ml || ml.TargetingMode != MissileBase.TargetingModes.Laser)
+			{
+				return;
+			}
+
+			MissileLauncher launcher = ml as MissileLauncher;
+			if (launcher != null)
+			{
+				foundCam = BDATargetManager.GetLaserTarget(launcher,
+					launcher.GuidanceMode == MissileBase.GuidanceModes.BeamRiding);
+			}
+			else
+			{
+				foundCam = BDATargetManager.GetLaserTarget((BDModularGuidance)ml, false);
+			}
+
+			if (foundCam)
+			{
+				laserPointDetected = true;
+			}
+			else
+			{
+				laserPointDetected = false;
+			}
+		}
+
+		void SearchForHeatTarget()
+		{
+			if (CurrentMissile != null)
+			{
+				if (!CurrentMissile || CurrentMissile.TargetingMode != MissileBase.TargetingModes.Heat)
+				{
+					return;
+				}
+
+				float scanRadius = CurrentMissile.lockedSensorFOV * 2;
+				float maxOffBoresight = CurrentMissile.maxOffBoresight * 0.85f;
+
+				if (vesselRadarData && vesselRadarData.locked)
+				{
+					heatTarget = vesselRadarData.lockedTargetData.targetData;
+				}
+
+				Vector3 direction =
+					heatTarget.exists && Vector3.Angle(heatTarget.position - CurrentMissile.MissileReferenceTransform.position, CurrentMissile.GetForwardTransform()) < maxOffBoresight ?
+					heatTarget.predictedPosition - CurrentMissile.MissileReferenceTransform.position
+					: CurrentMissile.GetForwardTransform();
+
+				heatTarget = BDATargetManager.GetHeatTarget(new Ray(CurrentMissile.MissileReferenceTransform.position + (50 * CurrentMissile.GetForwardTransform()), direction), scanRadius, CurrentMissile.heatThreshold, CurrentMissile.allAspect, this);
+			}
+		}
+
+		bool CrossCheckWithRWR(TargetInfo v)
+		{
+			bool matchFound = false;
+			if (rwr && rwr.rwrEnabled)
+			{
+				for (int i = 0; i < rwr.pingsData.Length; i++)
+				{
+					if (rwr.pingsData[i].exists && (rwr.pingWorldPositions[i] - v.position).sqrMagnitude < 20 * 20)
+					{
+						matchFound = true;
+						break;
+					}
+				}
+			}
+
+			return matchFound;
+		}
+
+		public void SendTargetDataToMissile(MissileBase ml)
+		{ //TODO BDModularGuidance: implement all targetings on base
+			if (ml.TargetingMode == MissileBase.TargetingModes.Laser && laserPointDetected)
+			{
+				ml.lockedCamera = foundCam;
+			}
+			else if (ml.TargetingMode == MissileBase.TargetingModes.Gps)
+			{
+				if (BDArmorySettings.ALLOW_LEGACY_TARGETING)
+				{
+					if (vessel.targetObject != null && vessel.targetObject.GetVessel() != null)
+					{
+						ml.TargetAcquired = true;
+						ml.legacyTargetVessel = vessel.targetObject.GetVessel();
+					}
+				}
+				else if (designatedGPSCoords != Vector3d.zero)
+				{
+					ml.targetGPSCoords = designatedGPSCoords;
+					ml.TargetAcquired = true;
+				}
+
+			}
+			else if (ml.TargetingMode == MissileBase.TargetingModes.Heat && heatTarget.exists)
+			{
+
+				ml.heatTarget = heatTarget;
+				heatTarget = TargetSignatureData.noTarget;
+
+			}
+			else if (ml.TargetingMode == MissileBase.TargetingModes.Radar && vesselRadarData && vesselRadarData.locked)//&& radar && radar.lockedTarget.exists)
+			{
+				ml.radarTarget = vesselRadarData.lockedTargetData.targetData;
+				ml.vrd = vesselRadarData;
+				vesselRadarData.LastMissile = ml;
+			}
+			else if (ml.TargetingMode == MissileBase.TargetingModes.AntiRad && antiRadTargetAcquired)
+			{
+				ml.TargetAcquired = true;
+				ml.targetGPSCoords = VectorUtils.WorldPositionToGeoCoords(antiRadiationTarget,
+						vessel.mainBody);
+			}
+		}
+
+		public void TargetAcquire()
+		{
+			if (!isArmed || !BDArmorySettings.ALLOW_LEGACY_TARGETING) return;
+			Vessel acquiredTarget = null;
+			float smallestAngle = 8;
+
+			if (Time.time - targetListTimer > 1)
+			{
+				loadedVessels.Clear();
+				List<Vessel>.Enumerator v = FlightGlobals.Vessels.GetEnumerator();
+				while (v.MoveNext())
+				{
+					if (v.Current == null) continue;
+					float viewAngle = Vector3.Angle(-transform.forward, v.Current.transform.position - transform.position);
+					if (!v.Current.loaded || !(viewAngle < smallestAngle)) continue;
+					if (!v.Current.vesselName.Contains("(fired)")) loadedVessels.Add(v.Current);
+				}
+				v.Dispose();
+			}
+
+			List<Vessel>.Enumerator vl = loadedVessels.GetEnumerator();
+			while (vl.MoveNext())
+			{
+				if (vl.Current == null) continue;
+				float viewAngle = Vector3.Angle(-transform.forward, vl.Current.transform.position - transform.position);
+				//if(vl.Current!= vessel && vl.Current.loaded) Debug.Log ("view angle: " + viewAngle);
+				if (vl.Current == vessel || !vl.Current.loaded || !(viewAngle < smallestAngle) ||
+					!CanSeeTarget(vl.Current)) continue;
+				acquiredTarget = vl.Current;
+				smallestAngle = viewAngle;
+			}
+			vl.Dispose();
+
+			if (acquiredTarget == null || acquiredTarget == (Vessel)FlightGlobals.fetch.VesselTarget) return;
+			if (BDArmorySettings.DRAW_DEBUG_LABELS)
+			{
+				Debug.Log("[BDArmory]: found target! : " + acquiredTarget.name);
+			}
+			FlightGlobals.fetch.SetVesselTarget(acquiredTarget);
+		}
+
+		#endregion
+
+		#region Guard
+
+		public void ResetGuardInterval()
+		{
+			targetScanTimer = 0;
+		}
+
+		void GuardMode()
+		{
+			if (!gameObject.activeInHierarchy) return;
+			if (BDArmorySettings.PEACE_MODE) return;
+
+			if (!BDArmorySettings.ALLOW_LEGACY_TARGETING)
+			{
+				UpdateGuardViewScan();
+			}
+
+			//setting turrets to guard mode
+			if (selectedWeapon != null && (selectedWeapon.GetWeaponClass() == WeaponClasses.Gun || selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket))
+			{
+				//make this not have to go every frame
+				List<ModuleWeapon>.Enumerator weapon = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
+				while (weapon.MoveNext())
+				{
+					if (weapon.Current == null) continue;
 					if (weapon.Current.GetShortName() != selectedWeapon.GetShortName()) continue; //want to find all weapons in WeaponGroup, rather than all weapons of parttype
-					weapon.Current.EnableWeapon(); 
-                    weapon.Current.aiControlled = true;
-                    if (weapon.Current.yawRange >= 5 && (weapon.Current.maxPitch - weapon.Current.minPitch) >= 5)
-                        weapon.Current.maxAutoFireCosAngle = 1;
-                    else
-                        weapon.Current.maxAutoFireCosAngle = vessel.LandedOrSplashed ? 0.9993908f : 0.9975641f; //2 : 4 degrees
-                }
-                weapon.Dispose();
-            }
+					weapon.Current.EnableWeapon();
+					weapon.Current.aiControlled = true;
+					if (weapon.Current.yawRange >= 5 && (weapon.Current.maxPitch - weapon.Current.minPitch) >= 5)
+						weapon.Current.maxAutoFireCosAngle = 1;
+					else
+						weapon.Current.maxAutoFireCosAngle = vessel.LandedOrSplashed ? 0.9993908f : 0.9975641f; //2 : 4 degrees
+				}
+				weapon.Dispose();
+			}
 
-            if (guardTarget)
-            {
-                //release target if out of range
-                if (BDArmorySettings.ALLOW_LEGACY_TARGETING &&
-                    (guardTarget.transform.position - transform.position).sqrMagnitude > guardRange*guardRange)
-                {
-                    SetTarget(null);
-                }
-            }
-            else if (selectedWeapon != null && selectedWeapon.GetWeaponClass() == WeaponClasses.Gun)
-            {
-                List<ModuleWeapon>.Enumerator weapon = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
-                while (weapon.MoveNext())
-                {
-                    if (weapon.Current == null) continue;
+			if (guardTarget)
+			{
+				//release target if out of range
+				if (BDArmorySettings.ALLOW_LEGACY_TARGETING &&
+					(guardTarget.transform.position - transform.position).sqrMagnitude > guardRange * guardRange)
+				{
+					SetTarget(null);
+				}
+			}
+			else if (selectedWeapon != null && (selectedWeapon.GetWeaponClass() == WeaponClasses.Gun || selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket))
+			{
+				List<ModuleWeapon>.Enumerator weapon = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
+				while (weapon.MoveNext())
+				{
+					if (weapon.Current == null) continue;
 					if (weapon.Current.GetShortName() != selectedWeapon.GetShortName()) continue;
 					weapon.Current.autoFire = false;
-                    weapon.Current.legacyTargetVessel = null;
-                }
-                weapon.Dispose();
-            }
+					weapon.Current.legacyTargetVessel = null;
+				}
+				weapon.Dispose();
+			}
 
-            if (missilesAway < 0)
-                missilesAway = 0;
+			if (missilesAway < 0)
+				missilesAway = 0;
 
-            if (missileIsIncoming)
-            {
-                if (!isLegacyCMing)
-                {
-                    StartCoroutine(LegacyCMRoutine());
-                }
+			if (missileIsIncoming)
+			{
+				if (!isLegacyCMing)
+				{
+					StartCoroutine(LegacyCMRoutine());
+				}
 
-                targetScanTimer -= Time.fixedDeltaTime; //advance scan timing (increased urgency)
-            }
+				targetScanTimer -= Time.fixedDeltaTime; //advance scan timing (increased urgency)
+			}
 
-            //scan and acquire new target
-            if (Time.time - targetScanTimer > targetScanInterval)
-            {
-                targetScanTimer = Time.time;
+			//scan and acquire new target
+			if (Time.time - targetScanTimer > targetScanInterval)
+			{
+				targetScanTimer = Time.time;
 
-                if (!guardFiringMissile)
-                {
-                    SetTarget(null);
-                    if (BDArmorySettings.ALLOW_LEGACY_TARGETING)
-                    {
-                        ScanAllTargets();
-                    }
+				if (!guardFiringMissile)
+				{
+					SetTarget(null);
+					if (BDArmorySettings.ALLOW_LEGACY_TARGETING)
+					{
+						ScanAllTargets();
+					}
 
-                    SmartFindTarget();
+					SmartFindTarget();
 
-                    if (guardTarget == null || selectedWeapon == null)
-                    {
-                        SetCargoBays();
-                        return;
-                    }
+					if (guardTarget == null || selectedWeapon == null)
+					{
+						SetCargoBays();
+						return;
+					}
 
-                    //firing
-                    if (weaponIndex > 0)
-                    {
-                        if (selectedWeapon.GetWeaponClass() == WeaponClasses.Missile || selectedWeapon.GetWeaponClass() == WeaponClasses.SLW)
-                        {
-                            bool launchAuthorized = true;
-                            bool pilotAuthorized = true;
-                            //(!pilotAI || pilotAI.GetLaunchAuthorization(guardTarget, this));
+					//firing
+					if (weaponIndex > 0)
+					{
+						if (selectedWeapon.GetWeaponClass() == WeaponClasses.Missile || selectedWeapon.GetWeaponClass() == WeaponClasses.SLW)
+						{
+							bool launchAuthorized = true;
+							bool pilotAuthorized = true;
+							//(!pilotAI || pilotAI.GetLaunchAuthorization(guardTarget, this));
 
-                            float targetAngle = Vector3.Angle(-transform.forward, guardTarget.transform.position - transform.position);
-                            float targetDistance = Vector3.Distance(currentTarget.position, transform.position);
-                            MissileLaunchParams dlz = MissileLaunchParams.GetDynamicLaunchParams(CurrentMissile, guardTarget.Velocity(), guardTarget.CoM);
+							float targetAngle = Vector3.Angle(-transform.forward, guardTarget.transform.position - transform.position);
+							float targetDistance = Vector3.Distance(currentTarget.position, transform.position);
+							MissileLaunchParams dlz = MissileLaunchParams.GetDynamicLaunchParams(CurrentMissile, guardTarget.Velocity(), guardTarget.CoM);
 
-                            if (targetAngle > guardAngle / 2) //dont fire yet if target out of guard angle
-                            {
-                                launchAuthorized = false;
-                            }
-                            else if (targetDistance >= dlz.maxLaunchRange || targetDistance <= dlz.minLaunchRange)  //fire the missile only if target is further than missiles min launch range
-                            {
-                                launchAuthorized = false;
-                            }
+							if (targetAngle > guardAngle / 2) //dont fire yet if target out of guard angle
+							{
+								launchAuthorized = false;
+							}
+							else if (targetDistance >= dlz.maxLaunchRange || targetDistance <= dlz.minLaunchRange)  //fire the missile only if target is further than missiles min launch range
+							{
+								launchAuthorized = false;
+							}
 
-                            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                                Debug.Log("[BDArmory]:" + vessel.vesselName + " launchAuth=" + launchAuthorized + ", pilotAut=" + pilotAuthorized + ", missilesAway/Max=" + missilesAway + "/" + maxMissilesOnTarget);
+							if (BDArmorySettings.DRAW_DEBUG_LABELS)
+								Debug.Log("[BDArmory]:" + vessel.vesselName + " launchAuth=" + launchAuthorized + ", pilotAut=" + pilotAuthorized + ", missilesAway/Max=" + missilesAway + "/" + maxMissilesOnTarget);
 
-                            if (missilesAway < maxMissilesOnTarget)
-                            {
-                                if (!guardFiringMissile && launchAuthorized &&
-                                    (pilotAuthorized || !BDArmorySettings.ALLOW_LEGACY_TARGETING))
-                                {
-                                    StartCoroutine(GuardMissileRoutine());
-                                }
-                            }
-                            else if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                            {
-                                Debug.Log("[BDArmory]:" + vessel.vesselName + " waiting for missile to be ready...");
-                            }
+							if (missilesAway < maxMissilesOnTarget)
+							{
+								if (!guardFiringMissile && launchAuthorized &&
+									(pilotAuthorized || !BDArmorySettings.ALLOW_LEGACY_TARGETING))
+								{
+									StartCoroutine(GuardMissileRoutine());
+								}
+							}
+							else if (BDArmorySettings.DRAW_DEBUG_LABELS)
+							{
+								Debug.Log("[BDArmory]:" + vessel.vesselName + " waiting for missile to be ready...");
+							}
 
-                            if (!launchAuthorized || !pilotAuthorized || missilesAway >= maxMissilesOnTarget)
-                            {
-                                targetScanTimer -= 0.5f * targetScanInterval;
-                            }
-                        }
-                        else if (selectedWeapon.GetWeaponClass() == WeaponClasses.Bomb)
-                        {
-                            if (!guardFiringMissile)
-                            {
-                                StartCoroutine(GuardBombRoutine());
-                            }
-                        }
-                        else if (selectedWeapon.GetWeaponClass() == WeaponClasses.Gun ||
-                                 selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket ||
-                                 selectedWeapon.GetWeaponClass() == WeaponClasses.DefenseLaser)
-                        {
-                            StartCoroutine(GuardTurretRoutine());
-                        }
-                    }
-                }
-                SetCargoBays();
-            }
+							if (!launchAuthorized || !pilotAuthorized || missilesAway >= maxMissilesOnTarget)
+							{
+								targetScanTimer -= 0.5f * targetScanInterval;
+							}
+						}
+						else if (selectedWeapon.GetWeaponClass() == WeaponClasses.Bomb)
+						{
+							if (!guardFiringMissile)
+							{
+								StartCoroutine(GuardBombRoutine());
+							}
+						}
+						else if (selectedWeapon.GetWeaponClass() == WeaponClasses.Gun ||
+								 selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket ||
+								 selectedWeapon.GetWeaponClass() == WeaponClasses.DefenseLaser)
+						{
+							StartCoroutine(GuardTurretRoutine());
+						}
+					}
+				}
+				SetCargoBays();
+			}
 
-            if (overrideTimer > 0)
-            {
-                overrideTimer -= TimeWarp.fixedDeltaTime;
-            }
-            else
-            {
-                overrideTimer = 0;
-                overrideTarget = null;
-            }
-        }
+			if (overrideTimer > 0)
+			{
+				overrideTimer -= TimeWarp.fixedDeltaTime;
+			}
+			else
+			{
+				overrideTimer = 0;
+				overrideTarget = null;
+			}
+		}
 
-        void UpdateGuardViewScan()
-        {
-            float finalMaxAngle = guardAngle / 2;
-            float finalScanDirectionAngle = currentGuardViewAngle;
-            if (guardTarget != null)
-            {
-                if (focusingOnTarget)
-                {
-                    if (focusingOnTargetTimer > 3)
-                    {
-                        focusingOnTargetTimer = 0;
-                        focusingOnTarget = false;
-                    }
-                    else
-                    {
-                        focusingOnTargetTimer += Time.fixedDeltaTime;
-                    }
-                    finalMaxAngle = 20;
-                    finalScanDirectionAngle =
-                        VectorUtils.SignedAngle(viewReferenceTransform.forward,
-                            guardTarget.transform.position - viewReferenceTransform.position,
-                            viewReferenceTransform.right) + currentGuardViewAngle;
-                }
-                else
-                {
-                    if (focusingOnTargetTimer > 2)
-                    {
-                        focusingOnTargetTimer = 0;
-                        focusingOnTarget = true;
-                    }
-                    else
-                    {
-                        focusingOnTargetTimer += Time.fixedDeltaTime;
-                    }
-                }
-            }
+		void UpdateGuardViewScan()
+		{
+			float finalMaxAngle = guardAngle / 2;
+			float finalScanDirectionAngle = currentGuardViewAngle;
+			if (guardTarget != null)
+			{
+				if (focusingOnTarget)
+				{
+					if (focusingOnTargetTimer > 3)
+					{
+						focusingOnTargetTimer = 0;
+						focusingOnTarget = false;
+					}
+					else
+					{
+						focusingOnTargetTimer += Time.fixedDeltaTime;
+					}
+					finalMaxAngle = 20;
+					finalScanDirectionAngle =
+						VectorUtils.SignedAngle(viewReferenceTransform.forward,
+							guardTarget.transform.position - viewReferenceTransform.position,
+							viewReferenceTransform.right) + currentGuardViewAngle;
+				}
+				else
+				{
+					if (focusingOnTargetTimer > 2)
+					{
+						focusingOnTargetTimer = 0;
+						focusingOnTarget = true;
+					}
+					else
+					{
+						focusingOnTargetTimer += Time.fixedDeltaTime;
+					}
+				}
+			}
 
 
-            float angleDelta = guardViewScanRate * Time.fixedDeltaTime;
-            ViewScanResults results;
-            debugGuardViewDirection = RadarUtils.GuardScanInDirection(this, finalScanDirectionAngle,
-                viewReferenceTransform, angleDelta, out results, guardRange);
+			float angleDelta = guardViewScanRate * Time.fixedDeltaTime;
+			ViewScanResults results;
+			debugGuardViewDirection = RadarUtils.GuardScanInDirection(this, finalScanDirectionAngle,
+				viewReferenceTransform, angleDelta, out results, guardRange);
 
-            currentGuardViewAngle += guardViewScanDirection * angleDelta;
-            if (Mathf.Abs(currentGuardViewAngle) > finalMaxAngle)
-            {
-                currentGuardViewAngle = Mathf.Sign(currentGuardViewAngle) * finalMaxAngle;
-                guardViewScanDirection = -guardViewScanDirection;
-            }
+			currentGuardViewAngle += guardViewScanDirection * angleDelta;
+			if (Mathf.Abs(currentGuardViewAngle) > finalMaxAngle)
+			{
+				currentGuardViewAngle = Mathf.Sign(currentGuardViewAngle) * finalMaxAngle;
+				guardViewScanDirection = -guardViewScanDirection;
+			}
 
-            if (results.foundMissile)
-            {
-                if (rwr && !rwr.rwrEnabled) rwr.EnableRWR();
-                if (rwr && rwr.rwrEnabled && !rwr.displayRWR) rwr.displayRWR = true;
-            }
+			if (results.foundMissile)
+			{
+				if (rwr && !rwr.rwrEnabled) rwr.EnableRWR();
+				if (rwr && rwr.rwrEnabled && !rwr.displayRWR) rwr.displayRWR = true;
+			}
 
-            if (results.foundHeatMissile)
-            {
-                StartCoroutine(UnderAttackRoutine());
+			if (results.foundHeatMissile)
+			{
+				StartCoroutine(UnderAttackRoutine());
 
-                if (!isFlaring)
-                {
-                    StartCoroutine(FlareRoutine(2.5f));
-                    StartCoroutine(ResetMissileThreatDistanceRoutine());
-                }
-                incomingThreatPosition = results.threatPosition;
+				if (!isFlaring)
+				{
+					StartCoroutine(FlareRoutine(2.5f));
+					StartCoroutine(ResetMissileThreatDistanceRoutine());
+				}
+				incomingThreatPosition = results.threatPosition;
 
-                if (results.threatVessel)
-                {
-                    if (!incomingMissileVessel ||
-                        (incomingMissileVessel.transform.position - vessel.transform.position).sqrMagnitude >
-                        (results.threatVessel.transform.position - vessel.transform.position).sqrMagnitude)
-                    {
-                        incomingMissileVessel = results.threatVessel;
-                    }
-                }
-            }
+				if (results.threatVessel)
+				{
+					if (!incomingMissileVessel ||
+						(incomingMissileVessel.transform.position - vessel.transform.position).sqrMagnitude >
+						(results.threatVessel.transform.position - vessel.transform.position).sqrMagnitude)
+					{
+						incomingMissileVessel = results.threatVessel;
+					}
+				}
+			}
 
-            if (results.foundRadarMissile)
-            {
-                StartCoroutine(UnderAttackRoutine());
+			if (results.foundRadarMissile)
+			{
+				StartCoroutine(UnderAttackRoutine());
 
-                FireChaff();
-                FireECM();
+				FireChaff();
+				FireECM();
 
-                incomingThreatPosition = results.threatPosition;
+				incomingThreatPosition = results.threatPosition;
 
-                if (results.threatVessel)
-                {
-                    if (!incomingMissileVessel ||
-                        (incomingMissileVessel.transform.position - vessel.transform.position).sqrMagnitude >
-                        (results.threatVessel.transform.position - vessel.transform.position).sqrMagnitude)
-                    {
-                        incomingMissileVessel = results.threatVessel;
-                    }
-                }
-            }
+				if (results.threatVessel)
+				{
+					if (!incomingMissileVessel ||
+						(incomingMissileVessel.transform.position - vessel.transform.position).sqrMagnitude >
+						(results.threatVessel.transform.position - vessel.transform.position).sqrMagnitude)
+					{
+						incomingMissileVessel = results.threatVessel;
+					}
+				}
+			}
 
-            if (results.foundAGM)
-            {
-                StartCoroutine(UnderAttackRoutine());
+			if (results.foundAGM)
+			{
+				StartCoroutine(UnderAttackRoutine());
 
-                //do smoke CM here.
-                if (targetMissiles && guardTarget == null)
-                {
-                    //targetScanTimer = Mathf.Min(targetScanInterval, Time.time - targetScanInterval + 0.5f);
-                    targetScanTimer -= targetScanInterval / 2;
-                }
-            }
+				//do smoke CM here.
+				if (targetMissiles && guardTarget == null)
+				{
+					//targetScanTimer = Mathf.Min(targetScanInterval, Time.time - targetScanInterval + 0.5f);
+					targetScanTimer -= targetScanInterval / 2;
+				}
+			}
 
-            incomingMissileDistance = Mathf.Min(results.missileThreatDistance, incomingMissileDistance);
+			incomingMissileDistance = Mathf.Min(results.missileThreatDistance, incomingMissileDistance);
 
-            if (results.firingAtMe)
-            {
-                StartCoroutine(UnderAttackRoutine());
+			if (results.firingAtMe)
+			{
+				StartCoroutine(UnderAttackRoutine());
 
-                incomingThreatPosition = results.threatPosition;
-                if (ufRoutine != null)
-                {
-                    StopCoroutine(ufRoutine);
-                    underFire = false;
-                }
-                if (results.threatWeaponManager != null)
-                {
-                    TargetInfo nearbyFriendly = BDATargetManager.GetClosestFriendly(this);
-                    TargetInfo nearbyThreat = BDATargetManager.GetTargetFromWeaponManager(results.threatWeaponManager);
+				incomingThreatPosition = results.threatPosition;
+				if (ufRoutine != null)
+				{
+					StopCoroutine(ufRoutine);
+					underFire = false;
+				}
+				if (results.threatWeaponManager != null)
+				{
+					TargetInfo nearbyFriendly = BDATargetManager.GetClosestFriendly(this);
+					TargetInfo nearbyThreat = BDATargetManager.GetTargetFromWeaponManager(results.threatWeaponManager);
 
-                    if (nearbyThreat?.weaponManager != null && nearbyFriendly?.weaponManager != null)
-                        if (nearbyThreat.weaponManager.team != team &&
-                            nearbyFriendly.weaponManager.team == team)
-                        //turns out that there's no check for AI on the same team going after each other due to this.  Who knew?
-                        {
-                            if (nearbyThreat == currentTarget && nearbyFriendly.weaponManager.currentTarget != null)
-                            //if being attacked by the current target, switch to the target that the nearby friendly was engaging instead
-                            {
-                                SetOverrideTarget(nearbyFriendly.weaponManager.currentTarget);
-                                nearbyFriendly.weaponManager.SetOverrideTarget(nearbyThreat);
-                                if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                                    Debug.Log("[BDArmory]: " + vessel.vesselName + " called for help from " +
-                                              nearbyFriendly.Vessel.vesselName + " and took its target in return");
-                                //basically, swap targets to cover each other
-                            }
-                            else
-                            {
-                                //otherwise, continue engaging the current target for now
-                                nearbyFriendly.weaponManager.SetOverrideTarget(nearbyThreat);
-                                if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                                    Debug.Log("[BDArmory]: " + vessel.vesselName + " called for help from " +
-                                              nearbyFriendly.Vessel.vesselName);
-                            }
-                        }
-                }
-                ufRoutine = StartCoroutine(UnderFireRoutine());
-            }
-        }
+					if (nearbyThreat?.weaponManager != null && nearbyFriendly?.weaponManager != null)
+						if (nearbyThreat.weaponManager.team != team &&
+							nearbyFriendly.weaponManager.team == team)
+						//turns out that there's no check for AI on the same team going after each other due to this.  Who knew?
+						{
+							if (nearbyThreat == currentTarget && nearbyFriendly.weaponManager.currentTarget != null)
+							//if being attacked by the current target, switch to the target that the nearby friendly was engaging instead
+							{
+								SetOverrideTarget(nearbyFriendly.weaponManager.currentTarget);
+								nearbyFriendly.weaponManager.SetOverrideTarget(nearbyThreat);
+								if (BDArmorySettings.DRAW_DEBUG_LABELS)
+									Debug.Log("[BDArmory]: " + vessel.vesselName + " called for help from " +
+											  nearbyFriendly.Vessel.vesselName + " and took its target in return");
+								//basically, swap targets to cover each other
+							}
+							else
+							{
+								//otherwise, continue engaging the current target for now
+								nearbyFriendly.weaponManager.SetOverrideTarget(nearbyThreat);
+								if (BDArmorySettings.DRAW_DEBUG_LABELS)
+									Debug.Log("[BDArmory]: " + vessel.vesselName + " called for help from " +
+											  nearbyFriendly.Vessel.vesselName);
+							}
+						}
+				}
+				ufRoutine = StartCoroutine(UnderFireRoutine());
+			}
+		}
 
-        public void ForceWideViewScan()
-        {
-            focusingOnTarget = false;
-            focusingOnTargetTimer = 1;
-        }
+		public void ForceWideViewScan()
+		{
+			focusingOnTarget = false;
+			focusingOnTargetTimer = 1;
+		}
 
-        public void ForceScan()
-        {
-            targetScanTimer = -100;
-        }
-        
-        void StartGuardTurretFiring()
-        {
-            if (!guardTarget) return;
-            if (selectedWeapon == null) return;
+		public void ForceScan()
+		{
+			targetScanTimer = -100;
+		}
 
-            if (selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket)
-            {
-                List<RocketLauncher>.Enumerator weapon = vessel.FindPartModulesImplementing<RocketLauncher>().GetEnumerator();
-                while (weapon.MoveNext())
-                {
-                    if (weapon.Current == null) continue;
-                    if (weapon.Current.GetShortName() != selectedWeaponString) continue;
-                    if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                    {
-                        Debug.Log("[BDArmory]: Setting rocket to auto fire");
-                    }
-                    weapon.Current.legacyGuardTarget = guardTarget;
-                    weapon.Current.autoFireStartTime = Time.time;
-                    //weapon.Current.autoFireDuration = targetScanInterval / 2;
-                    weapon.Current.autoFireDuration = (fireBurstLength < 0.5) ? targetScanInterval / 2 : fireBurstLength;
-                    weapon.Current.autoRippleRate = rippleFire ? rippleRPM : 0;
-                }
-                weapon.Dispose();
-            }
-            else
-            {
-                List<ModuleWeapon>.Enumerator weapon = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
-                while (weapon.MoveNext())
-                {
-                    if (weapon.Current == null) continue;
+		void StartGuardTurretFiring()
+		{
+			if (!guardTarget) return;
+			if (selectedWeapon == null) return;
+			
+				List<ModuleWeapon>.Enumerator weapon = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
+				while (weapon.MoveNext())
+				{
+					if (weapon.Current == null) continue;
 					if (weapon.Current.GetShortName() != selectedWeapon.GetShortName()) continue;
 					weapon.Current.legacyTargetVessel = guardTarget;
-                    weapon.Current.autoFireTimer = Time.time;
-                    //weapon.Current.autoFireLength = 3 * targetScanInterval / 4;
-                    weapon.Current.autoFireLength = (fireBurstLength < 0.5) ? targetScanInterval / 2 : fireBurstLength;
-                }
-                weapon.Dispose();
-            }
-        }
+					weapon.Current.autoFireTimer = Time.time;
+					//weapon.Current.autoFireLength = 3 * targetScanInterval / 4;
+					weapon.Current.autoFireLength = (fireBurstLength < 0.5) ? targetScanInterval / 2 : fireBurstLength;
+				}
+				weapon.Dispose();
+			
+		}
 
-        public void SetOverrideTarget(TargetInfo target)
-        {
-            overrideTarget = target;
-            targetScanTimer = -100;
-        }
+		public void SetOverrideTarget(TargetInfo target)
+		{
+			overrideTarget = target;
+			targetScanTimer = -100;
+		}
 
-        public void UpdateMaxGuardRange()
-        {
-            UI_FloatRange rangeEditor = (UI_FloatRange)Fields["guardRange"].uiControlEditor;
-            if (BDArmorySettings.PHYSICS_RANGE != 0)
-            {
-                if (BDArmorySettings.ALLOW_LEGACY_TARGETING)
-                {
-                    rangeEditor.maxValue = BDArmorySettings.PHYSICS_RANGE;
-                }
-                else
-                {
-                    rangeEditor.maxValue = BDArmorySettings.MAX_GUARD_VISUAL_RANGE;
-                }
-            }
-            else
-            {
-                rangeEditor.maxValue = 5000;
-            }
-        }
+		public void UpdateMaxGuardRange()
+		{
+			UI_FloatRange rangeEditor = (UI_FloatRange)Fields["guardRange"].uiControlEditor;
+			if (BDArmorySettings.PHYSICS_RANGE != 0)
+			{
+				if (BDArmorySettings.ALLOW_LEGACY_TARGETING)
+				{
+					rangeEditor.maxValue = BDArmorySettings.PHYSICS_RANGE;
+				}
+				else
+				{
+					rangeEditor.maxValue = BDArmorySettings.MAX_GUARD_VISUAL_RANGE;
+				}
+			}
+			else
+			{
+				rangeEditor.maxValue = 5000;
+			}
+		}
 
 
-        // moved from pilot AI, as it does not really do anything AI related?
-        bool GetLaunchAuthorization(Vessel targetV, MissileFire mf)
-        {
-            bool launchAuthorized = false;
-            Vector3 target = targetV.transform.position;
-            MissileBase missile = mf.CurrentMissile;
-            if (missile != null)
-            {
-                if (!targetV.LandedOrSplashed)
-                {
-                    target = MissileGuidance.GetAirToAirFireSolution(missile, targetV);
-                }
+		// moved from pilot AI, as it does not really do anything AI related?
+		bool GetLaunchAuthorization(Vessel targetV, MissileFire mf)
+		{
+			bool launchAuthorized = false;
+			Vector3 target = targetV.transform.position;
+			MissileBase missile = mf.CurrentMissile;
+			if (missile != null)
+			{
+				if (!targetV.LandedOrSplashed)
+				{
+					target = MissileGuidance.GetAirToAirFireSolution(missile, targetV);
+				}
 
-                float boresightFactor = targetV.LandedOrSplashed ? 0.75f : 0.35f;
+				float boresightFactor = targetV.LandedOrSplashed ? 0.75f : 0.35f;
 
-                //if(missile.TargetingMode == MissileBase.TargetingModes.Gps) maxOffBoresight = 45;
+				//if(missile.TargetingMode == MissileBase.TargetingModes.Gps) maxOffBoresight = 45;
 
-                float fTime = 2f;
-                Vector3 futurePos = target + (targetV.Velocity() * fTime);
-                Vector3 myFuturePos = vessel.ReferenceTransform.position + (vessel.Velocity() * fTime);
-                bool fDot = Vector3.Dot(vessel.ReferenceTransform.up, futurePos - myFuturePos) > 0; //check target won't likely be behind me soon
+				float fTime = 2f;
+				Vector3 futurePos = target + (targetV.Velocity() * fTime);
+				Vector3 myFuturePos = vessel.ReferenceTransform.position + (vessel.Velocity() * fTime);
+				bool fDot = Vector3.Dot(vessel.ReferenceTransform.up, futurePos - myFuturePos) > 0; //check target won't likely be behind me soon
 
-                if (fDot && Vector3.Angle(missile.GetForwardTransform(), target - missile.transform.position) < missile.maxOffBoresight * boresightFactor)
-                {
-                    launchAuthorized = true;
-                }
+				if (fDot && Vector3.Angle(missile.GetForwardTransform(), target - missile.transform.position) < missile.maxOffBoresight * boresightFactor)
+				{
+					launchAuthorized = true;
+				}
 
-            }
+			}
 
-            return launchAuthorized;
-        }
+			return launchAuthorized;
+		}
 
-        /// <summary>
-        /// Check if AI is online and can target the current guardTarget with direct fire weapons
-        /// </summary>
-        /// <returns>true if AI might fire</returns>
-        bool AIMightDirectFire()
-        {
-            return (AI == null || !AI.pilotEnabled || !AI.CanEngage() || !guardTarget || !AI.IsValidFixedWeaponTarget(guardTarget));
-        }
+		/// <summary>
+		/// Check if AI is online and can target the current guardTarget with direct fire weapons
+		/// </summary>
+		/// <returns>true if AI might fire</returns>
+		bool AIMightDirectFire()
+		{
+			return (AI == null || !AI.pilotEnabled || !AI.CanEngage() || !guardTarget || !AI.IsValidFixedWeaponTarget(guardTarget));
+		}
 
-        #endregion
+		#endregion
 
-        #region Turret
-        int CheckTurret(float distance)
-        {
-            if (weaponIndex == 0 || selectedWeapon == null ||
-                !(selectedWeapon.GetWeaponClass() == WeaponClasses.Gun ||
-                  selectedWeapon.GetWeaponClass() == WeaponClasses.DefenseLaser ||
-                  selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket))
-            {
-                return 2;
-            }
-            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-            {
-                Debug.Log("[BDArmory]: Checking turrets");
-            }
-            float finalDistance = distance;
-            //vessel.LandedOrSplashed ? distance : distance/2; //decrease distance requirement if airborne
+		#region Turret
+		int CheckTurret(float distance)
+		{
+			if (weaponIndex == 0 || selectedWeapon == null ||
+				!(selectedWeapon.GetWeaponClass() == WeaponClasses.Gun ||
+				  selectedWeapon.GetWeaponClass() == WeaponClasses.DefenseLaser ||
+				  selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket))
+			{
+				return 2;
+			}
+			if (BDArmorySettings.DRAW_DEBUG_LABELS)
+			{
+				Debug.Log("[BDArmory]: Checking turrets");
+			}
+			float finalDistance = distance;
+			//vessel.LandedOrSplashed ? distance : distance/2; //decrease distance requirement if airborne
 
-            if (selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket)
-            {
-                List<RocketLauncher>.Enumerator rl = vessel.FindPartModulesImplementing<RocketLauncher>().GetEnumerator();
-                while (rl.MoveNext())
-                {
-                    if (rl.Current == null) continue;
-                    if (rl.Current.part.partInfo.title != selectedWeapon.GetPart().partInfo.title) continue;
-                    float gimbalTolerance = vessel.LandedOrSplashed ? 0 : 15;
-                    if (!(rl.Current.maxTargetingRange >= finalDistance) ||
-                        !TargetInTurretRange(rl.Current.turret, gimbalTolerance)) continue;
-                    if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                    {
-                        Debug.Log("[BDArmory]: " + selectedWeapon + " is valid!");
-                    }
-                    return 1;
-                }
-                rl.Dispose();
-            }
-            else
-            {
-                List<ModuleWeapon>.Enumerator weapon = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
-                while (weapon.MoveNext())
-                {
-                    if (weapon.Current == null) continue;
+			if (selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket || selectedWeapon.GetWeaponClass() == WeaponClasses.Gun || selectedWeapon.GetWeaponClass() == WeaponClasses.DefenseLaser)
+			{
+				List<ModuleWeapon>.Enumerator weapon = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
+				while (weapon.MoveNext())
+				{
+					if (weapon.Current == null) continue;
 					if (weapon.Current.GetShortName() != selectedWeapon.GetShortName()) continue;
 					float gimbalTolerance = vessel.LandedOrSplashed ? 0 : 15;
-                    if (((AI != null && AI.pilotEnabled && AI.CanEngage()) || (TargetInTurretRange(weapon.Current.turret, gimbalTolerance))) && weapon.Current.maxEffectiveDistance >= finalDistance)
-                    {
-                        if (weapon.Current.isOverheated)
-                        {
-                            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                            {
-                                Debug.Log("[BDArmory]: " + selectedWeapon + " is overheated!");
-                            }
-                            return -1;
-                        }
-                        if (CheckAmmo(weapon.Current) || BDArmorySettings.INFINITE_AMMO)
-                        {
-                            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                            {
-                                Debug.Log("[BDArmory]: " + selectedWeapon + " is valid!");
-                            }
-                            return 1;
-                        }
-                        if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                        {
-                            Debug.Log("[BDArmory]: " + selectedWeapon + " has no ammo.");
-                        }
-                        return -1;
-                    }
-                    if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                    {
-                        Debug.Log("[BDArmory]: " + selectedWeapon + " cannot reach target (" + distance + " vs " + weapon.Current.maxEffectiveDistance + ", yawRange: " + weapon.Current.yawRange + "). Continuing.");
-                    }
-                    //else return 0;
-                }
-                weapon.Dispose();
-            }
-            return 2;
-        }
+					if (((AI != null && AI.pilotEnabled && AI.CanEngage()) || (TargetInTurretRange(weapon.Current.turret, gimbalTolerance))) && weapon.Current.maxEffectiveDistance >= finalDistance)
+					{
+						if (weapon.Current.isOverheated)
+						{
+							if (BDArmorySettings.DRAW_DEBUG_LABELS)
+							{
+								Debug.Log("[BDArmory]: " + selectedWeapon + " is overheated!");
+							}
+							return -1;
+						}
+						if (CheckAmmo(weapon.Current) || BDArmorySettings.INFINITE_AMMO)
+						{
+							if (BDArmorySettings.DRAW_DEBUG_LABELS)
+							{
+								Debug.Log("[BDArmory]: " + selectedWeapon + " is valid!");
+							}
+							return 1;
+						}
+						if (BDArmorySettings.DRAW_DEBUG_LABELS)
+						{
+							Debug.Log("[BDArmory]: " + selectedWeapon + " has no ammo.");
+						}
+						return -1;
+					}
+					if (BDArmorySettings.DRAW_DEBUG_LABELS)
+					{
+						Debug.Log("[BDArmory]: " + selectedWeapon + " cannot reach target (" + distance + " vs " + weapon.Current.maxEffectiveDistance + ", yawRange: " + weapon.Current.yawRange + "). Continuing.");
+					}
+					//else return 0;
+				}
+				weapon.Dispose();
+			}
+			return 2;
+		}
 
-        bool TargetInTurretRange(ModuleTurret turret, float tolerance)
-        {
-            if (!turret)
-            {
-                return false;
-            }
+		bool TargetInTurretRange(ModuleTurret turret, float tolerance)
+		{
+			if (!turret)
+			{
+				return false;
+			}
 
-            if (!guardTarget)
-            {
-                if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                {
-                    Debug.Log("[BDArmory]: Checking turret range but no guard target");
-                }
-                return false;
-            }
-            if (turret.yawRange == 360)
-            {
-                if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                {
-                    Debug.Log("[BDArmory]: Checking turret range - turret has full swivel");
-                }
-                return true;
-            }
+			if (!guardTarget)
+			{
+				if (BDArmorySettings.DRAW_DEBUG_LABELS)
+				{
+					Debug.Log("[BDArmory]: Checking turret range but no guard target");
+				}
+				return false;
+			}
+			if (turret.yawRange == 360)
+			{
+				if (BDArmorySettings.DRAW_DEBUG_LABELS)
+				{
+					Debug.Log("[BDArmory]: Checking turret range - turret has full swivel");
+				}
+				return true;
+			}
 
-            Transform turretTransform = turret.yawTransform.parent;
-            Vector3 direction = guardTarget.transform.position - turretTransform.position;
-            Vector3 directionYaw = Vector3.ProjectOnPlane(direction, turretTransform.up);
-            Vector3 directionPitch = Vector3.ProjectOnPlane(direction, turretTransform.right);
+			Transform turretTransform = turret.yawTransform.parent;
+			Vector3 direction = guardTarget.transform.position - turretTransform.position;
+			Vector3 directionYaw = Vector3.ProjectOnPlane(direction, turretTransform.up);
+			Vector3 directionPitch = Vector3.ProjectOnPlane(direction, turretTransform.right);
 
-            float angleYaw = Vector3.Angle(turretTransform.forward, directionYaw);
-            //float anglePitch = Vector3.Angle(-turret.transform.forward, directionPitch);
-            float signedAnglePitch = Misc.Misc.SignedAngle(turretTransform.forward, directionPitch, turretTransform.up);
-            if (Mathf.Abs(signedAnglePitch) > 90)
-            {
-                signedAnglePitch -= Mathf.Sign(signedAnglePitch) * 180;
-            }
-            bool withinPitchRange = (signedAnglePitch >= turret.minPitch && signedAnglePitch <= turret.maxPitch + tolerance);
+			float angleYaw = Vector3.Angle(turretTransform.forward, directionYaw);
+			//float anglePitch = Vector3.Angle(-turret.transform.forward, directionPitch);
+			float signedAnglePitch = Misc.Misc.SignedAngle(turretTransform.forward, directionPitch, turretTransform.up);
+			if (Mathf.Abs(signedAnglePitch) > 90)
+			{
+				signedAnglePitch -= Mathf.Sign(signedAnglePitch) * 180;
+			}
+			bool withinPitchRange = (signedAnglePitch >= turret.minPitch && signedAnglePitch <= turret.maxPitch + tolerance);
 
-            if (angleYaw < (turret.yawRange / 2) + tolerance && withinPitchRange)
-            {
-                if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                {
-                    Debug.Log("[BDArmory]: Checking turret range - target is INSIDE gimbal limits! signedAnglePitch: " + signedAnglePitch + ", minPitch: " + turret.minPitch + ", maxPitch: " + turret.maxPitch);
-                }
-                return true;
-            }
-            else
-            {
-                if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                {
-                    Debug.Log("[BDArmory]: Checking turret range - target is OUTSIDE gimbal limits! signedAnglePitch: " + signedAnglePitch + ", minPitch: " + turret.minPitch + ", maxPitch: " + turret.maxPitch + ", angleYaw: " + angleYaw);
-                }
-                return false;
-            }
-        }
+			if (angleYaw < (turret.yawRange / 2) + tolerance && withinPitchRange)
+			{
+				if (BDArmorySettings.DRAW_DEBUG_LABELS)
+				{
+					Debug.Log("[BDArmory]: Checking turret range - target is INSIDE gimbal limits! signedAnglePitch: " + signedAnglePitch + ", minPitch: " + turret.minPitch + ", maxPitch: " + turret.maxPitch);
+				}
+				return true;
+			}
+			else
+			{
+				if (BDArmorySettings.DRAW_DEBUG_LABELS)
+				{
+					Debug.Log("[BDArmory]: Checking turret range - target is OUTSIDE gimbal limits! signedAnglePitch: " + signedAnglePitch + ", minPitch: " + turret.minPitch + ", maxPitch: " + turret.maxPitch + ", angleYaw: " + angleYaw);
+				}
+				return false;
+			}
+		}
 
-        bool CheckAmmo(ModuleWeapon weapon)
-        {
-            string ammoName = weapon.ammoName;
-            List<Part>.Enumerator p = vessel.parts.GetEnumerator();
-            while (p.MoveNext())
-            {
-                if (p.Current == null) continue;
-                IEnumerator<PartResource> resource = p.Current.Resources.GetEnumerator();
-                while (resource.MoveNext())
-                {
-                    if (resource.Current == null) continue;
-                    if (resource.Current.resourceName != ammoName) continue;
-                    if (resource.Current.amount > 0)
-                    {
-                        return true;
-                    }
-                }
-                resource.Dispose();
-            }
-            p.Dispose();
+		bool CheckAmmo(ModuleWeapon weapon)
+		{
+			string ammoName = weapon.ammoName;
+			List<Part>.Enumerator p = vessel.parts.GetEnumerator();
+			while (p.MoveNext())
+			{
+				if (p.Current == null) continue;
+				IEnumerator<PartResource> resource = p.Current.Resources.GetEnumerator();
+				while (resource.MoveNext())
+				{
+					if (resource.Current == null) continue;
+					if (resource.Current.resourceName != ammoName) continue;
+					if (resource.Current.amount > 0)
+					{
+						return true;
+					}
+				}
+				resource.Dispose();
+			}
+			p.Dispose();
 
-            return false;
-        }
-
-        void ToggleTurret()
+			return false;
+		}
+		public Dictionary<string, float> vesselAmmunition = new Dictionary<string, float>();
+		public void AmmoController()
+		{
+			if (selectedWeapon.GetWeaponClass() == WeaponClasses.Gun || (selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket && currentGun.externalAmmo))
+			{
+				string lastAmmoName = null;
+				List<ModuleWeapon>.Enumerator w = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
+				while (w.MoveNext())
+				{
+					if (w.Current == null) continue;
+					//if (w.Current.GetShortName() != selectedWeapon.GetShortName()) continue; run through all weapons instead of selected incase multiple weapon grous use same ammo type.
+					if (vesselAmmunition.TryGetValue(w.Current.ammoName, out w.Current.ammoAmount))
+					{
+						w.Current.ammoAmount = vesselAmmunition[w.Current.ammoName]; // once dictinary populated, simply grab ammocount from stored value
+					}
+					w.Current.UpdateAmmoMeter();
+					if (w.Current.ammoName == lastAmmoName) continue; //only run a single enumerator for ammocount per ammotype, instead of an enum per weapon instance
+					List<Part>.Enumerator p = vessel.parts.GetEnumerator();
+					while (p.MoveNext())
+					{
+						if (p.Current == null) continue;
+						IEnumerator<PartResource> resource = p.Current.Resources.GetEnumerator();
+						while (resource.MoveNext())
+						{
+							if (resource.Current == null) continue;
+							if (resource.Current.resourceName != w.Current.ammoName) continue;
+							if (vesselAmmunition.ContainsKey(w.Current.ammoName))
+							{
+								vesselAmmunition[w.Current.ammoName] = (float)resource.Current.amount;
+							}
+							else
+							{
+								vesselAmmunition.Add(w.Current.ammoName, (float)resource.Current.amount);
+							}
+						}
+						resource.Dispose();
+					}
+					p.Dispose();
+					lastAmmoName = w.Current.ammoName;
+				}
+				w.Dispose();
+			}
+		}
+		void ToggleTurret()
         {
             List<ModuleWeapon>.Enumerator weapon = vessel.FindPartModulesImplementing<ModuleWeapon>().GetEnumerator();
             while (weapon.MoveNext())

--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -18,302 +18,302 @@ namespace BDArmory.Modules
 {
 	public class ModuleWeapon : EngageableWeapon, IBDWeapon
 	{
-		#region Declarations
+	#region Declarations
 
-		public static ObjectPool bulletPool;
-		public static ObjectPool shellPool;
+	public static ObjectPool bulletPool;
+	public static ObjectPool shellPool;
 
-		Coroutine startupRoutine;
-		Coroutine shutdownRoutine;
+	Coroutine startupRoutine;
+	Coroutine shutdownRoutine;
 
-		bool finalFire;
+	bool finalFire;
 
-		public int rippleIndex = 0;
+	public int rippleIndex = 0;
 
-		// WeaponTypes.Cannon is deprecated.  identical behavior is achieved with WeaponType.Ballistic and bulletInfo.explosive = true.
-		public enum WeaponTypes
+	// WeaponTypes.Cannon is deprecated.  identical behavior is achieved with WeaponType.Ballistic and bulletInfo.explosive = true.
+	public enum WeaponTypes
+	{
+		Ballistic,
+		Rocket, //Cannon's depreciated, lets use this for rocketlaunchers
+		Laser
+	}
+
+	public enum WeaponStates
+	{
+		Enabled,
+		Disabled,
+		PoweringUp,
+		PoweringDown
+	}
+
+	public enum BulletDragTypes
+	{
+		None,
+		AnalyticEstimate,
+		NumericalIntegration
+	}
+
+	public WeaponStates weaponState = WeaponStates.Disabled;
+
+	//animations
+	private float fireAnimSpeed = 1;
+	//is set when setting up animation so it plays a full animation for each shot (animation speed depends on rate of fire)
+
+	public float bulletBallisticCoefficient;
+
+	public WeaponTypes eWeaponType;
+
+	public float heat;
+	public bool isOverheated;
+	public bool isOutofAmmo = false;
+	public float ammoAmount;
+	public float ammoMax;
+	private bool wasFiring;
+	//used for knowing when to stop looped audio clip (when you're not shooting, but you were)
+
+	AudioClip reloadCompleteAudioClip;
+	AudioClip fireSound;
+	AudioClip overheatSound;
+	AudioClip chargeSound;
+	public AudioSource audioSource;
+	AudioSource audioSource2;
+	AudioLowPassFilter lowpassFilter;
+
+	//AI
+	public bool aiControlled = false;
+	public bool autoFire;
+	public float autoFireLength = 0;
+	public float autoFireTimer = 0;
+
+	//used by AI to lead moving targets
+	private float targetDistance;
+	private Vector3 targetPosition;
+	private Vector3 targetVelocity;  // local frame velocity
+	private Vector3 targetAcceleration; // local frame velocity
+	private Vector3 targetVelocityPrevious; // for acceleration calculation
+	private Vector3 relativeVelocity;
+	Vector3 finalAimTarget;
+	Vector3 lastFinalAimTarget;
+	public Vessel legacyTargetVessel;
+	bool targetAcquired;
+
+	public Vector3? FiringSolutionVector => finalAimTarget.IsZero() ? (Vector3?)null : (finalAimTarget - fireTransforms[0].position).normalized;
+
+	public bool recentlyFiring //used by guard to know if it should evaid this
+	{
+		get { return Time.time - timeFired < 1; }
+	}
+	
+	//used to reduce volume of audio if multiple guns are being fired (needs to be improved/changed)
+	//private int numberOfGuns = 0;
+
+	//UI gauges(next to staging icon)
+	private ProtoStageIconInfo heatGauge;
+	private ProtoStageIconInfo emptyGauge;
+	private ProtoStageIconInfo ammoGauge;
+
+	//AI will fire gun if target is within this Cos(angle) of barrel
+	public float maxAutoFireCosAngle = 0.9993908f; //corresponds to ~2 degrees
+
+	//aimer textures
+	Vector3 pointingAtPosition;
+	Vector3 bulletPrediction;
+	Vector3 fixedLeadOffset = Vector3.zero;
+	float targetLeadDistance;
+
+	//gapless particles
+	List<BDAGaplessParticleEmitter> gaplessEmitters = new List<BDAGaplessParticleEmitter>();
+
+	//muzzleflash emitters
+	List<KSPParticleEmitter> muzzleFlashEmitters;
+
+	//module references
+	[KSPField] public int turretID = 0;
+	public ModuleTurret turret;
+	Vector3 trajectoryOffset = Vector3.zero;
+	MissileFire mf;
+
+	public MissileFire weaponManager
+	{
+		get
 		{
-			Ballistic,
-			Rocket, //Cannon's depreciated, lets use this for rocketlaunchers
-			Laser
-		}
-
-		public enum WeaponStates
-		{
-			Enabled,
-			Disabled,
-			PoweringUp,
-			PoweringDown
-		}
-
-		public enum BulletDragTypes
-		{
-			None,
-			AnalyticEstimate,
-			NumericalIntegration
-		}
-
-		public WeaponStates weaponState = WeaponStates.Disabled;
-
-		//animations
-		private float fireAnimSpeed = 1;
-		//is set when setting up animation so it plays a full animation for each shot (animation speed depends on rate of fire)
-
-		public float bulletBallisticCoefficient;
-
-		public WeaponTypes eWeaponType;
-
-		public float heat;
-		public bool isOverheated;
-		public bool isOutofAmmo = false;
-		public float ammoAmount;
-		public float ammoMax;
-		private bool wasFiring;
-		//used for knowing when to stop looped audio clip (when you're not shooting, but you were)
-
-		AudioClip reloadCompleteAudioClip;
-		AudioClip fireSound;
-		AudioClip overheatSound;
-		AudioClip chargeSound;
-		public AudioSource audioSource;
-		AudioSource audioSource2;
-		AudioLowPassFilter lowpassFilter;
-
-		//AI
-		public bool aiControlled = false;
-		public bool autoFire;
-		public float autoFireLength = 0;
-		public float autoFireTimer = 0;
-
-		//used by AI to lead moving targets
-		private float targetDistance;
-		private Vector3 targetPosition;
-		private Vector3 targetVelocity;  // local frame velocity
-		private Vector3 targetAcceleration; // local frame velocity
-		private Vector3 targetVelocityPrevious; // for acceleration calculation
-		private Vector3 relativeVelocity;
-		Vector3 finalAimTarget;
-		Vector3 lastFinalAimTarget;
-		public Vessel legacyTargetVessel;
-		bool targetAcquired;
-
-		public Vector3? FiringSolutionVector => finalAimTarget.IsZero() ? (Vector3?)null : (finalAimTarget - fireTransforms[0].position).normalized;
-
-		public bool recentlyFiring //used by guard to know if it should evaid this
-		{
-			get { return Time.time - timeFired < 1; }
-		}
-
-		//used to reduce volume of audio if multiple guns are being fired (needs to be improved/changed)
-		//private int numberOfGuns = 0;
-
-		//UI gauges(next to staging icon)
-		private ProtoStageIconInfo heatGauge;
-		private ProtoStageIconInfo emptyGauge;
-		private ProtoStageIconInfo ammoGauge;
-
-		//AI will fire gun if target is within this Cos(angle) of barrel
-		public float maxAutoFireCosAngle = 0.9993908f; //corresponds to ~2 degrees
-
-		//aimer textures
-		Vector3 pointingAtPosition;
-		Vector3 bulletPrediction;
-		Vector3 fixedLeadOffset = Vector3.zero;
-		float targetLeadDistance;
-
-		//gapless particles
-		List<BDAGaplessParticleEmitter> gaplessEmitters = new List<BDAGaplessParticleEmitter>();
-
-		//muzzleflash emitters
-		List<KSPParticleEmitter> muzzleFlashEmitters;
-
-		//module references
-		[KSPField] public int turretID = 0;
-		public ModuleTurret turret;
-		Vector3 trajectoryOffset = Vector3.zero;
-		MissileFire mf;
-
-		public MissileFire weaponManager
-		{
-			get
+			if (mf) return mf;
+			List<MissileFire>.Enumerator wm = vessel.FindPartModulesImplementing<MissileFire>().GetEnumerator();
+			while (wm.MoveNext())
 			{
-				if (mf) return mf;
-				List<MissileFire>.Enumerator wm = vessel.FindPartModulesImplementing<MissileFire>().GetEnumerator();
-				while (wm.MoveNext())
-				{
-					if (wm.Current == null) continue;
-					mf = wm.Current;
-					break;
-				}
-				wm.Dispose();
-				return mf;
+				if (wm.Current == null) continue;
+				mf = wm.Current;
+				break;
 			}
+			wm.Dispose();
+			return mf;
 		}
+	}
 
-		LineRenderer[] laserRenderers;
+	LineRenderer[] laserRenderers;
 
-		public bool pointingAtSelf; //true if weapon is pointing at own vessel
-		bool userFiring;
-		Vector3 laserPoint;
-		public bool slaved;
+	public bool pointingAtSelf; //true if weapon is pointing at own vessel
+	bool userFiring;
+	Vector3 laserPoint;
+	public bool slaved;
 
-		public Transform turretBaseTransform
+	public Transform turretBaseTransform
+	{
+		get
 		{
-			get
+			if (turret)
 			{
-				if (turret)
-				{
-					return turret.yawTransform.parent;
-				}
-				else
-				{
-					return fireTransforms[0];
-				}
-			}
-		}
-
-		public float maxPitch
-		{
-			get { return turret ? turret.maxPitch : 0; }
-		}
-
-		public float minPitch
-		{
-			get { return turret ? turret.minPitch : 0; }
-		}
-
-		public float yawRange
-		{
-			get { return turret ? turret.yawRange : 0; }
-		}
-
-		//weapon interface
-		public WeaponClasses GetWeaponClass()
-		{
-			if (eWeaponType == WeaponTypes.Ballistic)
-			{
-				return WeaponClasses.Gun;
-			}
-			else if (eWeaponType == WeaponTypes.Rocket)
-			{
-				return WeaponClasses.Rocket;
+				return turret.yawTransform.parent;
 			}
 			else
 			{
-				return WeaponClasses.DefenseLaser;
+				return fireTransforms[0];
 			}
 		}
+	}
 
-		public Part GetPart()
+	public float maxPitch
+	{
+		get { return turret ? turret.maxPitch : 0; }
+	}
+
+	public float minPitch
+	{
+		get { return turret ? turret.minPitch : 0; }
+	}
+	
+	public float yawRange
+	{
+		get { return turret ? turret.yawRange : 0; }
+	}
+
+	//weapon interface
+	public WeaponClasses GetWeaponClass()
+	{
+		if (eWeaponType == WeaponTypes.Ballistic)
 		{
-			return part;
+			return WeaponClasses.Gun;
 		}
-
-		public string GetSubLabel()
+		else if (eWeaponType == WeaponTypes.Rocket)
 		{
-			return string.Empty;
+			return WeaponClasses.Rocket;
 		}
-
-		public string GetMissileType()
+		else
 		{
-			return string.Empty;
+			return WeaponClasses.DefenseLaser;
 		}
+	}
 
-#if DEBUG
-		Vector3 relVelAdj;
-		Vector3 accAdj;
-		Vector3 gravAdj;
-#endif
+	public Part GetPart()
+	{
+		return part;
+	}
 
-		#endregion
+	public string GetSubLabel()
+	{
+		return string.Empty;
+	}
 
-		#region KSPFields
+	public string GetMissileType()
+	{
+		return string.Empty;
+	}
 
-		[KSPField(isPersistant = true, guiActive = true, guiName = "Weapon Name ", guiActiveEditor = true), UI_Label(affectSymCounterparts = UI_Scene.All, scene = UI_Scene.All)]
-		public string WeaponName;
+	#if DEBUG
+	Vector3 relVelAdj;
+	Vector3 accAdj;
+	Vector3 gravAdj;
+	#endif
 
-		[KSPField]
-		public string fireTransformName = "fireTransform";
-		public Transform[] fireTransforms;
+	#endregion
 
-		[KSPField]
-		public string shellEjectTransformName = "shellEject";
-		public Transform[] shellEjectTransforms;
+	#region KSPFields
 
-		[KSPField]
-		public bool hasDeployAnim = false;
-		[KSPField]
-		public string deployAnimName = "deployAnim";
-		AnimationState deployState;
-		[KSPField]
-		public bool hasFireAnimation = false;
-		[KSPField]
-		public string fireAnimName = "fireAnim";
-		private AnimationState fireState;
-		[KSPField]
-		public bool spinDownAnimation = false;
-		private bool spinningDown;
+	[KSPField(isPersistant = true, guiActive = true, guiName = "Weapon Name ", guiActiveEditor = true), UI_Label(affectSymCounterparts = UI_Scene.All, scene = UI_Scene.All)]
+	public string WeaponName;
 
-		//weapon specifications
-		[KSPField]
-		public float maxTargetingRange = 2000; //max range for raycasting and sighting
-		[KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Rate of Fire"),
-			UI_FloatRange(minValue = 100f, maxValue = 1500, stepIncrement = 25f, scene = UI_Scene.Editor, affectSymCounterparts = UI_Scene.All)]
-		public float roundsPerMinute = 850; //move RoF slider to editor for rockets
-		[KSPField]
-		public float maxDeviation = 1; //inaccuracy two standard deviations in degrees (two because backwards compatibility :)
-		[KSPField]
-		public float maxEffectiveDistance = 2500; //used by AI to select appropriate weapon
-		[KSPField]
-		public float bulletMass = 0.3880f; //mass in KG - used for damage and recoil and drag
-		[KSPField]
-		public float caliber = 30; //caliber in mm, used for penetration calcs
-		[KSPField]
-		public float bulletDmgMult = 1; //Used for heat damage modifier for non-explosive bullets
-		[KSPField]
-		public float bulletVelocity = 1030; //velocity in meters/second
-		[KSPField]
-		public float ECPerShot = 0; //EC to use per shot for weapons like railguns
+	[KSPField]
+	public string fireTransformName = "fireTransform";
+	public Transform[] fireTransforms;
 
-		[KSPField]
-		public string bulletDragTypeName = "AnalyticEstimate";
-		public BulletDragTypes bulletDragType;
+	[KSPField]
+	public string shellEjectTransformName = "shellEject";
+	public Transform[] shellEjectTransforms;
 
-		//drag area of the bullet in m^2; equal to Cd * A with A being the frontal area of the bullet; as a first approximation, take Cd to be 0.3
-		//bullet mass / bullet drag area.  Used in analytic estimate to speed up code
-		[KSPField]
-		public float bulletDragArea = 1.209675e-5f;
+	[KSPField]
+	public bool hasDeployAnim = false;
+	[KSPField]
+	public string deployAnimName = "deployAnim";
+	AnimationState deployState;
+	[KSPField]
+	public bool hasFireAnimation = false;
+	[KSPField]
+	public string fireAnimName = "fireAnim";
+	private AnimationState fireState;
+	[KSPField]
+	public bool spinDownAnimation = false;
+	private bool spinningDown;
 
-		private BulletInfo bulletInfo;
+	//weapon specifications
+	[KSPField]
+	public float maxTargetingRange = 2000; //max range for raycasting and sighting
+	[KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Rate of Fire"),
+	UI_FloatRange(minValue = 100f, maxValue = 1500, stepIncrement = 25f, scene = UI_Scene.Editor, affectSymCounterparts = UI_Scene.All)]
+	public float roundsPerMinute = 850; //move RoF slider to editor for rockets
+	[KSPField]
+	public float maxDeviation = 1; //inaccuracy two standard deviations in degrees (two because backwards compatibility :)
+	[KSPField]
+	public float maxEffectiveDistance = 2500; //used by AI to select appropriate weapon
+	[KSPField]
+	public float bulletMass = 0.3880f; //mass in KG - used for damage and recoil and drag
+	[KSPField]
+	public float caliber = 30; //caliber in mm, used for penetration calcs
+	[KSPField]
+	public float bulletDmgMult = 1; //Used for heat damage modifier for non-explosive bullets
+	[KSPField]
+	public float bulletVelocity = 1030; //velocity in meters/second
+	[KSPField]
+	public float ECPerShot = 0; //EC to use per shot for weapons like railguns
 
-		[KSPField]
-		public string bulletType = "def";
+	[KSPField]
+	public string bulletDragTypeName = "AnalyticEstimate";
+	public BulletDragTypes bulletDragType;
 
-		[KSPField]
-		public string ammoName = "50CalAmmo"; //resource usage
-		[KSPField]
-		public float requestResourceAmount = 1; //amount of resource/ammo to deplete per shot
-		[KSPField]
-		public float shellScale = 0.66f; //scale of shell to eject
-		[KSPField]
-		public bool hasRecoil = true;
-		[KSPField]
-		public float recoilReduction = 1; //for reducing recoil on large guns with built in compensation
+	//drag area of the bullet in m^2; equal to Cd * A with A being the frontal area of the bullet; as a first approximation, take Cd to be 0.3
+	//bullet mass / bullet drag area.  Used in analytic estimate to speed up code
+	[KSPField]
+	public float bulletDragArea = 1.209675e-5f;
 
-		[KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Fire Limits"),
-		 UI_Toggle(disabledText = "None", enabledText = "In range")]
-		public bool onlyFireInRange = true;
-		//prevent firing when gun's turret is trying to exceed gimbal limits
+	private BulletInfo bulletInfo;
 
-		[KSPField]
-		public bool bulletDrop = true; //projectiles are affected by gravity
+	[KSPField]
+	public string bulletType = "def";
 
-		[KSPField]
-		public string weaponType = "ballistic";
-		//ballistic, cannon or laser
+	[KSPField]
+	public string ammoName = "50CalAmmo"; //resource usage
+	[KSPField]
+	public float requestResourceAmount = 1; //amount of resource/ammo to deplete per shot
+	[KSPField]
+	public float shellScale = 0.66f; //scale of shell to eject
+	[KSPField]
+	public bool hasRecoil = true;
+	[KSPField]
+	public float recoilReduction = 1; //for reducing recoil on large guns with built in compensation
 
-		[KSPField]
-		public float laserDamage = 10000; //base damage/second of lasers
+	[KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Fire Limits"),
+	UI_Toggle(disabledText = "None", enabledText = "In range")]
+	public bool onlyFireInRange = true;
+	//prevent firing when gun's turret is trying to exceed gimbal limits
+
+	[KSPField]
+	public bool bulletDrop = true; //projectiles are affected by gravity
+
+	[KSPField]
+	public string weaponType = "ballistic";
+	//ballistic, rocket or laser
+
+	[KSPField]
+	public float laserDamage = 10000; //base damage/second of lasers
 
         //TODO: deprectated, moved to bullet config
         [KSPField]
@@ -323,22 +323,22 @@ namespace BDArmory.Modules
         [KSPField]
         public float cannonShellHeat = -1; //if non-negative, heat damage
 
-		//Rocket info; 
-		[KSPField(isPersistant = false)] public string rocketType;
-		[KSPField(isPersistant = false)] public string rocketModelPath;
-		[KSPField(isPersistant = false)] public float rocketMass;
-		[KSPField(isPersistant = false)] public float thrust;
-		[KSPField(isPersistant = false)] public float thrustTime;
-		[KSPField(isPersistant = false)] public float blastRadius;
-		[KSPField(isPersistant = false)] public float blastForce;
-		[KSPField] public float blastHeat = -1;
-		[KSPField(isPersistant = false)] public bool descendingOrder = true;
-		[KSPField] public float thrustDeviation = 0.10f;
-		[KSPField] public bool externalAmmo = false; //used for rocketlaunchers drawing from ammoboxes instead of internals
-		Transform[] rockets;
+	//Rocket info; 
+	[KSPField(isPersistant = false)] public string rocketType;
+	[KSPField(isPersistant = false)] public string rocketModelPath;
+	[KSPField(isPersistant = false)] public float rocketMass;
+	[KSPField(isPersistant = false)] public float thrust;
+	[KSPField(isPersistant = false)] public float thrustTime;
+	[KSPField(isPersistant = false)] public float blastRadius;
+	[KSPField(isPersistant = false)] public float blastForce;
+	[KSPField] public float blastHeat = -1;
+	[KSPField(isPersistant = false)] public bool descendingOrder = true;
+	[KSPField] public float thrustDeviation = 0.10f;
+	[KSPField] public bool externalAmmo = false; //used for rocketlaunchers drawing from ammoboxes instead of internals
+	Transform[] rockets;
 
-		//projectile graphics
-		[KSPField]
+	//projectile graphics
+	[KSPField]
         public string projectileColor = "255, 130, 0, 255"; //final color of projectile
         Color projectileColorC;
         [KSPField]
@@ -369,9 +369,9 @@ namespace BDArmory.Modules
         int tracerIntervalCounter;
         [KSPField]
         public string bulletTexturePath = "BDArmory/Textures/bullet";
-		[KSPField]
-		public string laserTexturePath = "BDArmory/Textures/laser";
-		[KSPField]
+	[KSPField]
+	public string laserTexturePath = "BDArmory/Textures/laser";
+	[KSPField]
         public bool oneShotWorldParticles = false;
 
         //heat
@@ -394,7 +394,6 @@ namespace BDArmory.Modules
         public float tanAngle = 0.0001f;
         //Angle of divergeance/2. Theoretical minimum value calculated using θ = (1.22 L/RL)/2, 
         //where L is laser's wavelength and RL is the radius of the mirror (=gun).
-
 
         //audioclip paths
         [KSPField]
@@ -419,7 +418,6 @@ namespace BDArmory.Modules
         [KSPField]
         public string reloadCompletePath = string.Empty;
 
-
         private ProtoStageIconInfo reloadBar;
         [KSPField]
         public bool showReloadMeter = false; //used for cannons or guns with extremely low rate of fire
@@ -431,20 +429,20 @@ namespace BDArmory.Modules
         [KSPField]
         public bool proximityDetonation = false;
 
-		[KSPField(isPersistant = true, guiActive = true, guiName = "Fuzed Detonation Range ", guiActiveEditor = false)]
-		public float defaultDetonationRange = 3500;
+	[KSPField(isPersistant = true, guiActive = true, guiName = "Fuzed Detonation Range ", guiActiveEditor = false)]
+	public float defaultDetonationRange = 3500;
 
-		[KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Proximity Fuze Radius"), UI_FloatRange(minValue = 0f, maxValue = 100f, stepIncrement = 1f, scene = UI_Scene.Editor, affectSymCounterparts = UI_Scene.All)]
-		public float detonationRange = 5;
+	[KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Proximity Fuze Radius"), UI_FloatRange(minValue = 0f, maxValue = 100f, stepIncrement = 1f, scene = UI_Scene.Editor, affectSymCounterparts = UI_Scene.All)]
+	public float detonationRange = 5;
 
-		[KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Max Detonation Range"),
-		 UI_FloatRange(minValue = 500, maxValue = 8000f, stepIncrement = 5f, scene = UI_Scene.All)]
-		public float maxAirDetonationRange = 3500;
-		[KSPField]
-		public bool airDetonationTiming = true;
+	[KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "Max Detonation Range"),
+	 UI_FloatRange(minValue = 500, maxValue = 8000f, stepIncrement = 5f, scene = UI_Scene.All)]
+	public float maxAirDetonationRange = 3500;
+	[KSPField]
+	public bool airDetonationTiming = true;
 
-		//auto proximity tracking
-		[KSPField]
+	//auto proximity tracking
+	[KSPField]
         public float autoProxyTrackRange = 0;
         bool atprAcquired;
         int aptrTicker;
@@ -453,37 +451,35 @@ namespace BDArmory.Modules
         public float initialFireDelay = 0; //used to ripple fire multiple weapons of this type
 
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Barrage")]
-        public bool
-            useRippleFire = true;
+        public bool useRippleFire = true;
 
         [KSPEvent(guiActive = false, guiActiveEditor = true, guiName = "Toggle Barrage")]
         public void ToggleRipple()
         {
-            List<Part>.Enumerator craftPart = EditorLogic.fetch.ship.parts.GetEnumerator();
-            while (craftPart.MoveNext())
-            {
-                if (craftPart.Current == null) continue;
-                if (craftPart.Current.name != part.name) continue;
-                List<ModuleWeapon>.Enumerator weapon = craftPart.Current.FindModulesImplementing<ModuleWeapon>().GetEnumerator();
-                while (weapon.MoveNext())
-                {
-                    if (weapon.Current == null) continue;
-                    weapon.Current.useRippleFire = !weapon.Current.useRippleFire;
-                }
-                weapon.Dispose();
-            }
-            craftPart.Dispose();
+        	List<Part>.Enumerator craftPart = EditorLogic.fetch.ship.parts.GetEnumerator();
+            	while (craftPart.MoveNext())
+            	{
+                	if (craftPart.Current == null) continue;
+                	if (craftPart.Current.name != part.name) continue;
+                	List<ModuleWeapon>.Enumerator weapon = craftPart.Current.FindModulesImplementing<ModuleWeapon>().GetEnumerator();
+                	while (weapon.MoveNext())
+                	{
+                    		if (weapon.Current == null) continue;
+                    		weapon.Current.useRippleFire = !weapon.Current.useRippleFire;
+                	}
+                	weapon.Dispose();
+            	}
+            	craftPart.Dispose();
         }
 
         IEnumerator IncrementRippleIndex(float delay)
         {
-            if (delay > 0)
-            {
-                yield return new WaitForSeconds(delay);
-            }
-            weaponManager.gunRippleIndex = weaponManager.gunRippleIndex + 1;
-
-            //Debug.Log("incrementing ripple index to: " + weaponManager.gunRippleIndex);
+ 	        if (delay > 0)
+    	        {
+  	        	yield return new WaitForSeconds(delay);
+         	}
+        	weaponManager.gunRippleIndex = weaponManager.gunRippleIndex + 1;
+     	       //Debug.Log("incrementing ripple index to: " + weaponManager.gunRippleIndex);
         }
         
         #endregion
@@ -493,25 +489,24 @@ namespace BDArmory.Modules
         [KSPAction("Toggle Weapon")]
         public void AGToggle(KSPActionParam param)
         {
-            Toggle();
+        	Toggle();
         }
 
         [KSPField(guiActive = true, guiActiveEditor = false, guiName = "Status")]
-        public string guiStatusString =
-            "Disabled";
+        public string guiStatusString = "Disabled";
 
         //PartWindow buttons
         [KSPEvent(guiActive = true, guiActiveEditor = false, guiName = "Toggle")]
         public void Toggle()
         {
-            if (weaponState == WeaponStates.Disabled || weaponState == WeaponStates.PoweringDown)
-            {
-                EnableWeapon();
-            }
-            else
-            {
-                DisableWeapon();
-            }
+            	if (weaponState == WeaponStates.Disabled || weaponState == WeaponStates.PoweringDown)
+            	{	
+                	EnableWeapon();
+            	}
+            	else
+            	{
+                	DisableWeapon();
+            	}
         }
 
         bool agHoldFiring;
@@ -519,42 +514,40 @@ namespace BDArmory.Modules
         [KSPAction("Fire (Toggle)")]
         public void AGFireToggle(KSPActionParam param)
         {
-            agHoldFiring = (param.type == KSPActionType.Activate);
+            	agHoldFiring = (param.type == KSPActionType.Activate);
         }
 
         [KSPAction("Fire (Hold)")]
         public void AGFireHold(KSPActionParam param)
         {
-            StartCoroutine(FireHoldRoutine(param.group));
+            	StartCoroutine(FireHoldRoutine(param.group));
         }
-		[KSPEvent(guiActive = true, guiName = "Jettison", active = true, guiActiveEditor = false)]
-		public void Jettison()
+	[KSPEvent(guiActive = true, guiName = "Jettison", active = true, guiActiveEditor = false)]
+	public void Jettison()
+	{
+		if (turret || eWeaponType != WeaponTypes.Rocket)
 		{
-			if (turret || eWeaponType != WeaponTypes.Rocket)
-			{
-				return;
-			}
-
+			return;
+		}
 			part.decouple(0);
 			if (BDArmorySetup.Instance.ActiveWeaponManager != null)
-				BDArmorySetup.Instance.ActiveWeaponManager.UpdateList();
-		}
-		IEnumerator FireHoldRoutine(KSPActionGroup group)
+			BDArmorySetup.Instance.ActiveWeaponManager.UpdateList();
+	}
+	IEnumerator FireHoldRoutine(KSPActionGroup group)
         {
-            KeyBinding key = Misc.Misc.AGEnumToKeybinding(group);
-            if (key == null)
-            {
-                yield break;
-            }
+            	KeyBinding key = Misc.Misc.AGEnumToKeybinding(group);
+            	if (key == null)
+            	{
+                	yield break;
+            	}
 
-            while (key.GetKey())
-            {
-                agHoldFiring = true;
-                yield return null;
-            }
-
-            agHoldFiring = false;
-            yield break;
+            	while (key.GetKey())
+            	{
+	                agHoldFiring = true;
+        	        yield return null;
+            	}
+            	agHoldFiring = false;
+            	yield break;
         }
 
         #endregion
@@ -563,230 +556,228 @@ namespace BDArmory.Modules
 
         public override void OnAwake()
         {
-            base.OnAwake();
+            	base.OnAwake();
 
-            part.stagingIconAlwaysShown = true;
-            this.part.stackIconGrouping = StackIconGrouping.SAME_TYPE;
+            	part.stagingIconAlwaysShown = true;
+            	this.part.stackIconGrouping = StackIconGrouping.SAME_TYPE;
         }
 
         public override void OnStart(StartState state)
         {
-            base.OnStart(state);
+		base.OnStart(state);
 
-            part.stagingIconAlwaysShown = true;
-            this.part.stackIconGrouping = StackIconGrouping.SAME_TYPE;
+           	part.stagingIconAlwaysShown = true;
+            	this.part.stackIconGrouping = StackIconGrouping.SAME_TYPE;
 
-            GameEvents.onVesselSwitching.Add(ReloadIconOnVesselSwitch);
+            	GameEvents.onVesselSwitching.Add(ReloadIconOnVesselSwitch);
 
-			Events["HideUI"].active = false;
-			Events["ShowUI"].active = true;
-			ParseWeaponType();
+		Events["HideUI"].active = false;
+		Events["ShowUI"].active = true;
+		ParseWeaponType();
             
-            // extension for feature_engagementenvelope
-            InitializeEngagementRange(0, maxEffectiveDistance);
-			if (string.IsNullOrEmpty(GetShortName()))
-			{
-				shortName = part.partInfo.title;
-			}
-			WeaponName = shortName;
-			IEnumerator<KSPParticleEmitter> emitter = part.FindModelComponents<KSPParticleEmitter>().AsEnumerable().GetEnumerator();
-            while (emitter.MoveNext())
-            {
-                if (emitter.Current == null) continue;
-                emitter.Current.emit = false;
-                EffectBehaviour.AddParticleEmitter(emitter.Current);
-            }
-            emitter.Dispose();
+            	// extension for feature_engagementenvelope
+            	InitializeEngagementRange(0, maxEffectiveDistance);
+		if (string.IsNullOrEmpty(GetShortName()))
+		{
+			shortName = part.partInfo.title;
+		}
+		WeaponName = shortName;
+		IEnumerator<KSPParticleEmitter> emitter = part.FindModelComponents<KSPParticleEmitter>().AsEnumerable().GetEnumerator();
+            	while (emitter.MoveNext())
+            	{
+                	if (emitter.Current == null) continue;
+                	emitter.Current.emit = false;
+                	EffectBehaviour.AddParticleEmitter(emitter.Current);
+            	}
+            	emitter.Dispose();
 
-            if (roundsPerMinute >= 1500)
-            {
-                Events["ToggleRipple"].guiActiveEditor = false;
-                Fields["useRippleFire"].guiActiveEditor = false;
-            }
-			if (eWeaponType != WeaponTypes.Rocket)
-			{
-				Fields["roundsPerMinute"].guiActiveEditor = false;
-			}
+            	if (roundsPerMinute >= 1500)
+            	{
+               	 	Events["ToggleRipple"].guiActiveEditor = false;
+                	Fields["useRippleFire"].guiActiveEditor = false;
+            	}
+		if (eWeaponType != WeaponTypes.Rocket)
+		{
+			Fields["roundsPerMinute"].guiActiveEditor = false;
+		}
 
-            vessel.Velocity();
-			if (airDetonation)
+            	vessel.Velocity();
+		if (airDetonation)
+		{
+			UI_FloatRange detRange = (UI_FloatRange)Fields["maxAirDetonationRange"].uiControlEditor;
+			detRange.maxValue = maxEffectiveDistance;
+		}
+		else
+		{
+			Fields["maxAirDetonationRange"].guiActive = false;
+			Fields["maxAirDetonationRange"].guiActiveEditor = false;
+			Fields["defaultDetonationRange"].guiActive = false;
+			Fields["defaultDetonationRange"].guiActiveEditor = false;
+		}
+		if (!proximityDetonation)
+		{
+			Fields["detonationRange"].guiActive = false;
+			Fields["detonationRange"].guiActiveEditor = false;
+		}
+		muzzleFlashEmitters = new List<KSPParticleEmitter>();
+            	IEnumerator<Transform> mtf = part.FindModelTransforms("muzzleTransform").AsEnumerable().GetEnumerator();
+            	while (mtf.MoveNext())
+            	{	
+                	if (mtf.Current == null) continue;
+                	KSPParticleEmitter kpe = mtf.Current.GetComponent<KSPParticleEmitter>();
+                	EffectBehaviour.AddParticleEmitter(kpe);
+                	muzzleFlashEmitters.Add(kpe);
+                	kpe.emit = false;
+            	}
+            	mtf.Dispose();
+		if (HighLogic.LoadedSceneIsFlight)
+		{
+			//setup transforms
+			fireTransforms = part.FindModelTransforms(fireTransformName);
+			shellEjectTransforms = part.FindModelTransforms(shellEjectTransformName);
+			if (eWeaponType == WeaponTypes.Ballistic)
 			{
-				UI_FloatRange detRange = (UI_FloatRange)Fields["maxAirDetonationRange"].uiControlEditor;
-				detRange.maxValue = maxEffectiveDistance;
-			}
-			else
-			{
-				Fields["maxAirDetonationRange"].guiActive = false;
-				Fields["maxAirDetonationRange"].guiActiveEditor = false;
-				Fields["defaultDetonationRange"].guiActive = false;
-				Fields["defaultDetonationRange"].guiActiveEditor = false;
-			}
-			if (!proximityDetonation)
-			{
-				Fields["detonationRange"].guiActive = false;
-				Fields["detonationRange"].guiActiveEditor = false;
-			}
-			muzzleFlashEmitters = new List<KSPParticleEmitter>();
-            IEnumerator<Transform> mtf = part.FindModelTransforms("muzzleTransform").AsEnumerable().GetEnumerator();
-            while (mtf.MoveNext())
-            {
-                if (mtf.Current == null) continue;
-                KSPParticleEmitter kpe = mtf.Current.GetComponent<KSPParticleEmitter>();
-                EffectBehaviour.AddParticleEmitter(kpe);
-                muzzleFlashEmitters.Add(kpe);
-                kpe.emit = false;
-            }
-            mtf.Dispose();
-			if (HighLogic.LoadedSceneIsFlight)
-			{
-				//setup transforms
-				fireTransforms = part.FindModelTransforms(fireTransformName);
-				shellEjectTransforms = part.FindModelTransforms(shellEjectTransformName);
-
-				if (eWeaponType == WeaponTypes.Ballistic)
+				if (bulletPool == null)
 				{
-
-					if (bulletPool == null)
-					{
-						SetupBulletPool();
-					}
-					if (shellPool == null)
-					{
-						SetupShellPool();
-					}
+					SetupBulletPool();
 				}
-				if (eWeaponType == WeaponTypes.Rocket && !externalAmmo)// only call these for rocket pods
+				if (shellPool == null)
 				{
-					MakeRocketArray();
-					UpdateRocketScales();
+					SetupShellPool();
 				}
-				//setup emitters
-				IEnumerator<KSPParticleEmitter> pe = part.FindModelComponents<KSPParticleEmitter>().AsEnumerable().GetEnumerator();
-				while (pe.MoveNext())
-				{
-					if (pe.Current == null) continue;
-					pe.Current.maxSize *= part.rescaleFactor;
-					pe.Current.minSize *= part.rescaleFactor;
-					pe.Current.shape3D *= part.rescaleFactor;
-					pe.Current.shape2D *= part.rescaleFactor;
-					pe.Current.shape1D *= part.rescaleFactor;
+			}
+			if (eWeaponType == WeaponTypes.Rocket && !externalAmmo)// only call these for rocket pods
+			{
+				MakeRocketArray();
+				UpdateRocketScales();
+			}
+			//setup emitters
+			IEnumerator<KSPParticleEmitter> pe = part.FindModelComponents<KSPParticleEmitter>().AsEnumerable().GetEnumerator();
+			while (pe.MoveNext())
+			{
+				if (pe.Current == null) continue;
+				pe.Current.maxSize *= part.rescaleFactor;
+				pe.Current.minSize *= part.rescaleFactor;
+				pe.Current.shape3D *= part.rescaleFactor;
+				pe.Current.shape2D *= part.rescaleFactor;
+				pe.Current.shape1D *= part.rescaleFactor;
 
-					if (pe.Current.useWorldSpace && !oneShotWorldParticles)
-					{
-						BDAGaplessParticleEmitter gpe = pe.Current.gameObject.AddComponent<BDAGaplessParticleEmitter>();
-						gpe.part = part;
-						gaplessEmitters.Add(gpe);
-					}
-					else
-					{
-						EffectBehaviour.AddParticleEmitter(pe.Current);
-					}
+				if (pe.Current.useWorldSpace && !oneShotWorldParticles)
+				{
+					BDAGaplessParticleEmitter gpe = pe.Current.gameObject.AddComponent<BDAGaplessParticleEmitter>();
+					gpe.part = part;
+					gaplessEmitters.Add(gpe);
 				}
-				pe.Dispose();
-
-				//setup projectile colors
-				projectileColorC = Misc.Misc.ParseColor255(projectileColor);
-				startColorC = Misc.Misc.ParseColor255(startColor);
-
-				//init and zero points
-				targetPosition = Vector3.zero;
-				pointingAtPosition = Vector3.zero;
-				bulletPrediction = Vector3.zero;
-
-				//setup audio
-				SetupAudio();
-
-				//laser setup
-				if (eWeaponType == WeaponTypes.Laser)
+				else
 				{
-					SetupLaserSpecifics();
+					EffectBehaviour.AddParticleEmitter(pe.Current);
 				}
-				//ammo gauge setup
-				List<Part>.Enumerator p = vessel.parts.GetEnumerator(); //Moved to OnStart, only needs to proc once
-				while (p.MoveNext())
+			}
+			pe.Dispose();
+
+			//setup projectile colors
+			projectileColorC = Misc.Misc.ParseColor255(projectileColor);
+			startColorC = Misc.Misc.ParseColor255(startColor);
+
+			//init and zero points
+			targetPosition = Vector3.zero;
+			pointingAtPosition = Vector3.zero;
+			bulletPrediction = Vector3.zero;
+
+			//setup audio
+			SetupAudio();
+
+			//laser setup
+			if (eWeaponType == WeaponTypes.Laser)
+			{
+				SetupLaserSpecifics();
+			}
+			//ammo gauge setup
+			List<Part>.Enumerator p = vessel.parts.GetEnumerator(); //Moved to OnStart, only needs to proc once
+			while (p.MoveNext())
+			{
+				if (p.Current == null) continue;
+				IEnumerator<PartResource> resource = p.Current.Resources.GetEnumerator();
+				while (resource.MoveNext())
 				{
-					if (p.Current == null) continue;
-					IEnumerator<PartResource> resource = p.Current.Resources.GetEnumerator();
-					while (resource.MoveNext())
+					if (resource.Current == null) continue;
 					{
-						if (resource.Current == null) continue;
+						if (resource.Current.resourceName != ammoName) continue; //doesn't return ElectricCharge for the ABL, but does return resource amoutns for lasers using custom resources.
 						{
-							if (resource.Current.resourceName != ammoName) continue; //doesn't return ElectricCharge for the ABL, but does return resource amoutns for lasers using custom resources.
-							{
-								ammoAmount = (float)resource.Current.amount;
-								ammoMax = (float)resource.Current.maxAmount;
-							}
+							ammoAmount = (float)resource.Current.amount;
+							ammoMax = (float)resource.Current.maxAmount;
 						}
 					}
-					resource.Dispose();
 				}
-				p.Dispose();
-				//mf.AmmoController();
+				resource.Dispose();
 			}
-			else if (HighLogic.LoadedSceneIsEditor)
+			p.Dispose();
+			//mf.AmmoController();
+		}
+		else if (HighLogic.LoadedSceneIsEditor)
+		{
+			fireTransforms = part.FindModelTransforms(fireTransformName);
+			WeaponNameWindow.OnActionGroupEditorOpened.Add(OnActionGroupEditorOpened);
+			WeaponNameWindow.OnActionGroupEditorClosed.Add(OnActionGroupEditorClosed);
+		}
+		//turret setup
+		List<ModuleTurret>.Enumerator turr = part.FindModulesImplementing<ModuleTurret>().GetEnumerator();
+		    while (turr.MoveNext())
+            	{
+                	if (turr.Current == null) continue;
+                	if (turr.Current.turretID != turretID) continue;
+                	turret = turr.Current;
+			turret.SetReferenceTransform(fireTransforms[0]);
+                	break;
+            	}
+            	turr.Dispose();
+
+		if (!turret)
+            	{
+                	Fields["onlyFireInRange"].guiActive = false;
+                	Fields["onlyFireInRange"].guiActiveEditor = false;
+            	}
+		if (HighLogic.LoadedSceneIsEditor || HighLogic.LoadedSceneIsFlight)
+		{
+			if (turret || eWeaponType != WeaponTypes.Rocket)
 			{
-				fireTransforms = part.FindModelTransforms(fireTransformName);
-				WeaponNameWindow.OnActionGroupEditorOpened.Add(OnActionGroupEditorOpened);
-				WeaponNameWindow.OnActionGroupEditorClosed.Add(OnActionGroupEditorClosed);
+				Events["Jettison"].guiActive = false;
 			}
-			//turret setup
-			List<ModuleTurret>.Enumerator turr = part.FindModulesImplementing<ModuleTurret>().GetEnumerator();
-            while (turr.MoveNext())
-            {
-                if (turr.Current == null) continue;
-                if (turr.Current.turretID != turretID) continue;
-                turret = turr.Current;
-				turret.SetReferenceTransform(fireTransforms[0]);
-                break;
-            }
-            turr.Dispose();
+		}
 
-			if (!turret)
-            {
-                Fields["onlyFireInRange"].guiActive = false;
-                Fields["onlyFireInRange"].guiActiveEditor = false;
-            }
-			if (HighLogic.LoadedSceneIsEditor || HighLogic.LoadedSceneIsFlight)
-				{
-				if (turret || eWeaponType != WeaponTypes.Rocket)
-				{
-					Events["Jettison"].guiActive = false;
-				}
-			}
+		//setup animations
 
-			//setup animations
+		if (!string.IsNullOrEmpty(deployAnimName) && eWeaponType == WeaponTypes.Rocket) // hack to grab the hasAnim bool for legacy RL's converted via MM
+		{
+			hasDeployAnim = true;
+		}
+		if (hasDeployAnim)
+            	{
+                	deployState = Misc.Misc.SetUpSingleAnimation(deployAnimName, part);
+                	deployState.normalizedTime = 0;
+                	deployState.speed = 0;
+                	deployState.enabled = true;
+            	}
+            	if (hasFireAnimation)
+            	{
+	                fireState = Misc.Misc.SetUpSingleAnimation(fireAnimName, part);
+        	        fireState.enabled = false;
+            	}
 
-			if (!string.IsNullOrEmpty(deployAnimName) && eWeaponType == WeaponTypes.Rocket) // hack to grab the hasAnim bool for legacy RL's converted via MM
-			{
-				hasDeployAnim = true;
-			}
-			if (hasDeployAnim)
-            {
-                deployState = Misc.Misc.SetUpSingleAnimation(deployAnimName, part);
-                deployState.normalizedTime = 0;
-                deployState.speed = 0;
-                deployState.enabled = true;
-            }
-            if (hasFireAnimation)
-            {
-                fireState = Misc.Misc.SetUpSingleAnimation(fireAnimName, part);
-                fireState.enabled = false;
-            }
+            	SetupBullet();
 
-            SetupBullet();
+            	if (bulletInfo == null)
+            	{
+                	if(BDArmorySettings.DRAW_DEBUG_LABELS)
+                    	Debug.Log("[BDArmory]: Failed To load bullet : " + bulletType);
+            	}
+            	else
+            	{
+	                if(BDArmorySettings.DRAW_DEBUG_LABELS)
+	                Debug.Log("[BDArmory]: BulletType Loaded : " + bulletType);
+            	}
 
-            if (bulletInfo == null)
-            {
-                if(BDArmorySettings.DRAW_DEBUG_LABELS)
-                    Debug.Log("[BDArmory]: Failed To load bullet : " + bulletType);
-            }
-            else
-            {
-                if(BDArmorySettings.DRAW_DEBUG_LABELS)
-                    Debug.Log("[BDArmory]: BulletType Loaded : " + bulletType);
-            }
-
-            BDArmorySetup.OnVolumeChange += UpdateVolume;
+            	BDArmorySetup.OnVolumeChange += UpdateVolume;
         }
 
         private void ReloadIconOnVesselSwitch(Vessel data0, Vessel data1)
@@ -798,160 +789,158 @@ namespace BDArmory.Modules
             {
                 part.stagingIconAlwaysShown = true;
                 this.part.stackIconGrouping = StackIconGrouping.SAME_TYPE;
-				ammoGauge = null;
-				emptyGauge = null;
-				heatGauge = null;
-				reloadBar = null;
-			}
+		ammoGauge = null;
+		emptyGauge = null;
+		heatGauge = null;
+		reloadBar = null;
+		}
         }
 
         void OnDestroy()
         {
-            BDArmorySetup.OnVolumeChange -= UpdateVolume;
-			WeaponNameWindow.OnActionGroupEditorOpened.Remove(OnActionGroupEditorOpened);
-			WeaponNameWindow.OnActionGroupEditorClosed.Remove(OnActionGroupEditorClosed);
-		}
-		void Update()
+            	BDArmorySetup.OnVolumeChange -= UpdateVolume;
+		WeaponNameWindow.OnActionGroupEditorOpened.Remove(OnActionGroupEditorOpened);
+		WeaponNameWindow.OnActionGroupEditorClosed.Remove(OnActionGroupEditorClosed);
+	}
+	void Update() 
         {
-			float updateList = 0;
-			if (HighLogic.LoadedSceneIsFlight && !vessel.packed && vessel.isCommandable)
+		float updateList = 0;
+		if (HighLogic.LoadedSceneIsFlight && !vessel.packed && vessel.isCommandable)
+		{
+			if (vessel.isActiveVessel)// moved gauges stuff to Update. Why was it in FixedUpdate to begin with?
 			{
-				if (vessel.isActiveVessel)// lets not have to re-initialize and redraw all gauges and ammo counts every tick. Seriously, what was I thinking?
+				if (showReloadMeter)
 				{
-					if (showReloadMeter)
-					{
-						UpdateReloadMeter();
-					}
-					else
-					{
-						UpdateHeatMeter();
-					}
-					UpdateAmmo();
-					if (!isOutofAmmo && ammoGauge == null) //only redraw these if nulled from vessel switch
-					{
-						UpdateAmmoMeter();
-					}
-					if (isOutofAmmo && emptyGauge == null)
-					{
-						UpdateEmptyAlert();
-					}
-					updateList -= Time.fixedDeltaTime;
-					if (updateList < 0)
-					{
-						UpdateAmmoMeter(); //call once a second to check for infinite ammo toggle, sanity check, etc
-						UpdateEmptyAlert();
-						updateList = 1.0f;
-					}
+					UpdateReloadMeter();
 				}
-				UpdateHeat();
+				else
+				{
+					UpdateHeatMeter();
+				}
+				UpdateAmmo();
+				if (!isOutofAmmo && ammoGauge == null) //only redraw these if nulled from vessel switch
+				{
+					UpdateAmmoMeter();
+				}
+				if (isOutofAmmo && emptyGauge == null)
+				{
+					UpdateEmptyAlert();
+				}
+				updateList -= Time.fixedDeltaTime;
+				if (updateList < 0)
+				{
+					UpdateAmmoMeter(); //call once a second to check for infinite ammo toggle, sanity check, etc
+					UpdateEmptyAlert();
+					updateList = 1.0f;
+				}
 			}
+			UpdateHeat();
+		}
 		
-            if (HighLogic.LoadedSceneIsFlight && FlightGlobals.ready && !vessel.packed && vessel.IsControllable)
-            {
-				if (lowpassFilter)
+            	if (HighLogic.LoadedSceneIsFlight && FlightGlobals.ready && !vessel.packed && vessel.IsControllable)
+            	{
+			if (lowpassFilter)
+			{
+				if (InternalCamera.Instance && InternalCamera.Instance.isActive)
 				{
-					if (InternalCamera.Instance && InternalCamera.Instance.isActive)
-					{
-						lowpassFilter.enabled = true;
-					}
-					else
-					{
-						lowpassFilter.enabled = false;
-					}
+					lowpassFilter.enabled = true;
 				}
-                if (weaponState == WeaponStates.Enabled &&
-                    (TimeWarp.WarpMode != TimeWarp.Modes.HIGH || TimeWarp.CurrentRate == 1))
-                {
-                    userFiring = (BDInputUtils.GetKey(BDInputSettingsFields.WEAP_FIRE_KEY) &&
-                                  (vessel.isActiveVessel || BDArmorySettings.REMOTE_SHOOTING) && !MapView.MapIsEnabled &&
-                                  !aiControlled);
-                    if ((userFiring || autoFire || agHoldFiring) &&
-                        (yawRange == 0 || (maxPitch - minPitch) == 0 ||
-                         turret.TargetInRange(finalAimTarget, 10, float.MaxValue)))
-                    {
-                        if (useRippleFire && (pointingAtSelf || isOverheated))
-                        {
-                            StartCoroutine(IncrementRippleIndex(0));
-                            finalFire = false;
-                        }
-                        else if (eWeaponType == WeaponTypes.Ballistic || eWeaponType == WeaponTypes.Rocket) 
-                        {
-                            finalFire = true;
-                        }
-                    }
-                    else
-                    {
-                        if (spinDownAnimation) spinningDown = true;
-                        if (eWeaponType == WeaponTypes.Laser) audioSource.Stop();
-                        if (!oneShotSound && wasFiring)
-                        {
-                            audioSource.Stop();
-                            wasFiring = false;
-                            audioSource2.PlayOneShot(overheatSound);
-                        }
-                    }
-                }
-                else
-                {
-                    audioSource.Stop();
-                    autoFire = false;
-                }
+				else
+				{
+					lowpassFilter.enabled = false;
+				}
+			}
+               		if (weaponState == WeaponStates.Enabled && (TimeWarp.WarpMode != TimeWarp.Modes.HIGH || TimeWarp.CurrentRate == 1))
+                	{
+	        		userFiring = (BDInputUtils.GetKey(BDInputSettingsFields.WEAP_FIRE_KEY) &&
+				(vessel.isActiveVessel || BDArmorySettings.REMOTE_SHOOTING) && !MapView.MapIsEnabled &&
+                        	!aiControlled);
+                    		if ((userFiring || autoFire || agHoldFiring) &&
+                        	(yawRange == 0 || (maxPitch - minPitch) == 0 ||
+                        	turret.TargetInRange(finalAimTarget, 10, float.MaxValue)))
+                    			{
+                        		if (useRippleFire && (pointingAtSelf || isOverheated))
+                        		{	
+                            			StartCoroutine(IncrementRippleIndex(0));
+                            			finalFire = false;
+                        		}
+                        		else if (eWeaponType == WeaponTypes.Ballistic || eWeaponType == WeaponTypes.Rocket) 
+                        		{
+                            		finalFire = true;
+                        		}
+                    		}
+                    		else
+                    		{
+                        		if (spinDownAnimation) spinningDown = true;
+                        		if (eWeaponType == WeaponTypes.Laser) audioSource.Stop();
+                        		if (!oneShotSound && wasFiring)
+                        		{
+                            			audioSource.Stop();
+                            			wasFiring = false;
+                            			audioSource2.PlayOneShot(overheatSound);
+                        		}	
+                    		}
+                	}
+                	else
+                	{
+                    		audioSource.Stop();
+                    		autoFire = false;
+                	}
 
-                if (spinningDown && spinDownAnimation && hasFireAnimation)
-                {
-                    if (fireState.normalizedTime > 1) fireState.normalizedTime = 0;
-                    fireState.speed = fireAnimSpeed;
-                    fireAnimSpeed = Mathf.Lerp(fireAnimSpeed, 0, 0.04f);
-                }
-            }
+                	if (spinningDown && spinDownAnimation && hasFireAnimation)
+                	{
+                    		if (fireState.normalizedTime > 1) fireState.normalizedTime = 0;
+                    		fireState.speed = fireAnimSpeed;
+                    		fireAnimSpeed = Mathf.Lerp(fireAnimSpeed, 0, 0.04f);
+                	}
+            	}
         }
 
-		void FixedUpdate()
+	void FixedUpdate()
         {
-			if (HighLogic.LoadedSceneIsFlight && !vessel.packed)
-            {
-                if (!vessel.IsControllable)
-                {
-                    if (weaponState != WeaponStates.PoweringDown || weaponState != WeaponStates.Disabled)
-                    {
-                        DisableWeapon();
-                    }
-                    return;
-                }
-				if (weaponState == WeaponStates.Enabled &&
-                    (TimeWarp.WarpMode != TimeWarp.Modes.HIGH || TimeWarp.CurrentRate == 1))
-                {
-                    //Aim();
-                    StartCoroutine(AimAndFireAtEndOfFrame());
+		if (HighLogic.LoadedSceneIsFlight && !vessel.packed)
+            	{
+                	if (!vessel.IsControllable)
+                	{
+                    		if (weaponState != WeaponStates.PoweringDown || weaponState != WeaponStates.Disabled)
+                    		{
+                        		DisableWeapon();
+                    		}
+                    		return;
+                	}
+			if (weaponState == WeaponStates.Enabled &&
+                    	(TimeWarp.WarpMode != TimeWarp.Modes.HIGH || TimeWarp.CurrentRate == 1))
+                	{
+               			//Aim();
+                		StartCoroutine(AimAndFireAtEndOfFrame());
 
-
-                    if (eWeaponType == WeaponTypes.Laser)
-                    {
+	                    	if (eWeaponType == WeaponTypes.Laser)
+                    	{	
                         if ((userFiring || autoFire || agHoldFiring) &&
                             (!turret || turret.TargetInRange(targetPosition, 10, float.MaxValue)))
                         {
-                            finalFire = true;
+                            	finalFire = true;
                         }
                         else
                         {
-                            for (int i = 0; i < laserRenderers.Length; i++)
-                            {
-                                laserRenderers[i].enabled = false;
-                            }
-                            audioSource.Stop();
+                            	for (int i = 0; i < laserRenderers.Length; i++)
+                            	{
+                                	laserRenderers[i].enabled = false;
+                            	}
+                            	audioSource.Stop();
                         }
-                    }
                 }
-                else if (eWeaponType == WeaponTypes.Laser)
+        }
+	else if (eWeaponType == WeaponTypes.Laser)
+        {
+        	for (int i = 0; i < laserRenderers.Length; i++)
                 {
-                    for (int i = 0; i < laserRenderers.Length; i++)
-                    {
                         laserRenderers[i].enabled = false;
-                    }
-                    audioSource.Stop();
                 }
-            }
-            lastFinalAimTarget = finalAimTarget;
+                    	audioSource.Stop();
+                }
+        }
+        lastFinalAimTarget = finalAimTarget;
         }
 		private void UpdateMenus(bool visible)
 		{
@@ -983,373 +972,361 @@ namespace BDArmory.Modules
 			WeaponGroupWindow.ShowGUI(this);
 			UpdateMenus(true);
 		}
-		void OnGUI()
+	void OnGUI()
         {
-            if (weaponState == WeaponStates.Enabled && vessel && !vessel.packed && vessel.isActiveVessel &&
+        	if (weaponState == WeaponStates.Enabled && vessel && !vessel.packed && vessel.isActiveVessel &&
                 BDArmorySettings.DRAW_AIMERS && !aiControlled && !MapView.MapIsEnabled && !pointingAtSelf)
-            {
-                float size = 30;
+		{
+               		float size = 30;
+               		Vector3 reticlePosition;
+               		if (BDArmorySettings.AIM_ASSIST)
+               		{
+                  		if (targetAcquired && (slaved || yawRange < 1 || maxPitch - minPitch < 1))
+                  		{
+                        		reticlePosition = pointingAtPosition + fixedLeadOffset;
 
-                Vector3 reticlePosition;
-                if (BDArmorySettings.AIM_ASSIST)
-                {
-                    if (targetAcquired && (slaved || yawRange < 1 || maxPitch - minPitch < 1))
-                    {
-                        reticlePosition = pointingAtPosition + fixedLeadOffset;
+                        		if (!slaved)
+                        		{
+                            			BDGUIUtils.DrawLineBetweenWorldPositions(pointingAtPosition, reticlePosition, 2,
+                                		new Color(0, 1, 0, 0.6f));
+                        		}
 
-                        if (!slaved)
-                        {
-                            BDGUIUtils.DrawLineBetweenWorldPositions(pointingAtPosition, reticlePosition, 2,
-                                new Color(0, 1, 0, 0.6f));
-                        }
+                        		BDGUIUtils.DrawTextureOnWorldPos(pointingAtPosition, BDArmorySetup.Instance.greenDotTexture,
+                        		new Vector2(6, 6), 0);
 
-                        BDGUIUtils.DrawTextureOnWorldPos(pointingAtPosition, BDArmorySetup.Instance.greenDotTexture,
-                            new Vector2(6, 6), 0);
+                       			if (atprAcquired)
+                        		{
+                            			BDGUIUtils.DrawTextureOnWorldPos(targetPosition, BDArmorySetup.Instance.openGreenSquare,
+                                		new Vector2(20, 20), 0);
+                        		}
+                		}
+                		else
+                		{	
+					reticlePosition = bulletPrediction;
+				}
+         		}
+			else
+       	 		{
+       	        		reticlePosition = pointingAtPosition;
+        		}
 
-                        if (atprAcquired)
-                        {
-                            BDGUIUtils.DrawTextureOnWorldPos(targetPosition, BDArmorySetup.Instance.openGreenSquare,
-                                new Vector2(20, 20), 0);
-                        }
-                    }
-                    else
-                    {
-						reticlePosition = bulletPrediction;
-					}
-                }
-                else
-                {
-                    reticlePosition = pointingAtPosition;
-                }
+         		Texture2D texture;
+         		if (Vector3.Angle(pointingAtPosition - transform.position, finalAimTarget - transform.position) < 1f)
+         		{
+                		texture = BDArmorySetup.Instance.greenSpikedPointCircleTexture;
+         		}
+         		else
+         		{
+				texture = BDArmorySetup.Instance.greenPointCircleTexture;
+         		}	
+         		BDGUIUtils.DrawTextureOnWorldPos(reticlePosition, texture, new Vector2(size, size), 0);
 
+         		if (BDArmorySettings.DRAW_DEBUG_LINES)
+         		{
+         			if (targetAcquired)
+                		{
+					BDGUIUtils.DrawLineBetweenWorldPositions(fireTransforms[0].position, targetPosition, 2,
+					Color.blue);
+				}
+         		}
+  		}
 
-                Texture2D texture;
-                if (Vector3.Angle(pointingAtPosition - transform.position, finalAimTarget - transform.position) < 1f)
-                {
-                    texture = BDArmorySetup.Instance.greenSpikedPointCircleTexture;
-                }
-                else
-                {
-                    texture = BDArmorySetup.Instance.greenPointCircleTexture;
-                }
-                BDGUIUtils.DrawTextureOnWorldPos(reticlePosition, texture, new Vector2(size, size), 0);
+       		if (HighLogic.LoadedSceneIsEditor && BDArmorySetup.showWeaponAlignment)
+        	{
+                	DrawAlignmentIndicator();
+        	}
 
-                if (BDArmorySettings.DRAW_DEBUG_LINES)
-                {
-                    if (targetAcquired)
-                    {
-						BDGUIUtils.DrawLineBetweenWorldPositions(fireTransforms[0].position, targetPosition, 2,
-							Color.blue);
-					}
-                }
-            }
+        	#if DEBUG
+        	if (BDArmorySettings.DRAW_DEBUG_LINES && weaponState == WeaponStates.Enabled && vessel && !vessel.packed && !MapView.MapIsEnabled)
+        	{
+        		BDGUIUtils.DrawLineBetweenWorldPositions(targetPosition + transform.right * 3, targetPosition - transform.right * 3, 2, Color.cyan);
+                	BDGUIUtils.DrawLineBetweenWorldPositions(targetPosition + transform.up * 3, targetPosition - transform.up * 3, 2, Color.cyan);
+                	BDGUIUtils.DrawLineBetweenWorldPositions(targetPosition + transform.forward * 3, targetPosition - transform.forward * 3, 2, Color.cyan);
 
-            if (HighLogic.LoadedSceneIsEditor && BDArmorySetup.showWeaponAlignment)
-            {
-                DrawAlignmentIndicator();
-            }
+                	BDGUIUtils.DrawLineBetweenWorldPositions(targetPosition, targetPosition + relVelAdj, 2, Color.green);
+                	BDGUIUtils.DrawLineBetweenWorldPositions(targetPosition + relVelAdj, targetPosition + relVelAdj + accAdj, 2, Color.magenta);
+                	BDGUIUtils.DrawLineBetweenWorldPositions(targetPosition + relVelAdj + accAdj, targetPosition + relVelAdj + accAdj + gravAdj, 2, Color.yellow);
 
-            #if DEBUG
-            if (BDArmorySettings.DRAW_DEBUG_LINES && weaponState == WeaponStates.Enabled && vessel && !vessel.packed && !MapView.MapIsEnabled)
-            {
-                BDGUIUtils.DrawLineBetweenWorldPositions(targetPosition + transform.right * 3, targetPosition - transform.right * 3, 2, Color.cyan);
-                BDGUIUtils.DrawLineBetweenWorldPositions(targetPosition + transform.up * 3, targetPosition - transform.up * 3, 2, Color.cyan);
-                BDGUIUtils.DrawLineBetweenWorldPositions(targetPosition + transform.forward * 3, targetPosition - transform.forward * 3, 2, Color.cyan);
-
-                BDGUIUtils.DrawLineBetweenWorldPositions(targetPosition, targetPosition + relVelAdj, 2, Color.green);
-                BDGUIUtils.DrawLineBetweenWorldPositions(targetPosition + relVelAdj, targetPosition + relVelAdj + accAdj, 2, Color.magenta);
-                BDGUIUtils.DrawLineBetweenWorldPositions(targetPosition + relVelAdj + accAdj, targetPosition + relVelAdj + accAdj + gravAdj, 2, Color.yellow);
-
-                BDGUIUtils.DrawLineBetweenWorldPositions(finalAimTarget + transform.right * 4, finalAimTarget - transform.right * 4, 2, Color.cyan);
-                BDGUIUtils.DrawLineBetweenWorldPositions(finalAimTarget + transform.up * 4, finalAimTarget - transform.up * 4, 2, Color.cyan);
-                BDGUIUtils.DrawLineBetweenWorldPositions(finalAimTarget + transform.forward * 4, finalAimTarget - transform.forward * 4, 2, Color.cyan);
-            }
-            #endif
+                	BDGUIUtils.DrawLineBetweenWorldPositions(finalAimTarget + transform.right * 4, finalAimTarget - transform.right * 4, 2, Color.cyan);
+                	BDGUIUtils.DrawLineBetweenWorldPositions(finalAimTarget + transform.up * 4, finalAimTarget - transform.up * 4, 2, Color.cyan);
+                	BDGUIUtils.DrawLineBetweenWorldPositions(finalAimTarget + transform.forward * 4, finalAimTarget - transform.forward * 4, 2, Color.cyan);
+        	}
+        	#endif
         }
 	#endregion
-       //new regions sorting/organizing gun, laser, and rocket code into their own sections for ease of maintainence
+        //new regions sorting/organizing gun, laser, and rocket code into their own sections for ease of maintainence
 	#region Gun Fire 
 
-        private void Fire()
-        {
-            if (BDArmorySetup.GameIsPaused)
-            {
-                if (audioSource.isPlaying)
-                {
-                    audioSource.Stop();
-                }
-                return;
-            }
+	private void Fire()
+	{
+		if (BDArmorySetup.GameIsPaused)
+		{
+			if (audioSource.isPlaying)
+			{
+				audioSource.Stop();
+			}
+			return;
+		}
+		float timeGap = (60 / roundsPerMinute) * TimeWarp.CurrentRate;
+		if (Time.time - timeFired > timeGap
+		&& !isOverheated
+		&& !pointingAtSelf
+		&& (aiControlled || !Misc.Misc.CheckMouseIsOnGui())
+		&& WMgrAuthorized())
+		{
+			bool effectsShot = false;
+			//Transform[] fireTransforms = part.FindModelTransforms("fireTransform");
+			for (float iTime = Mathf.Min(Time.time - timeFired - timeGap, TimeWarp.fixedDeltaTime); iTime >= 0; iTime -= timeGap)
+				for (int i = 0; i < fireTransforms.Length; i++)
+				{
+					//if ((BDArmorySettings.INFINITE_AMMO || part.RequestResource(ammoName, requestResourceAmount) > 0))
+					if (CanFire())
+					{
+						Transform fireTransform = fireTransforms[i];
+						spinningDown = false;
 
-            float timeGap = (60 / roundsPerMinute) * TimeWarp.CurrentRate;
-            if (Time.time - timeFired > timeGap 
-                && !isOverheated 
-                && !pointingAtSelf 
-                && (aiControlled || !Misc.Misc.CheckMouseIsOnGui())
-                && WMgrAuthorized())
-            {
-                bool effectsShot = false;
-                //Transform[] fireTransforms = part.FindModelTransforms("fireTransform");
-                for (float iTime = Mathf.Min(Time.time - timeFired - timeGap, TimeWarp.fixedDeltaTime); iTime >= 0; iTime -= timeGap)
-                for (int i = 0; i < fireTransforms.Length; i++)
-                {
-                    //if ((BDArmorySettings.INFINITE_AMMO || part.RequestResource(ammoName, requestResourceAmount) > 0))
-                    if (CanFire())
-                        {
-                        Transform fireTransform = fireTransforms[i];
-                        spinningDown = false;
+						//recoil
+						if (hasRecoil)
+						{
+							part.rb.AddForceAtPosition((-fireTransform.forward) * (bulletVelocity * bulletMass / 1000 * BDArmorySettings.RECOIL_FACTOR * recoilReduction),
+							fireTransform.position, ForceMode.Impulse);
+						}
+						if (!effectsShot)
+						{
+							//sound
+							if (oneShotSound)
+							{
+								audioSource.Stop();
+								audioSource.PlayOneShot(fireSound);
+							}
+							else
+							{
+								wasFiring = true;
+								if (!audioSource.isPlaying)
+								{
+									audioSource.clip = fireSound;
+									audioSource.loop = false;
+									audioSource.time = 0;
+									audioSource.Play();
+								}
+								else
+								{
+									if (audioSource.time >= fireSound.length)
+									{
+										audioSource.time = soundRepeatTime;
+									}
+								}
+							}
 
-                        //recoil
-                        if (hasRecoil)
-                        {
-                            part.rb.AddForceAtPosition((-fireTransform.forward) * (bulletVelocity * bulletMass/1000 * BDArmorySettings.RECOIL_FACTOR * recoilReduction),
-                                fireTransform.position, ForceMode.Impulse);
-                        }
+							//animation
+							if (hasFireAnimation)
+							{
+								float unclampedSpeed = (roundsPerMinute * fireState.length) / 60f;
+								float lowFramerateFix = 1;
+								if (roundsPerMinute > 500f)
+								{
+									lowFramerateFix = (0.02f / Time.deltaTime);
+								}
+								fireAnimSpeed = Mathf.Clamp(unclampedSpeed, 1f * lowFramerateFix, 20f * lowFramerateFix);
+								fireState.enabled = true;
+								if (unclampedSpeed == fireAnimSpeed || fireState.normalizedTime > 1)
+								{
+									fireState.normalizedTime = 0;
+								}
+								fireState.speed = fireAnimSpeed;
+								fireState.normalizedTime = Mathf.Repeat(fireState.normalizedTime, 1);
+								//Debug.Log("fireAnim time: " + fireState.normalizedTime + ", speed; " + fireState.speed);
+							}
 
-                        if (!effectsShot)
-                        {
-                            //sound
-                            if (oneShotSound)
-                            {
-                                audioSource.Stop();
-                                audioSource.PlayOneShot(fireSound);
-                            }
-                            else
-                            {
-                                wasFiring = true;
-                                if (!audioSource.isPlaying)
-                                {
-                                    audioSource.clip = fireSound;
-                                    audioSource.loop = false;
-                                    audioSource.time = 0;
-                                    audioSource.Play();
-                                }
-                                else
-                                {
-                                    if (audioSource.time >= fireSound.length)
-                                    {
-                                        audioSource.time = soundRepeatTime;
-                                    }
-                                }
-                            }
+							//muzzle flash
+							List<KSPParticleEmitter>.Enumerator pEmitter = muzzleFlashEmitters.GetEnumerator();
+							while (pEmitter.MoveNext())
+							{
+								if (pEmitter.Current == null) continue;
+								//KSPParticleEmitter pEmitter = mtf.gameObject.GetComponent<KSPParticleEmitter>();
+								if (pEmitter.Current.useWorldSpace && !oneShotWorldParticles) continue;
+								if (pEmitter.Current.maxEnergy < 0.5f)
+								{
+									float twoFrameTime = Mathf.Clamp(Time.deltaTime * 2f, 0.02f, 0.499f);
+									pEmitter.Current.maxEnergy = twoFrameTime;
+									pEmitter.Current.minEnergy = twoFrameTime / 3f;
+								}
+								pEmitter.Current.Emit();
+							}
+							pEmitter.Dispose();
+							
+							List<BDAGaplessParticleEmitter>.Enumerator gpe = gaplessEmitters.GetEnumerator();
+							while (gpe.MoveNext())
+							{
+								if (gpe.Current == null) continue;
+								gpe.Current.EmitParticles();
+							}
+							gpe.Dispose();
 
-                            //animation
-                            if (hasFireAnimation)
-                            {
-                                float unclampedSpeed = (roundsPerMinute * fireState.length) / 60f;
-                                float lowFramerateFix = 1;
-                                if (roundsPerMinute > 500f)
-                                {
-                                    lowFramerateFix = (0.02f / Time.deltaTime);
-                                }
-                                fireAnimSpeed = Mathf.Clamp(unclampedSpeed, 1f * lowFramerateFix, 20f * lowFramerateFix);
-                                fireState.enabled = true;
-                                if (unclampedSpeed == fireAnimSpeed || fireState.normalizedTime > 1)
-                                {
-                                    fireState.normalizedTime = 0;
-                                }
-                                fireState.speed = fireAnimSpeed;
-                                fireState.normalizedTime = Mathf.Repeat(fireState.normalizedTime, 1);
+							//shell ejection
+							if (BDArmorySettings.EJECT_SHELLS)
+							{
+								IEnumerator<Transform> sTf = shellEjectTransforms.AsEnumerable().GetEnumerator();
+								while (sTf.MoveNext())
+								{
+									if (sTf.Current == null) continue;
+									GameObject ejectedShell = shellPool.GetPooledObject();
+									ejectedShell.transform.position = sTf.Current.position;
+									//+(part.rb.velocity*TimeWarp.fixedDeltaTime);
+									ejectedShell.transform.rotation = sTf.Current.rotation;
+									ejectedShell.transform.localScale = Vector3.one * shellScale;
+									ShellCasing shellComponent = ejectedShell.GetComponent<ShellCasing>();
+									shellComponent.initialV = part.rb.velocity;
+									ejectedShell.SetActive(true);
+								}
+								sTf.Dispose();
+							}
+							effectsShot = true;
+						}
 
-                                //Debug.Log("fireAnim time: " + fireState.normalizedTime + ", speed; " + fireState.speed);
-                            }
+						//firing bullet
+						GameObject firedBullet = bulletPool.GetPooledObject();
+						PooledBullet pBullet = firedBullet.GetComponent<PooledBullet>();
 
-                            //muzzle flash
-                            List<KSPParticleEmitter>.Enumerator pEmitter = muzzleFlashEmitters.GetEnumerator();
-                            while (pEmitter.MoveNext())
-                            {
-                                if (pEmitter.Current == null) continue;
-                                //KSPParticleEmitter pEmitter = mtf.gameObject.GetComponent<KSPParticleEmitter>();
-                                if (pEmitter.Current.useWorldSpace && !oneShotWorldParticles) continue;
-                                if (pEmitter.Current.maxEnergy < 0.5f)
-                                {
-                                    float twoFrameTime = Mathf.Clamp(Time.deltaTime * 2f, 0.02f, 0.499f);
-                                    pEmitter.Current.maxEnergy = twoFrameTime;
-                                    pEmitter.Current.minEnergy = twoFrameTime / 3f;
-                                }
-                                pEmitter.Current.Emit();
-                            }
-                            pEmitter.Dispose();
+						firedBullet.transform.position = fireTransform.position;
 
-                            List<BDAGaplessParticleEmitter>.Enumerator gpe = gaplessEmitters.GetEnumerator();
-                            while (gpe.MoveNext())
-                            {
-                                if (gpe.Current == null) continue;
-                                gpe.Current.EmitParticles();
-                            }
-                            gpe.Dispose();
+						pBullet.caliber = bulletInfo.caliber;
+						pBullet.bulletVelocity = bulletInfo.bulletVelocity;
+						pBullet.bulletMass = bulletInfo.bulletMass;
+						pBullet.explosive = bulletInfo.explosive;
+						pBullet.apBulletMod = bulletInfo.apBulletMod;
+						pBullet.bulletDmgMult = bulletDmgMult;
 
-                            //shell ejection
-                            if (BDArmorySettings.EJECT_SHELLS)
-                            {
-                                IEnumerator<Transform> sTf = shellEjectTransforms.AsEnumerable().GetEnumerator();
-                                while (sTf.MoveNext())
-                                {
-                                    if (sTf.Current == null) continue;                                    
-                                    GameObject ejectedShell = shellPool.GetPooledObject();
-                                    ejectedShell.transform.position = sTf.Current.position;
-                                    //+(part.rb.velocity*TimeWarp.fixedDeltaTime);
-                                    ejectedShell.transform.rotation = sTf.Current.rotation;
-                                    ejectedShell.transform.localScale = Vector3.one * shellScale;
-                                    ShellCasing shellComponent = ejectedShell.GetComponent<ShellCasing>();
-                                    shellComponent.initialV = part.rb.velocity;
-                                    ejectedShell.SetActive(true);
-                                }
-                                sTf.Dispose();
-                            }
-                            effectsShot = true;
-                        }
-                        
-                        //firing bullet
-                        GameObject firedBullet = bulletPool.GetPooledObject();
-                        PooledBullet pBullet = firedBullet.GetComponent<PooledBullet>();
+						//A = π x (Ø / 2)^2
+						bulletDragArea = Mathf.PI * Mathf.Pow(caliber / 2f, 2f);
 
-                        firedBullet.transform.position = fireTransform.position;
+						//Bc = m/Cd * A
+						bulletBallisticCoefficient = bulletMass / ((bulletDragArea / 1000000f) * 0.295f); // mm^2 to m^2
 
-                        pBullet.caliber = bulletInfo.caliber;
-                        pBullet.bulletVelocity = bulletInfo.bulletVelocity;
-                        pBullet.bulletMass = bulletInfo.bulletMass;
-                        pBullet.explosive = bulletInfo.explosive;
-                        pBullet.apBulletMod = bulletInfo.apBulletMod;                  
-                        pBullet.bulletDmgMult = bulletDmgMult;
+						//Bc = m/d^2 * i where i = 0.484
+						//bulletBallisticCoefficient = bulletMass / Mathf.Pow(caliber / 1000, 2f) * 0.484f;
 
-                        //A = π x (Ø / 2)^2
-                        bulletDragArea = Mathf.PI * Mathf.Pow(caliber / 2f, 2f);
+						pBullet.ballisticCoefficient = bulletBallisticCoefficient;
 
-                        //Bc = m/Cd * A
-                        bulletBallisticCoefficient = bulletMass / ((bulletDragArea / 1000000f) * 0.295f); // mm^2 to m^2
-                        
-                        //Bc = m/d^2 * i where i = 0.484
-                        //bulletBallisticCoefficient = bulletMass / Mathf.Pow(caliber / 1000, 2f) * 0.484f;
+						pBullet.flightTimeElapsed = iTime;
+						// measure bullet lifetime in time rather than in distance, because distances get very relative in orbit
+						pBullet.timeToLiveUntil = Mathf.Max(maxTargetingRange, maxEffectiveDistance) / bulletVelocity * 1.1f + Time.time;
 
-                        pBullet.ballisticCoefficient = bulletBallisticCoefficient;
+						timeFired = Time.time - iTime;
 
-                        pBullet.flightTimeElapsed = iTime;
-                        // measure bullet lifetime in time rather than in distance, because distances get very relative in orbit
-                        pBullet.timeToLiveUntil = Mathf.Max(maxTargetingRange, maxEffectiveDistance) / bulletVelocity * 1.1f + Time.time;
+						Vector3 firedVelocity =	VectorUtils.GaussianDirectionDeviation(fireTransform.forward, maxDeviation / 2) * bulletVelocity;
 
-                        timeFired = Time.time - iTime;
-                        
-                        Vector3 firedVelocity =
-                            VectorUtils.GaussianDirectionDeviation(fireTransform.forward, maxDeviation / 2) * bulletVelocity;
+						pBullet.currentVelocity = (part.rb.velocity + Krakensbane.GetFrameVelocityV3f()) + firedVelocity; // use the real velocity, w/o offloading
+						firedBullet.transform.position += (part.rb.velocity + Krakensbane.GetFrameVelocityV3f()) * Time.fixedDeltaTime
+																+ pBullet.currentVelocity * iTime;
+						pBullet.sourceVessel = vessel;
+						pBullet.bulletTexturePath = bulletTexturePath;
+						pBullet.projectileColor = projectileColorC;
+						pBullet.startColor = startColorC;
+						pBullet.fadeColor = fadeColor;
+						tracerIntervalCounter++;
+						pBullet.tracerLuminance = tracerLuminance;
+						if (tracerIntervalCounter > tracerInterval)
+						{
+							tracerIntervalCounter = 0;
+							pBullet.tracerStartWidth = tracerStartWidth;
+							pBullet.tracerEndWidth = tracerEndWidth;
+							pBullet.tracerLength = tracerLength;
+						}
+						else
+						{
+							pBullet.tracerStartWidth = nonTracerWidth;
+							pBullet.tracerEndWidth = nonTracerWidth;
+							pBullet.startColor.a *= 0.5f;
+							pBullet.projectileColor.a *= 0.5f;
+							pBullet.tracerLength = 1;
+							pBullet.tracerLuminance *= 0.25f;
+						}
+						pBullet.tracerDeltaFactor = tracerDeltaFactor;
+						pBullet.bulletDrop = bulletDrop;
 
-                        pBullet.currentVelocity = (part.rb.velocity + Krakensbane.GetFrameVelocityV3f()) + firedVelocity; // use the real velocity, w/o offloading
-                        firedBullet.transform.position += (part.rb.velocity + Krakensbane.GetFrameVelocityV3f()) * Time.fixedDeltaTime 
-                                                            + pBullet.currentVelocity * iTime;
+						if (eWeaponType == WeaponTypes.Ballistic && bulletInfo.explosive) //WeaponTypes.Cannon is deprecated
+						{
+							if (bulletType == "def")
+							{
+								//legacy model, per weapon config
+								pBullet.bulletType = PooledBullet.PooledBulletTypes.Explosive;
+								pBullet.explModelPath = explModelPath;
+								pBullet.explSoundPath = explSoundPath;
+								pBullet.blastPower = cannonShellPower;
+								pBullet.blastHeat = cannonShellHeat;
+								pBullet.radius = cannonShellRadius;
+								pBullet.airDetonation = airDetonation;
+								pBullet.detonationRange = detonationRange;
+								pBullet.maxAirDetonationRange = maxAirDetonationRange;
+								pBullet.defaultDetonationRange = defaultDetonationRange;
+								pBullet.proximityDetonation = proximityDetonation;
+							}
+							else
+							{
+								//use values from bullets.cfg
+								pBullet.bulletType = PooledBullet.PooledBulletTypes.Explosive;
+								pBullet.explModelPath = explModelPath;
+								pBullet.explSoundPath = explSoundPath;
 
-                        pBullet.sourceVessel = vessel;
-                        pBullet.bulletTexturePath = bulletTexturePath;
-                        pBullet.projectileColor = projectileColorC;
-                        pBullet.startColor = startColorC;
-                        pBullet.fadeColor = fadeColor;
-                        tracerIntervalCounter++;
-			pBullet.tracerLuminance = tracerLuminance;
-                        if (tracerIntervalCounter > tracerInterval)
-                        {
-                            tracerIntervalCounter = 0;
-                            pBullet.tracerStartWidth = tracerStartWidth;
-                            pBullet.tracerEndWidth = tracerEndWidth;
-			    pBullet.tracerLength = tracerLength;
-                        }
-                        else
-                        {
-                            pBullet.tracerStartWidth = nonTracerWidth;
-                            pBullet.tracerEndWidth = nonTracerWidth;
-                            pBullet.startColor.a *= 0.5f;
-                            pBullet.projectileColor.a *= 0.5f;
-                            pBullet.tracerLength = 1;   
-			    pBullet.tracerLuminance *= 0.25f;
-                        }
-                        pBullet.tracerDeltaFactor = tracerDeltaFactor;
-                        pBullet.bulletDrop = bulletDrop;
+								pBullet.tntMass = bulletInfo.tntMass;
+								pBullet.blastPower = bulletInfo.blastPower;
+								pBullet.blastHeat = bulletInfo.blastHeat;
+								pBullet.radius = bulletInfo.blastRadius;
 
-                        if (eWeaponType == WeaponTypes.Ballistic && bulletInfo.explosive) //WeaponTypes.Cannon is deprecated
-                        {
-                            if (bulletType == "def")
-                            {
-                                //legacy model, per weapon config
-                                pBullet.bulletType = PooledBullet.PooledBulletTypes.Explosive;
-                                pBullet.explModelPath = explModelPath;
-                                pBullet.explSoundPath = explSoundPath;
-                                pBullet.blastPower = cannonShellPower;
-                                pBullet.blastHeat = cannonShellHeat;
-                                pBullet.radius = cannonShellRadius;
-                                pBullet.airDetonation = airDetonation;
-                                pBullet.detonationRange = detonationRange;
-                                pBullet.maxAirDetonationRange = maxAirDetonationRange;
-                                pBullet.defaultDetonationRange = defaultDetonationRange;
-                                pBullet.proximityDetonation = proximityDetonation;
+								pBullet.airDetonation = airDetonation;
+								pBullet.detonationRange = detonationRange;
+								pBullet.maxAirDetonationRange = maxAirDetonationRange;
+								pBullet.defaultDetonationRange = defaultDetonationRange;
+								pBullet.proximityDetonation = proximityDetonation;
+							}
+						}
+						else
+						{
+							pBullet.bulletType = PooledBullet.PooledBulletTypes.Standard;
+							pBullet.airDetonation = false;
+						}
+						switch (bulletDragType)
+						{
+							case BulletDragTypes.None:
+								pBullet.dragType = PooledBullet.BulletDragTypes.None;
+								break;
+							case BulletDragTypes.AnalyticEstimate:
+								pBullet.dragType = PooledBullet.BulletDragTypes.AnalyticEstimate;
+								break;
+							case BulletDragTypes.NumericalIntegration:
+								pBullet.dragType = PooledBullet.BulletDragTypes.NumericalIntegration;
+								break;
+						}
+						pBullet.bullet = BulletInfo.bullets[bulletType];
+						pBullet.gameObject.SetActive(true);
 
-                            }
-                            else
-                            {
-                                //use values from bullets.cfg
-                                pBullet.bulletType = PooledBullet.PooledBulletTypes.Explosive;                                
-                                pBullet.explModelPath = explModelPath;
-                                pBullet.explSoundPath = explSoundPath;
-
-                                pBullet.tntMass = bulletInfo.tntMass;
-                                pBullet.blastPower = bulletInfo.blastPower;
-                                pBullet.blastHeat = bulletInfo.blastHeat;
-                                pBullet.radius = bulletInfo.blastRadius;
-
-                                pBullet.airDetonation = airDetonation;
-                                pBullet.detonationRange = detonationRange;
-                                pBullet.maxAirDetonationRange = maxAirDetonationRange;
-                                pBullet.defaultDetonationRange = defaultDetonationRange;
-                                pBullet.proximityDetonation = proximityDetonation;
-                            }
-
-                        }
-                        else
-                        {
-                            pBullet.bulletType = PooledBullet.PooledBulletTypes.Standard;
-                            pBullet.airDetonation = false;
-                        }
-                        switch (bulletDragType)
-                        {
-                            case BulletDragTypes.None:
-                                pBullet.dragType = PooledBullet.BulletDragTypes.None;
-                                break;
-                            case BulletDragTypes.AnalyticEstimate:
-                                pBullet.dragType = PooledBullet.BulletDragTypes.AnalyticEstimate;
-                                break;
-                            case BulletDragTypes.NumericalIntegration:
-                                pBullet.dragType = PooledBullet.BulletDragTypes.NumericalIntegration;
-                                break;
-                        }
-
-                        pBullet.bullet = BulletInfo.bullets[bulletType];
-                        pBullet.gameObject.SetActive(true);
-
-
-                        //heat
-                        heat += heatPerShot;
-                        //EC
-                        DrainECPerShot();
-                    }
-                    else
-                    {
-                        spinningDown = true;
-                        if (!oneShotSound && wasFiring)
-                        {
-                            audioSource.Stop();
-                            wasFiring = false;
-                            audioSource2.PlayOneShot(overheatSound);
-                        }
-                    }
-                }
-
-                if (useRippleFire)
-                {
-                    StartCoroutine(IncrementRippleIndex(initialFireDelay * TimeWarp.CurrentRate));
-                }
-            }
-            else
-            {
-                spinningDown = true;
-            }
-        }
+						//heat
+						heat += heatPerShot;
+						//EC
+						DrainECPerShot();
+					}
+					else
+					{
+						spinningDown = true;
+						if (!oneShotSound && wasFiring)
+						{
+							audioSource.Stop();
+							wasFiring = false;
+							audioSource2.PlayOneShot(overheatSound);
+						}
+					}
+				}
+			if (useRippleFire)
+			{
+				StartCoroutine(IncrementRippleIndex(initialFireDelay * TimeWarp.CurrentRate));
+			}
+		}
+		else
+		{
+			spinningDown = true;
+		}	
+	}
 	bool CanFire()
 	{
 		if (ECPerShot != 0)
@@ -1379,119 +1356,113 @@ namespace BDArmory.Modules
 	#region Laser Fire
 	private bool FireLaser()
         {
-            float maxDistance = BDArmorySettings.PHYSICS_RANGE;
-            if (BDArmorySettings.PHYSICS_RANGE == 0)
-                maxDistance = 2500;
+            	float maxDistance = BDArmorySettings.PHYSICS_RANGE;
+            	if (BDArmorySettings.PHYSICS_RANGE == 0)
+                	maxDistance = 2500;
 
-            float chargeAmount = requestResourceAmount * TimeWarp.fixedDeltaTime;
+            	float chargeAmount = requestResourceAmount * TimeWarp.fixedDeltaTime;
 
 			if (!pointingAtSelf && !Misc.Misc.CheckMouseIsOnGui() && WMgrAuthorized() && !isOverheated &&
                 (part.RequestResource(ammoName, chargeAmount) >= chargeAmount || BDArmorySettings.INFINITE_AMMO))
-            {
-                if (!audioSource.isPlaying)
-                {
-                    audioSource.PlayOneShot(chargeSound);
-                    audioSource.Play();
-                    audioSource.loop = true;
-                }
-				//for (float iTime = Mathf.Min(Time.time - timeFired - timeGap, TimeWarp.fixedDeltaTime); iTime >= 0; iTime -= timeGap)
-				//timeFired = Time.time - iTime;
-				for (int i = 0; i < fireTransforms.Length; i++)
-                {
-                    Transform tf = fireTransforms[i];
+            	{
+                	if (!audioSource.isPlaying)
+                	{
+                    		audioSource.PlayOneShot(chargeSound);
+                    		audioSource.Play();
+                    		audioSource.loop = true;
+                	}
+			//for (float iTime = Mathf.Min(Time.time - timeFired - timeGap, TimeWarp.fixedDeltaTime); iTime >= 0; iTime -= timeGap)
+			//timeFired = Time.time - iTime;
+			for (int i = 0; i < fireTransforms.Length; i++)
+                	{
+                  		Transform tf = fireTransforms[i];
 
-                    LineRenderer lr = laserRenderers[i];                    
+                    		LineRenderer lr = laserRenderers[i];                    
 
-                    Vector3 rayDirection = tf.forward;
+                    		Vector3 rayDirection = tf.forward;
 
-                    Vector3 targetDirection = Vector3.zero; //autoTrack enhancer
-                    Vector3 targetDirectionLR = tf.forward;
+                    		Vector3 targetDirection = Vector3.zero; //autoTrack enhancer
+                    		Vector3 targetDirectionLR = tf.forward;
 
-                    if (((legacyTargetVessel != null && legacyTargetVessel.loaded) || slaved) 
-                        && Vector3.Angle(rayDirection, targetDirection) < 1)
-                    {
-                        targetDirection = targetPosition + relativeVelocity * Time.fixedDeltaTime * 2 - tf.position;
-                        rayDirection = targetDirection;
-                        targetDirectionLR = targetDirection;
-                    }
+                    		if (((legacyTargetVessel != null && legacyTargetVessel.loaded) || slaved) 
+                        	&& Vector3.Angle(rayDirection, targetDirection) < 1)
+                    		{
+                        		targetDirection = targetPosition + relativeVelocity * Time.fixedDeltaTime * 2 - tf.position;
+                        		rayDirection = targetDirection;
+                        		targetDirectionLR = targetDirection;
+                    		}
 
-                    Ray ray = new Ray(tf.position, rayDirection);
-                    lr.useWorldSpace = false;
-                    lr.SetPosition(0, Vector3.zero);
-                    RaycastHit hit;
-					if (Physics.Raycast(ray, out hit, maxDistance, 9076737))
-                    {
-                        lr.useWorldSpace = true;
-                        laserPoint = hit.point + targetVelocity * Time.fixedDeltaTime;
+                    		Ray ray = new Ray(tf.position, rayDirection);
+                    		lr.useWorldSpace = false;
+                    		lr.SetPosition(0, Vector3.zero);
+                    		RaycastHit hit;
+				if (Physics.Raycast(ray, out hit, maxDistance, 9076737))
+		                {
+                        		lr.useWorldSpace = true;
+                        		laserPoint = hit.point + targetVelocity * Time.fixedDeltaTime;
                         
-                        lr.SetPosition(0, tf.position + (part.rb.velocity * Time.fixedDeltaTime));
-                        lr.SetPosition(1, laserPoint);  
+                        		lr.SetPosition(0, tf.position + (part.rb.velocity * Time.fixedDeltaTime));
+                        		lr.SetPosition(1, laserPoint);  
 
-                        KerbalEVA eva = hit.collider.gameObject.GetComponentUpwards<KerbalEVA>();
-                        Part p = eva ? eva.part : hit.collider.gameObject.GetComponentInParent<Part>();
+                       			KerbalEVA eva = hit.collider.gameObject.GetComponentUpwards<KerbalEVA>();
+                        		Part p = eva ? eva.part : hit.collider.gameObject.GetComponentInParent<Part>();
 
-                        if (p && p.vessel && p.vessel != vessel)
-                        {
-                            float distance = hit.distance;
-                            //Scales down the damage based on the increased surface area of the area being hit by the laser. Think flashlight on a wall.
-                            p.AddDamage(laserDamage / (1 + Mathf.PI * Mathf.Pow(tanAngle * distance, 2)) *
-                                             TimeWarp.fixedDeltaTime
-                                             * 0.425f);
-
-                            if (BDArmorySettings.INSTAKILL) p.Destroy();
-                        }
-
-
-                        if (Time.time - timeFired > 6 / 120 && BDArmorySettings.BULLET_HITS)
-                        {
-                            BulletHitFX.CreateBulletHit(p,hit.point, hit, hit.normal, false,0,0);
-                        }
-
-                    }
-                    else
-                    {
-                        laserPoint = lr.transform.InverseTransformPoint((targetDirectionLR * maxDistance) + tf.position);
-                        lr.SetPosition(1, laserPoint);
-                    }
-                }
-				heat += heatPerShot * TimeWarp.CurrentRate;
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+                        		if (p && p.vessel && p.vessel != vessel)
+                        		{
+                            			float distance = hit.distance;
+                            			//Scales down the damage based on the increased surface area of the area being hit by the laser. Think flashlight on a wall.
+                            			p.AddDamage(laserDamage / (1 + Mathf.PI * Mathf.Pow(tanAngle * distance, 2)) * TimeWarp.fixedDeltaTime * 0.425f);
+                          			if (BDArmorySettings.INSTAKILL) p.Destroy();
+                        		}
+	    			        if (Time.time - timeFired > 6 / 120 && BDArmorySettings.BULLET_HITS)
+                        		{
+                            			BulletHitFX.CreateBulletHit(p,hit.point, hit, hit.normal, false,0,0);
+                        		}
+                    		}
+                   		else
+                    		{
+                        	laserPoint = lr.transform.InverseTransformPoint((targetDirectionLR * maxDistance) + tf.position);
+                        	lr.SetPosition(1, laserPoint);
+                    		}
+                	}
+			heat += heatPerShot * TimeWarp.CurrentRate;
+                	return true;
+            	}
+            	else
+            	{
+                	return false;
+            	}
         }
 
 	void SetupLaserSpecifics()
         {
-            chargeSound = GameDatabase.Instance.GetAudioClip(chargeSoundPath);
-            if (HighLogic.LoadedSceneIsFlight)
-            {
-                audioSource.clip = fireSound;
-            }
+            	chargeSound = GameDatabase.Instance.GetAudioClip(chargeSoundPath);
+            	if (HighLogic.LoadedSceneIsFlight)
+            	{
+                	audioSource.clip = fireSound;
+            	}
 
-            laserRenderers = new LineRenderer[fireTransforms.Length];
+            	laserRenderers = new LineRenderer[fireTransforms.Length];
 
-            for (int i = 0; i < fireTransforms.Length; i++)
-            {
-                Transform tf = fireTransforms[i];
-                laserRenderers[i] = tf.gameObject.AddComponent<LineRenderer>();
-                Color laserColor = Misc.Misc.ParseColor255(projectileColor);
-                laserColor.a = laserColor.a / 2;
-                laserRenderers[i].material = new Material(Shader.Find("KSP/Particles/Alpha Blended"));
-                laserRenderers[i].material.SetColor("_TintColor", laserColor);
-                laserRenderers[i].material.mainTexture = GameDatabase.Instance.GetTexture(laserTexturePath, false);
-                laserRenderers[i].shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off; //= false;
-                laserRenderers[i].receiveShadows = false;
-                laserRenderers[i].startWidth = tracerStartWidth;
-                laserRenderers[i].endWidth = tracerEndWidth;
-                laserRenderers[i].positionCount = 2;
-                laserRenderers[i].SetPosition(0, Vector3.zero);
-                laserRenderers[i].SetPosition(1, Vector3.zero);
-                laserRenderers[i].useWorldSpace = false;
-                laserRenderers[i].enabled = false;
-            }
+            	for (int i = 0; i < fireTransforms.Length; i++)
+            	{
+                	Transform tf = fireTransforms[i];
+                	laserRenderers[i] = tf.gameObject.AddComponent<LineRenderer>();
+                	Color laserColor = Misc.Misc.ParseColor255(projectileColor);
+                	laserColor.a = laserColor.a / 2;
+                	laserRenderers[i].material = new Material(Shader.Find("KSP/Particles/Alpha Blended"));
+                	laserRenderers[i].material.SetColor("_TintColor", laserColor);
+                	laserRenderers[i].material.mainTexture = GameDatabase.Instance.GetTexture(laserTexturePath, false);
+                	laserRenderers[i].shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off; //= false;
+                	laserRenderers[i].receiveShadows = false;
+                	laserRenderers[i].startWidth = tracerStartWidth;
+                	laserRenderers[i].endWidth = tracerEndWidth;
+	                laserRenderers[i].positionCount = 2;
+        	        laserRenderers[i].SetPosition(0, Vector3.zero);
+	                laserRenderers[i].SetPosition(1, Vector3.zero);
+        	        laserRenderers[i].useWorldSpace = false;
+                	laserRenderers[i].enabled = false;
+            	}
         }
 	#endregion
 
@@ -1622,246 +1593,239 @@ namespace BDArmory.Modules
 	#region Weapon Setup
 	public void EnableWeapon()
         {
-            if (weaponState == WeaponStates.Enabled || weaponState == WeaponStates.PoweringUp)
-            {
-                return;
-            }
+            	if (weaponState == WeaponStates.Enabled || weaponState == WeaponStates.PoweringUp)
+            	{
+                	return;
+            	}
 
-            StopShutdownStartupRoutines();
-
-            startupRoutine = StartCoroutine(StartupRoutine());
+            	StopShutdownStartupRoutines();
+           	startupRoutine = StartCoroutine(StartupRoutine());
         }
 
         public void DisableWeapon()
         {
-            if (weaponState == WeaponStates.Disabled || weaponState == WeaponStates.PoweringDown)
-            {
-                return;
-            }
+            	if (weaponState == WeaponStates.Disabled || weaponState == WeaponStates.PoweringDown)
+            	{
+                	return;
+            	}
 
-            StopShutdownStartupRoutines();
-
-            shutdownRoutine = StartCoroutine(ShutdownRoutine());
+            	StopShutdownStartupRoutines();
+            	shutdownRoutine = StartCoroutine(ShutdownRoutine());
         }
 
         void ParseWeaponType()
         {
-            weaponType = weaponType.ToLower();
+            	weaponType = weaponType.ToLower();
 
-            switch (weaponType)
-            {
-                case "ballistic":
-                    eWeaponType = WeaponTypes.Ballistic;
-                    break;
+            	switch (weaponType)
+            	{
+                	case "ballistic":
+                    		eWeaponType = WeaponTypes.Ballistic;
+                    		break;
 
-                case "rocket":
-                    // Note:  this type is deprecated.  behavior is duplicated with Ballistic and bulletInfo.explosive = true
-                    // Type remains for backward compatability for now.
-                    eWeaponType = WeaponTypes.Rocket;
-                    break;
+                	case "rocket":
+                    		eWeaponType = WeaponTypes.Rocket;
+                    		break;
 
-                case "laser":
-                    eWeaponType = WeaponTypes.Laser;
-                    break;
-            }
+                	case "laser":
+                    		eWeaponType = WeaponTypes.Laser;
+                    		break;
+            	}
         }
 
-		#endregion
+	#endregion
 		
         #region Audio
 
         void UpdateVolume()
         {
-            if (audioSource)
-            {
-                audioSource.volume = BDArmorySettings.BDARMORY_WEAPONS_VOLUME;
-            }
-            if (audioSource2)
-            {
-                audioSource2.volume = BDArmorySettings.BDARMORY_WEAPONS_VOLUME;
-            }
-            if (lowpassFilter)
-            {
-                lowpassFilter.cutoffFrequency = BDArmorySettings.IVA_LOWPASS_FREQ;
-            }
+            	if (audioSource)
+            	{
+                	audioSource.volume = BDArmorySettings.BDARMORY_WEAPONS_VOLUME;
+            	}
+            	if (audioSource2)
+            	{
+                	audioSource2.volume = BDArmorySettings.BDARMORY_WEAPONS_VOLUME;
+            	}
+            	if (lowpassFilter)
+            	{
+                	lowpassFilter.cutoffFrequency = BDArmorySettings.IVA_LOWPASS_FREQ;
+            	}
         }
 
         void SetupAudio()
         {
-            fireSound = GameDatabase.Instance.GetAudioClip(fireSoundPath);
-            overheatSound = GameDatabase.Instance.GetAudioClip(overheatSoundPath);
-            if (!audioSource)
-            {
-                audioSource = gameObject.AddComponent<AudioSource>();
-                audioSource.bypassListenerEffects = true;
-                audioSource.minDistance = .3f;
-                audioSource.maxDistance = 1000;
-                audioSource.priority = 10;
-                audioSource.dopplerLevel = 0;
-                audioSource.spatialBlend = 1;
-            }
+            	fireSound = GameDatabase.Instance.GetAudioClip(fireSoundPath);
+            	overheatSound = GameDatabase.Instance.GetAudioClip(overheatSoundPath);
+            	if (!audioSource)
+            	{
+	                audioSource = gameObject.AddComponent<AudioSource>();
+        	        audioSource.bypassListenerEffects = true;
+                	audioSource.minDistance = .3f;
+	                audioSource.maxDistance = 1000;
+        	        audioSource.priority = 10;
+                	audioSource.dopplerLevel = 0;
+	                audioSource.spatialBlend = 1;
+            	}
 
-            if (!audioSource2)
-            {
-                audioSource2 = gameObject.AddComponent<AudioSource>();
-                audioSource2.bypassListenerEffects = true;
-                audioSource2.minDistance = .3f;
-                audioSource2.maxDistance = 1000;
-                audioSource2.dopplerLevel = 0;
-                audioSource2.priority = 10;
-                audioSource2.spatialBlend = 1;
-            }
+            	if (!audioSource2)
+            	{
+                	audioSource2 = gameObject.AddComponent<AudioSource>();
+                	audioSource2.bypassListenerEffects = true;
+                	audioSource2.minDistance = .3f;
+                	audioSource2.maxDistance = 1000;
+                	audioSource2.dopplerLevel = 0;
+                	audioSource2.priority = 10;
+                	audioSource2.spatialBlend = 1;
+            	}
 
-            if (reloadAudioPath != string.Empty)
-            {
-                reloadAudioClip = (AudioClip)GameDatabase.Instance.GetAudioClip(reloadAudioPath);
-            }
-            if (reloadCompletePath != string.Empty)
-            {
-                reloadCompleteAudioClip = (AudioClip)GameDatabase.Instance.GetAudioClip(reloadCompletePath);
-            }
+            	if (reloadAudioPath != string.Empty)
+            	{
+	                reloadAudioClip = (AudioClip)GameDatabase.Instance.GetAudioClip(reloadAudioPath);
+            	}
+            	if (reloadCompletePath != string.Empty)
+            	{
+                	reloadCompleteAudioClip = (AudioClip)GameDatabase.Instance.GetAudioClip(reloadCompletePath);
+            	}
 
-            if (!lowpassFilter && gameObject.GetComponents<AudioLowPassFilter>().Length == 0)
-            {
-                lowpassFilter = gameObject.AddComponent<AudioLowPassFilter>();
-                lowpassFilter.cutoffFrequency = BDArmorySettings.IVA_LOWPASS_FREQ;
-                lowpassFilter.lowpassResonanceQ = 1f;
-            }
+            	if (!lowpassFilter && gameObject.GetComponents<AudioLowPassFilter>().Length == 0)
+            	{
+	                lowpassFilter = gameObject.AddComponent<AudioLowPassFilter>();
+	                lowpassFilter.cutoffFrequency = BDArmorySettings.IVA_LOWPASS_FREQ;
+	                lowpassFilter.lowpassResonanceQ = 1f;
+            	}
 
-            UpdateVolume();
+            	UpdateVolume();
         }
 	#endregion
 
 	#region Targeting
 	void Aim()
         {
-            //AI control
-            if (aiControlled && !slaved)
-            {
-                if (!targetAcquired)
-                {
-                    autoFire = false;
-                    return;
-                }
-            }
-
-            if (!slaved && !aiControlled && (yawRange > 0 || maxPitch - minPitch > 0))
-            {
-                //MouseControl
-                Vector3 mouseAim = new Vector3(Input.mousePosition.x / Screen.width, Input.mousePosition.y / Screen.height,
-                    0);
-                Ray ray = FlightCamera.fetch.mainCamera.ViewportPointToRay(mouseAim);
-                RaycastHit hit;
-
-                if (Physics.Raycast(ray, out hit, maxTargetingRange, 9076737))
-                {
-                    targetPosition = hit.point;
-
-                    //aim through self vessel if occluding mouseray
-
-                    KerbalEVA eva = hit.collider.gameObject.GetComponentUpwards<KerbalEVA>();
-                    Part p = eva ? eva.part : hit.collider.gameObject.GetComponentInParent<Part>();
-
-                    if (p && p.vessel && p.vessel == vessel)
-                    {
-                        targetPosition = ray.direction * maxTargetingRange +
-                                         FlightCamera.fetch.mainCamera.transform.position;
-                    }
-                }
-                else
-                {
-                    targetPosition = (ray.direction * (maxTargetingRange + (FlightCamera.fetch.Distance * 0.75f))) +
-                                     FlightCamera.fetch.mainCamera.transform.position;
-                    if (legacyTargetVessel != null && legacyTargetVessel.loaded)
-                    {
-                        targetPosition = ray.direction *
-                                         Vector3.Distance(legacyTargetVessel.transform.position,
-                                             FlightCamera.fetch.mainCamera.transform.position) +
-                                         FlightCamera.fetch.mainCamera.transform.position;
-                    }
-                }
-            }
-
-            //aim assist
-            Vector3 finalTarget = targetPosition;
-            Vector3 originalTarget = targetPosition;
-            targetDistance = Vector3.Distance(finalTarget, transform.position);
-            targetLeadDistance = targetDistance;
-
-            if ((BDArmorySettings.AIM_ASSIST || aiControlled) && eWeaponType != WeaponTypes.Laser)
-            {
-		float effectiveVelocity = bulletVelocity;
-
-		int rocketaccel = 1;
-		int iterations = 4;
-                while (--iterations >= 0)
-                {
-			if (eWeaponType == WeaponTypes.Rocket)
-			{
-				rocketaccel++;
-				effectiveVelocity = ((thrust / rocketMass)* rocketaccel);// may need a little more tinkering
+            	//AI control
+            	if (aiControlled && !slaved)
+            	{
+                	if (!targetAcquired)
+                	{
+                    		autoFire = false;
+                    		return;
 			}
-		float time = targetDistance / effectiveVelocity;
-                finalTarget = targetPosition;
+		}
+        	if (!slaved && !aiControlled && (yawRange > 0 || maxPitch - minPitch > 0))
+        	{
+                	//MouseControl
+               		Vector3 mouseAim = new Vector3(Input.mousePosition.x / Screen.width, Input.mousePosition.y / Screen.height, 0);
+                	Ray ray = FlightCamera.fetch.mainCamera.ViewportPointToRay(mouseAim);
+                	RaycastHit hit;
+
+                	if (Physics.Raycast(ray, out hit, maxTargetingRange, 9076737))
+                	{
+                    		targetPosition = hit.point;
+
+                    		//aim through self vessel if occluding mouseray
+
+                    		KerbalEVA eva = hit.collider.gameObject.GetComponentUpwards<KerbalEVA>();
+                    		Part p = eva ? eva.part : hit.collider.gameObject.GetComponentInParent<Part>();
+
+                    		if (p && p.vessel && p.vessel == vessel)
+                    		{
+                        		targetPosition = ray.direction * maxTargetingRange +
+                                        FlightCamera.fetch.mainCamera.transform.position;
+                    		}	
+                	}
+                	else
+                	{
+	                    	targetPosition = (ray.direction * (maxTargetingRange + (FlightCamera.fetch.Distance * 0.75f))) +
+                                     FlightCamera.fetch.mainCamera.transform.position;
+        	            	if (legacyTargetVessel != null && legacyTargetVessel.loaded)
+                	    	{
+                        		targetPosition = ray.direction *
+                                        Vector3.Distance(legacyTargetVessel.transform.position,
+                                        FlightCamera.fetch.mainCamera.transform.position) +
+                                        FlightCamera.fetch.mainCamera.transform.position;
+                    		}
+                	}
+		}
+
+            	//aim assist
+           	Vector3 finalTarget = targetPosition;
+            	Vector3 originalTarget = targetPosition;
+            	targetDistance = Vector3.Distance(finalTarget, transform.position);
+            	targetLeadDistance = targetDistance;
+
+           	if ((BDArmorySettings.AIM_ASSIST || aiControlled) && eWeaponType != WeaponTypes.Laser)
+            	{
+			float effectiveVelocity = bulletVelocity;
+
+			int rocketaccel = 1;
+			int iterations = 4;
+                	while (--iterations >= 0)
+                	{
+				if (eWeaponType == WeaponTypes.Rocket)
+				{
+					rocketaccel++;
+					effectiveVelocity = ((thrust / rocketMass)* rocketaccel);// may need a little more tinkering
+				}
+			float time = targetDistance / effectiveVelocity;
+                	finalTarget = targetPosition;
                     
-                    if (targetAcquired)
-                    {
-			float time2 = VectorUtils.CalculateLeadTime(finalTarget - fireTransforms[0].position,
-			relativeVelocity, effectiveVelocity);
-			if (time2 > 0) time = time2;
-                        finalTarget += relativeVelocity * time;
-                        #if DEBUG
-                        relVelAdj = relativeVelocity * time;
-                        var vc = finalTarget;
-                        #endif
+                    	if (targetAcquired)
+                    	{
+				float time2 = VectorUtils.CalculateLeadTime(finalTarget - fireTransforms[0].position,
+				relativeVelocity, effectiveVelocity);
+				if (time2 > 0) time = time2;
+                        	finalTarget += relativeVelocity * time;
+                        	#if DEBUG
+                        	relVelAdj = relativeVelocity * time;
+                        	var vc = finalTarget;
+                        	#endif
                         
-                        //target vessel relative velocity compensation
-                        if (weaponManager.currentTarget?.Vessel.InOrbit() == true)
-                        {
-                            var geeForceAtTarget = FlightGlobals.getGeeForceAtPosition(targetPosition);
-                            var finalTargetGeeForce = FlightGlobals.getGeeForceAtPosition(finalTarget + 0.5f * (targetAcceleration
-                                - (FlightGlobals.getGeeForceAtPosition(targetPosition) - FlightGlobals.getGeeForceAtPosition(finalTarget)) / 2)
-                                * time * time);
-                            var cosine = Vector3d.Dot(finalTargetGeeForce.normalized, geeForceAtTarget.normalized);
-                            var avGeeForce = (finalTargetGeeForce + geeForceAtTarget) / 2 / (2 * cosine * cosine - 1);
-                            finalTarget += 0.5f * (targetAcceleration - geeForceAtTarget + avGeeForce) * time * time;
-                        }
-                        else
-                            finalTarget += 0.5f * targetAcceleration * time * time; //target acceleration
+	                        //target vessel relative velocity compensation
+        	                if (weaponManager.currentTarget?.Vessel.InOrbit() == true)
+                	        {
+                        		var geeForceAtTarget = FlightGlobals.getGeeForceAtPosition(targetPosition);
+                            		var finalTargetGeeForce = FlightGlobals.getGeeForceAtPosition(finalTarget + 0.5f * (targetAcceleration
+                               		 - (FlightGlobals.getGeeForceAtPosition(targetPosition) - FlightGlobals.getGeeForceAtPosition(finalTarget)) / 2)
+                                	 * time * time);
+                            		var cosine = Vector3d.Dot(finalTargetGeeForce.normalized, geeForceAtTarget.normalized);
+                            		var avGeeForce = (finalTargetGeeForce + geeForceAtTarget) / 2 / (2 * cosine * cosine - 1);
+                            		finalTarget += 0.5f * (targetAcceleration - geeForceAtTarget + avGeeForce) * time * time;
+                        	}
+                        	else
+                            	finalTarget += 0.5f * targetAcceleration * time * time; //target acceleration
 
-                        #if DEBUG
-                        accAdj = (finalTarget - vc);
-                        #endif
-                    }
-                    else if (vessel.altitude < 6000)
-                    {
-						float time2 = VectorUtils.CalculateLeadTime(finalTarget - fireTransforms[0].position,
-							-(part.rb.velocity + Krakensbane.GetFrameVelocityV3f()), effectiveVelocity);
+                        	#if DEBUG
+                        	accAdj = (finalTarget - vc);
+                        	#endif
+                    	}
+                    	else if (vessel.altitude < 6000)
+                    	{
+				float time2 = VectorUtils.CalculateLeadTime(finalTarget - fireTransforms[0].position,
+				 -(part.rb.velocity + Krakensbane.GetFrameVelocityV3f()), effectiveVelocity);
 
-                        if (time2 > 0) time = time2;
-                        finalTarget += (-(part.rb.velocity + Krakensbane.GetFrameVelocityV3f()) * time);
-                        //this vessel velocity compensation against stationary
-                    }
-					Vector3 up = (VectorUtils.GetUpDirection(finalTarget) + VectorUtils.GetUpDirection(fireTransforms[0].position)).normalized;
-					if (bulletDrop || eWeaponType == WeaponTypes.Rocket)
-                    {
-                        #if DEBUG
-                        var vc = finalTarget;
-                        #endif
-                        float gAccel = ((float)FlightGlobals.getGeeForceAtPosition(finalTarget).magnitude
-                        + (float)FlightGlobals.getGeeForceAtPosition(fireTransforms[0].position).magnitude) / 2;
-                        Vector3 intermediateTarget = finalTarget + (0.5f * gAccel * time * time * up); //gravity compensation, -fixedDeltaTime is for fixedUpdate granularity
-						var avGrav = (FlightGlobals.getGeeForceAtPosition(finalTarget) + FlightGlobals.getGeeForceAtPosition(fireTransforms[0].position)) / 2;
-							effectiveVelocity = bulletVelocity
-								* (float)Vector3d.Dot((intermediateTarget - fireTransforms[0].position).normalized, (finalTarget - fireTransforms[0].position).normalized);
-						// effectiveVelocity += (float)Vector3d.Dot(avGrav, (finalTarget - fireTransforms[0].position).normalized) * time * time / 2;
-						finalTarget = intermediateTarget;
+                        	if (time2 > 0) time = time2;
+                        	finalTarget += (-(part.rb.velocity + Krakensbane.GetFrameVelocityV3f()) * time);
+                        	//this vessel velocity compensation against stationary
+                    	}
+			Vector3 up = (VectorUtils.GetUpDirection(finalTarget) + VectorUtils.GetUpDirection(fireTransforms[0].position)).normalized;
+			if (bulletDrop || eWeaponType == WeaponTypes.Rocket)
+                    	{
+                        	#if DEBUG
+                        	var vc = finalTarget;
+                        	#endif
+                        	float gAccel = ((float)FlightGlobals.getGeeForceAtPosition(finalTarget).magnitude
+                        	 + (float)FlightGlobals.getGeeForceAtPosition(fireTransforms[0].position).magnitude) / 2;
+                        	Vector3 intermediateTarget = finalTarget + (0.5f * gAccel * time * time * up); //gravity compensation, -fixedDeltaTime is for fixedUpdate granularity
+				var avGrav = (FlightGlobals.getGeeForceAtPosition(finalTarget) + FlightGlobals.getGeeForceAtPosition(fireTransforms[0].position)) / 2;
+				effectiveVelocity = bulletVelocity * (float)Vector3d.Dot((intermediateTarget - fireTransforms[0].position).normalized, (finalTarget - fireTransforms[0].position).normalized);
+				// effectiveVelocity += (float)Vector3d.Dot(avGrav, (finalTarget - fireTransforms[0].position).normalized) * time * time / 2;
+				finalTarget = intermediateTarget;
 
-                        #if DEBUG
-                        gravAdj = (finalTarget - vc);
-                        #endif
-                    }
-                    else break;
+                        	#if DEBUG
+                        	gravAdj = (finalTarget - vc);
+                        	#endif
+                    	}
+                    	else break;
                 }
 		targetLeadDistance = Vector3.Distance(finalTarget, fireTransforms[0].position);
                 fixedLeadOffset = originalTarget - finalTarget; //for aiming fixed guns to moving target
@@ -1881,20 +1845,20 @@ namespace BDArmory.Modules
 			//removed the detonationange += math.rand, that gets called every frame and just causes the prox fuze range to wander
 		}
 
-            finalAimTarget = finalTarget;
+            	finalAimTarget = finalTarget;
 
-            //final turret aiming
-            if (slaved && !targetAcquired) return;
-            if (turret)
-            {
-                bool origSmooth = turret.smoothRotation;
-                if (aiControlled || slaved)
-                {
-                    turret.smoothRotation = false;
-                }
-                turret.AimToTarget(finalTarget);
-                turret.smoothRotation = origSmooth;
-            }
+            	//final turret aiming
+            	if (slaved && !targetAcquired) return;
+            	if (turret)
+            	{
+               		bool origSmooth = turret.smoothRotation;
+                	if (aiControlled || slaved)
+                	{
+                    		turret.smoothRotation = false;
+                	}
+                	turret.AimToTarget(finalTarget);
+                	turret.smoothRotation = origSmooth;
+            	}
         }
 
 	void RunTrajectorySimulation()
@@ -1986,7 +1950,6 @@ namespace BDArmory.Modules
 							simulating = false;
 						}
 					}
-
 					simPrevPos = simCurrPos;
 
 					if (legacyTargetVessel != null && legacyTargetVessel.loaded && !legacyTargetVessel.Landed &&
@@ -2039,64 +2002,62 @@ namespace BDArmory.Modules
 
 	IEnumerator AimAndFireAtEndOfFrame()
         {
-            if (eWeaponType != WeaponTypes.Laser) yield return new WaitForEndOfFrame();
+            	if (eWeaponType != WeaponTypes.Laser) yield return new WaitForEndOfFrame();
 
-            UpdateTargetVessel();
-            updateAcceleration(targetVelocity);
-            relativeVelocity = targetVelocity - vessel.rb_velocity;
+            	UpdateTargetVessel();
+            	updateAcceleration(targetVelocity);
+            	relativeVelocity = targetVelocity - vessel.rb_velocity;
 
-			RunTrajectorySimulation();
-            Aim();
-            CheckWeaponSafety();
-            CheckAIAutofire();
+		RunTrajectorySimulation();
+           	Aim();
+            	CheckWeaponSafety();
+            	CheckAIAutofire();
 
-            if (finalFire)
-            {
-                if (eWeaponType == WeaponTypes.Laser)
-                {
-                    if (FireLaser())
-                    {
-                        for (int i = 0; i < laserRenderers.Length; i++)
-                        {
-                            laserRenderers[i].enabled = true;
-                        }
-                    }
-                    else
-                    {
-                        for (int i = 0; i < laserRenderers.Length; i++)
-                        {
-                            laserRenderers[i].enabled = false;
-                        }
-                        audioSource.Stop();
-                    }
+            	if (finalFire)
+            	{
+                	if (eWeaponType == WeaponTypes.Laser)
+                	{
+                    		if (FireLaser())
+                    		{
+                        		for (int i = 0; i < laserRenderers.Length; i++)
+                        		{
+                            			laserRenderers[i].enabled = true;
+                        		}
+                    		}
+                    	else
+                    	{
+                        	for (int i = 0; i < laserRenderers.Length; i++)
+                        	{
+                            		laserRenderers[i].enabled = false;
+                        	}
+                        	audioSource.Stop();
+                    	}
                 }
                 else
                 {
-                    if (useRippleFire && weaponManager.gunRippleIndex != rippleIndex)
-                    {
-                        //timeFired = Time.time + (initialFireDelay - (60f / roundsPerMinute)) * TimeWarp.CurrentRate;
-                        finalFire = false;
-                    }
-                    else
-                    {
-                        finalFire = true;
-                    }
-					if (eWeaponType == WeaponTypes.Ballistic)
-					{
-						if (finalFire)
-							Fire();
-					}
-					else 
-					{
-						if (finalFire)
-							FireRocket();
-					}
-                }
-
-                finalFire = false;
-            }
-
-            yield break;
+                    	if (useRippleFire && weaponManager.gunRippleIndex != rippleIndex)
+                    	{
+                        	//timeFired = Time.time + (initialFireDelay - (60f / roundsPerMinute)) * TimeWarp.CurrentRate;
+                        	finalFire = false;
+                    	}
+                    	else
+                    	{
+	                        finalFire = true;
+			}
+				if (eWeaponType == WeaponTypes.Ballistic)
+				{
+					if (finalFire)
+						Fire();
+				}
+				else 
+				{
+					if (finalFire)
+						FireRocket();
+				}
+        	        }
+                	finalFire = false;
+            	}
+            	yield break;
         }
 	public bool WMgrAuthorized()
 	{
@@ -2243,408 +2204,402 @@ namespace BDArmory.Modules
         #region Updates
         void UpdateHeat()
         {
-            heat = Mathf.Clamp(heat - heatLoss * TimeWarp.fixedDeltaTime, 0, Mathf.Infinity);
-            if (heat > maxHeat && !isOverheated)
-            {
-                isOverheated = true;
-                autoFire = false;
-                audioSource.Stop();
-                wasFiring = false;
-                audioSource2.PlayOneShot(overheatSound);
-                weaponManager.ResetGuardInterval();
-            }
-            if (heat < maxHeat / 3 && isOverheated) //reset on cooldown
-            {
-                isOverheated = false;
-                heat = 0;
-            }
+            	heat = Mathf.Clamp(heat - heatLoss * TimeWarp.fixedDeltaTime, 0, Mathf.Infinity);
+            	if (heat > maxHeat && !isOverheated)
+            	{
+              		isOverheated = true;
+                	autoFire = false;
+                	audioSource.Stop();
+                	wasFiring = false;
+                	audioSource2.PlayOneShot(overheatSound);
+                	weaponManager.ResetGuardInterval();
+            	}
+            	if (heat < maxHeat / 3 && isOverheated) //reset on cooldown
+            	{
+	                isOverheated = false;
+	                heat = 0;
+            	}
         }
-		void UpdateAmmo()
+	void UpdateAmmo()
+	{
+		if (!BDArmorySettings.INFINITE_AMMO)
 		{
-			if (!BDArmorySettings.INFINITE_AMMO)
-			{
-				if (ammoAmount > 0)
-				{
-					isOutofAmmo = false;
-				}
-				else
-				{
-					isOutofAmmo = true;
-					wasFiring = false;
-					weaponManager.ResetGuardInterval();
-				}
-			}
-			else
+			if (ammoAmount > 0)
 			{
 				isOutofAmmo = false;
 			}
+			else
+			{
+				isOutofAmmo = true;
+				wasFiring = false;
+				weaponManager.ResetGuardInterval();
+			}
 		}
-		public void UpdateAmmoMeter()
+		else
 		{
+			isOutofAmmo = false;
+		}
+	}
+	public void UpdateAmmoMeter()
+	{
+		if (!BDArmorySettings.INFINITE_AMMO)
+		{
+			if (!isOutofAmmo)
+			{
+				if (ammoGauge == null)
+				{
+					ammoGauge = InitAmmoGauge();
+				}
+				ammoGauge?.SetValue(ammoAmount, 0, ammoMax);  //null check
+			}
+			else if (ammoGauge != null && isOutofAmmo)
+			{
+				part.stackIcon.ClearInfoBoxes();
+				ammoGauge = null;
+				emptyGauge = null;
+				UpdateEmptyAlert();
+			}
+		}
+		else //clear ammo gauges if infinite ammo, they're unnecessary
+		{
+			part.stackIcon.ClearInfoBoxes();
+			ammoGauge = null;
+			heatGauge = null;
+			reloadBar = null;
+			emptyGauge = null;
+			UpdateHeatMeter();
+			UpdateReloadMeter();
+		}
+	}
+	public void UpdateEmptyAlert()
+	{
+		if (!BDArmorySettings.INFINITE_AMMO)
+		{
+			if (isOutofAmmo)
+			{
+				if (emptyGauge == null)
+				{
+					emptyGauge = InitEmptyGauge();
+				}
+				emptyGauge?.SetValue(1, 0, 1);    //null check
+			}
+			else if (emptyGauge != null && !isOutofAmmo)
+			{
+				part.stackIcon.ClearInfoBoxes();
+				ammoGauge = null;
+				emptyGauge = null;
+				heatGauge = null;
+				reloadBar = null;
+			}
+		}
+		else
+		{
+			part.stackIcon.ClearInfoBoxes();
+			ammoGauge = null;
+			emptyGauge = null;
+			heatGauge = null;
+			reloadBar = null;
+		}
+	}
+	void UpdateHeatMeter()
+	{
+		//heat
+		if (heat > maxHeat / 3)
+		{
+			if (heatGauge == null)
+			{
+				heatGauge = InitHeatGauge();
+			}
+			heatGauge?.SetValue(heat, maxHeat / 3, maxHeat);    //null check
+		}
+		else if (heatGauge != null && heat < maxHeat / 4)
+		{
+			part.stackIcon.ClearInfoBoxes();
+			heatGauge = null;
+			ammoGauge = null;
+			emptyGauge = null;
 			if (!BDArmorySettings.INFINITE_AMMO)
 			{
 				if (!isOutofAmmo)
 				{
-					if (ammoGauge == null)
-					{
-						ammoGauge = InitAmmoGauge();
-					}
-					ammoGauge?.SetValue(ammoAmount, 0, ammoMax);  //null check
+					UpdateAmmoMeter();
 				}
-				else if (ammoGauge != null && isOutofAmmo)
+				else
 				{
-					part.stackIcon.ClearInfoBoxes();
-					ammoGauge = null;
-					emptyGauge = null;
 					UpdateEmptyAlert();
 				}
 			}
-			else //clear ammo gauges if infinite ammo, they're unnecessary
-			{
-				part.stackIcon.ClearInfoBoxes();
-				ammoGauge = null;
-				heatGauge = null;
-				reloadBar = null;
-				emptyGauge = null;
-				UpdateHeatMeter();
-				UpdateReloadMeter();
-			}
 		}
-		public void UpdateEmptyAlert()
+	}
+	void UpdateReloadMeter()
+	{
+		if (Time.time - timeFired < (60 / roundsPerMinute) && Time.time - timeFired > 0.1f)
 		{
+			if (reloadBar == null)
+			{
+				reloadBar = InitReloadBar();
+				if (reloadAudioClip)
+				{
+					audioSource.PlayOneShot(reloadAudioClip);
+				}
+			}
+			reloadBar.SetValue(Time.time - timeFired, 0, 60 / roundsPerMinute);
+		}
+		else if (reloadBar != null)
+		{
+			part.stackIcon.ClearInfoBoxes();
+			reloadBar = null;
+			emptyGauge = null;
+			ammoGauge = null;
+			if (reloadCompleteAudioClip)
+			{
+				audioSource.PlayOneShot(reloadCompleteAudioClip);
+			}
 			if (!BDArmorySettings.INFINITE_AMMO)
 			{
-				if (isOutofAmmo)
+				if (!isOutofAmmo)
 				{
-					if (emptyGauge == null)
-					{
-						emptyGauge = InitEmptyGauge();
-					}
-					emptyGauge?.SetValue(1, 0, 1);    //null check
+					UpdateAmmoMeter();
 				}
-				else if (emptyGauge != null && !isOutofAmmo)
+				else
 				{
-					part.stackIcon.ClearInfoBoxes();
-					ammoGauge = null;
-					emptyGauge = null;
-					heatGauge = null;
-					reloadBar = null;
-				}
-			}
-			else
-			{
-				part.stackIcon.ClearInfoBoxes();
-				ammoGauge = null;
-				emptyGauge = null;
-				heatGauge = null;
-				reloadBar = null;
-			}
-
-		}
-		void UpdateHeatMeter()
-		{
-			//heat
-			if (heat > maxHeat / 3)
-			{
-				if (heatGauge == null)
-				{
-					heatGauge = InitHeatGauge();
-				}
-
-				heatGauge?.SetValue(heat, maxHeat / 3, maxHeat);    //null check
-			}
-			else if (heatGauge != null && heat < maxHeat / 4)
-			{
-				part.stackIcon.ClearInfoBoxes();
-				heatGauge = null;
-				ammoGauge = null;
-				emptyGauge = null;
-				if (!BDArmorySettings.INFINITE_AMMO)
-				{
-					if (!isOutofAmmo)
-					{
-						UpdateAmmoMeter();
-					}
-					else
-					{
-						UpdateEmptyAlert();
-					}
+					UpdateEmptyAlert();
 				}
 			}
 		}
-
-		void UpdateReloadMeter()
-		{
-			if (Time.time - timeFired < (60 / roundsPerMinute) && Time.time - timeFired > 0.1f)
-			{
-				if (reloadBar == null)
-				{
-					reloadBar = InitReloadBar();
-					if (reloadAudioClip)
-					{
-						audioSource.PlayOneShot(reloadAudioClip);
-					}
-				}
-				reloadBar.SetValue(Time.time - timeFired, 0, 60 / roundsPerMinute);
-			}
-			else if (reloadBar != null)
-			{
-				part.stackIcon.ClearInfoBoxes();
-				reloadBar = null;
-				emptyGauge = null;
-				ammoGauge = null;
-				if (reloadCompleteAudioClip)
-				{
-					audioSource.PlayOneShot(reloadCompleteAudioClip);
-				}
-				if (!BDArmorySettings.INFINITE_AMMO)
-				{
-					if (!isOutofAmmo)
-					{
-						UpdateAmmoMeter();
-					}
-					else
-					{
-						UpdateEmptyAlert();
-					}
-				}
-			}
-		}
-		void UpdateTargetVessel()
+	}
+	void UpdateTargetVessel()
         {
-            targetAcquired = false;
-            slaved = false;
-            bool atprWasAcquired = atprAcquired;
-            atprAcquired = false;
+            	targetAcquired = false;
+            	slaved = false;
+            	bool atprWasAcquired = atprAcquired;
+            	atprAcquired = false;
 
-            //targetVessel = null;
-            if (BDArmorySettings.ALLOW_LEGACY_TARGETING)
-            {
-                if (!aiControlled)
-                {
-                    if (vessel.targetObject != null && vessel.targetObject.GetVessel() != null)
-                    {
-                        legacyTargetVessel = vessel.targetObject.GetVessel();
-                    }
-                }
-            }
+            	//targetVessel = null;
+            	if (BDArmorySettings.ALLOW_LEGACY_TARGETING)
+            	{
+                	if (!aiControlled)
+                	{
+                    		if (vessel.targetObject != null && vessel.targetObject.GetVessel() != null)
+                    		{
+	                        	legacyTargetVessel = vessel.targetObject.GetVessel();
+                    		}
+                	}
+		}
 
-            if (weaponManager)
-            {
-                //legacy or visual range guard targeting
-                if (aiControlled && weaponManager && legacyTargetVessel &&
-                    (BDArmorySettings.ALLOW_LEGACY_TARGETING ||
-                     (legacyTargetVessel.transform.position - transform.position).sqrMagnitude < weaponManager.guardRange*weaponManager.guardRange))
-                {
-                    targetPosition = legacyTargetVessel.CoM;
-                    targetVelocity = legacyTargetVessel.rb_velocity;
-                    targetAcquired = true;
-                    return;
-                }
+        	if (weaponManager)
+        	{
+        		//legacy or visual range guard targeting
+                	if (aiControlled && weaponManager && legacyTargetVessel &&
+                    	(BDArmorySettings.ALLOW_LEGACY_TARGETING ||
+                     	(legacyTargetVessel.transform.position - transform.position).sqrMagnitude < weaponManager.guardRange*weaponManager.guardRange))
+                	{
+                    		targetPosition = legacyTargetVessel.CoM;
+                    		targetVelocity = legacyTargetVessel.rb_velocity;
+                    		targetAcquired = true;
+                    		return;
+                	}
 
-                if (weaponManager.slavingTurrets && turret)
-                {
-                    slaved = true;
-                    targetPosition = weaponManager.slavedPosition;
-                    targetVelocity = weaponManager.slavedTarget.vessel?.rb_velocity ?? (weaponManager.slavedVelocity - Krakensbane.GetFrameVelocityV3f());
-                    targetAcquired = true;
-                    return;
-                }
+                	if (weaponManager.slavingTurrets && turret)
+                	{
+                    		slaved = true;
+                    		targetPosition = weaponManager.slavedPosition;
+                    		targetVelocity = weaponManager.slavedTarget.vessel?.rb_velocity ?? (weaponManager.slavedVelocity - Krakensbane.GetFrameVelocityV3f());
+                    		targetAcquired = true;
+                    		return;
+                	}
 
-                if (weaponManager.vesselRadarData && weaponManager.vesselRadarData.locked)
-                {
-                    TargetSignatureData targetData = weaponManager.vesselRadarData.lockedTargetData.targetData;
-                    targetVelocity = targetData.velocity - Krakensbane.GetFrameVelocityV3f();
-                    targetPosition = targetData.predictedPosition;
-                    targetAcceleration = targetData.acceleration;
-                    if (targetData.vessel)
-                    {
-                        targetVelocity = targetData.vessel?.rb_velocity ?? targetVelocity;
-                        targetPosition = targetData.vessel.CoM;
-                    }
-                    targetAcquired = true;
-                    return;
-                }
+                	if (weaponManager.vesselRadarData && weaponManager.vesselRadarData.locked)
+                	{
+                    		TargetSignatureData targetData = weaponManager.vesselRadarData.lockedTargetData.targetData;
+                    		targetVelocity = targetData.velocity - Krakensbane.GetFrameVelocityV3f();
+                    		targetPosition = targetData.predictedPosition;
+                    		targetAcceleration = targetData.acceleration;
+                    		if (targetData.vessel)
+                    		{
+	                 	       targetVelocity = targetData.vessel?.rb_velocity ?? targetVelocity;
+	                 	       targetPosition = targetData.vessel.CoM;
+	                	}
+                    		targetAcquired = true;
+                    		return;
+                	}
+                	//auto proxy tracking
+                	if (vessel.isActiveVessel && autoProxyTrackRange > 0)
+                	{
+                    		if (aptrTicker < 20)
+                    		{
+                        		aptrTicker++;
+                        		if (atprWasAcquired)
+                        		{
+                            			targetAcquired = true;
+                            			atprAcquired = true;
+                        		}
+                    		}
+                    		else
+                    		{
+                        		aptrTicker = 0;
+                        		Vessel tgt = null;
+                        		float closestSqrDist = autoProxyTrackRange * autoProxyTrackRange;
+                        		List<Vessel>.Enumerator v = BDATargetManager.LoadedVessels.GetEnumerator();
+                        		while (v.MoveNext())
+                        		{
+                            			if (v.Current == null || !v.Current.loaded) continue;
+                            			if (!v.Current.IsControllable) continue;
+                            			if (v.Current == vessel) continue;
+                            			Vector3 targetVector = v.Current.transform.position - part.transform.position;
+                            			if (Vector3.Dot(targetVector, fireTransforms[0].forward) < 0) continue;
+                            			float sqrDist = (v.Current.transform.position - part.transform.position).sqrMagnitude;
+                            			if (sqrDist > closestSqrDist) continue;
+                            			if (Vector3.Angle(targetVector, fireTransforms[0].forward) > 20) continue;
+                            			tgt = v.Current;
+                            			closestSqrDist = sqrDist;
+                        		}
+                        		v.Dispose();
 
-                //auto proxy tracking
-                if (vessel.isActiveVessel && autoProxyTrackRange > 0)
-                {
-                    if (aptrTicker < 20)
-                    {
-                        aptrTicker++;
-
-                        if (atprWasAcquired)
-                        {
-                            targetAcquired = true;
-                            atprAcquired = true;
-                        }
-                    }
-                    else
-                    {
-                        aptrTicker = 0;
-                        Vessel tgt = null;
-                        float closestSqrDist = autoProxyTrackRange * autoProxyTrackRange;
-                        List<Vessel>.Enumerator v = BDATargetManager.LoadedVessels.GetEnumerator();
-                        while (v.MoveNext())
-                        {
-                            if (v.Current == null || !v.Current.loaded) continue;
-                            if (!v.Current.IsControllable) continue;
-                            if (v.Current == vessel) continue;
-                            Vector3 targetVector = v.Current.transform.position - part.transform.position;
-                            if (Vector3.Dot(targetVector, fireTransforms[0].forward) < 0) continue;
-                            float sqrDist = (v.Current.transform.position - part.transform.position).sqrMagnitude;
-                            if (sqrDist > closestSqrDist) continue;
-                            if (Vector3.Angle(targetVector, fireTransforms[0].forward) > 20) continue;
-                            tgt = v.Current;
-                            closestSqrDist = sqrDist;
-                        }
-                        v.Dispose();
-
-                        if (tgt == null) return;
-                        targetAcquired = true;
-                        atprAcquired = true;
-                        targetPosition = tgt.CoM;
-                        targetVelocity = tgt.rb_velocity;
-                    }
-                }
-            }
+                        		if (tgt == null) return;
+                        		targetAcquired = true;
+                        		atprAcquired = true;
+                        		targetPosition = tgt.CoM;
+                        		targetVelocity = tgt.rb_velocity;
+                    		}
+                	}
+            	}
         }
 
         void updateAcceleration(Vector3 target_rb_velocity)
         {
-            targetAcceleration = (target_rb_velocity - Krakensbane.GetLastCorrection() - targetVelocityPrevious) / Time.fixedDeltaTime;
-            targetVelocityPrevious = target_rb_velocity;
+            	targetAcceleration = (target_rb_velocity - Krakensbane.GetLastCorrection() - targetVelocityPrevious) / Time.fixedDeltaTime;
+            	targetVelocityPrevious = target_rb_velocity;
         }
 
         void UpdateGUIWeaponState()
         {
-            guiStatusString = weaponState.ToString();
+            	guiStatusString = weaponState.ToString();
         }
 
         private ProtoStageIconInfo InitReloadBar()
         {
-            ProtoStageIconInfo v = part.stackIcon.DisplayInfo();
-            v.SetMsgBgColor(XKCDColors.DarkGrey);
-            v.SetMsgTextColor(XKCDColors.White);
-            v.SetMessage("Reloading");
-            v.SetProgressBarBgColor(XKCDColors.DarkGrey);
-            v.SetProgressBarColor(XKCDColors.Silver);
+            	ProtoStageIconInfo v = part.stackIcon.DisplayInfo();
+            	v.SetMsgBgColor(XKCDColors.DarkGrey);
+            	v.SetMsgTextColor(XKCDColors.White);
+            	v.SetMessage("Reloading");
+            	v.SetProgressBarBgColor(XKCDColors.DarkGrey);
+            	v.SetProgressBarColor(XKCDColors.Silver);
 
-            return v;
+            	return v;
         }
 
         private ProtoStageIconInfo InitHeatGauge() //thanks DYJ
         {
-            ProtoStageIconInfo v = part.stackIcon.DisplayInfo();
+            	ProtoStageIconInfo v = part.stackIcon.DisplayInfo();
 
-            // fix nullref if no stackicon exists
-            if (v != null)
-            {
-                v.SetMsgBgColor(XKCDColors.DarkRed);
-                v.SetMsgTextColor(XKCDColors.Orange);
-                v.SetMessage("Overheat");
-                v.SetProgressBarBgColor(XKCDColors.DarkRed);
-                v.SetProgressBarColor(XKCDColors.Orange);
-            }
-            return v;
+            	// fix nullref if no stackicon exists
+            	if (v != null)
+            	{
+               		v.SetMsgBgColor(XKCDColors.DarkRed);
+                	v.SetMsgTextColor(XKCDColors.Orange);
+                	v.SetMessage("Overheat");
+                	v.SetProgressBarBgColor(XKCDColors.DarkRed);
+                	v.SetProgressBarColor(XKCDColors.Orange);
+            	}
+            	return v;
         }
-		private ProtoStageIconInfo InitAmmoGauge() //thanks DYJ
+	private ProtoStageIconInfo InitAmmoGauge() //thanks DYJ
+	{
+		ProtoStageIconInfo a = part.stackIcon.DisplayInfo();
+		// fix nullref if no stackicon exists
+		if (a != null)
 		{
-			ProtoStageIconInfo a = part.stackIcon.DisplayInfo();
-			// fix nullref if no stackicon exists
-			if (a != null)
-			{
-				a.SetMsgBgColor(XKCDColors.Grey);
-				a.SetMsgTextColor(XKCDColors.Yellow);
-				//a.SetMessage("Ammunition");
-				a.SetMessage($"{ammoName}");
-				a.SetProgressBarBgColor(XKCDColors.DarkGrey);
-				a.SetProgressBarColor(XKCDColors.Yellow);
-			}
-			return a;
+			a.SetMsgBgColor(XKCDColors.Grey);
+			a.SetMsgTextColor(XKCDColors.Yellow);
+			//a.SetMessage("Ammunition");
+			a.SetMessage($"{ammoName}");
+			a.SetProgressBarBgColor(XKCDColors.DarkGrey);
+			a.SetProgressBarColor(XKCDColors.Yellow);
 		}
-		private ProtoStageIconInfo InitEmptyGauge() //thanks DYJ
+		return a;
+	}
+	private ProtoStageIconInfo InitEmptyGauge() //thanks DYJ
+	{
+		ProtoStageIconInfo g = part.stackIcon.DisplayInfo();
+		// fix nullref if no stackicon exists
+		if (g != null)
 		{
-			ProtoStageIconInfo g = part.stackIcon.DisplayInfo();
-			// fix nullref if no stackicon exists
-			if (g != null)
-			{
-				g.SetMsgBgColor(XKCDColors.AlmostBlack);
-				g.SetMsgTextColor(XKCDColors.Yellow);
-				g.SetMessage("Ammo Depleted");
-				g.SetProgressBarBgColor(XKCDColors.Yellow);
-				g.SetProgressBarColor(XKCDColors.Black);
-			}
-			return g;
+			g.SetMsgBgColor(XKCDColors.AlmostBlack);
+			g.SetMsgTextColor(XKCDColors.Yellow);
+			g.SetMessage("Ammo Depleted");
+			g.SetProgressBarBgColor(XKCDColors.Yellow);
+			g.SetProgressBarColor(XKCDColors.Black);
 		}
-		IEnumerator StartupRoutine()
+		return g;
+	}
+	IEnumerator StartupRoutine()
         {
-            weaponState = WeaponStates.PoweringUp;
-            UpdateGUIWeaponState();
+            	weaponState = WeaponStates.PoweringUp;
+            	UpdateGUIWeaponState();
 
-            if (hasDeployAnim && deployState)
-            {
-                deployState.enabled = true;
-                deployState.speed = 1;
-                while (deployState.normalizedTime < 1) //wait for animation here
-                {
-                    yield return null;
-                }
-                deployState.normalizedTime = 1;
-                deployState.speed = 0;
-                deployState.enabled = false;
-            }
+            	if (hasDeployAnim && deployState)
+            	{
+                	deployState.enabled = true;
+                	deployState.speed = 1;
+                	while (deployState.normalizedTime < 1) //wait for animation here
+                	{
+                    		yield return null;
+                	}
+                	deployState.normalizedTime = 1;
+                	deployState.speed = 0;
+                	deployState.enabled = false;
+            	}
 
-            weaponState = WeaponStates.Enabled;
-            UpdateGUIWeaponState();
-            BDArmorySetup.Instance.UpdateCursorState();
+            	weaponState = WeaponStates.Enabled;
+            	UpdateGUIWeaponState();
+            	BDArmorySetup.Instance.UpdateCursorState();
         }
 
         IEnumerator ShutdownRoutine()
         {
-            weaponState = WeaponStates.PoweringDown;
-            UpdateGUIWeaponState();
-            BDArmorySetup.Instance.UpdateCursorState();
-            if (turret)
-            {
-                yield return new WaitForSeconds(0.2f);
+            	weaponState = WeaponStates.PoweringDown;
+            	UpdateGUIWeaponState();
+            	BDArmorySetup.Instance.UpdateCursorState();
+            	if (turret)
+            	{
+                	yield return new WaitForSeconds(0.2f);
 
-                while (!turret.ReturnTurret()) //wait till turret has returned
-                {
-                    yield return new WaitForFixedUpdate();
-                }
-            }
+                	while (!turret.ReturnTurret()) //wait till turret has returned
+                	{
+                    		yield return new WaitForFixedUpdate();
+                	}
+		}
 
-            if (hasDeployAnim)
-            {
-                deployState.enabled = true;
-                deployState.speed = -1;
-                while (deployState.normalizedTime > 0)
-                {
-                    yield return null;
-                }
-                deployState.normalizedTime = 0;
-                deployState.speed = 0;
-                deployState.enabled = false;
-            }
-
-            weaponState = WeaponStates.Disabled;
-            UpdateGUIWeaponState();
-        }
+        	if (hasDeployAnim)
+        	{
+                	deployState.enabled = true;
+                	deployState.speed = -1;
+                	while (deployState.normalizedTime > 0)
+                	{
+	                    	yield return null;
+	                }
+        	        deployState.normalizedTime = 0;
+                	deployState.speed = 0;
+                	deployState.enabled = false;
+		}
+		weaponState = WeaponStates.Disabled;
+		UpdateGUIWeaponState();
+        	}
 
         void StopShutdownStartupRoutines()
         {
-            if (shutdownRoutine != null)
-            {
-                StopCoroutine(shutdownRoutine);
-                shutdownRoutine = null;
-            }
+            	if (shutdownRoutine != null)
+            	{
+                	StopCoroutine(shutdownRoutine);
+                	shutdownRoutine = null;
+            	}
 
-            if (startupRoutine != null)
-            {
-                StopCoroutine(startupRoutine);
-                startupRoutine = null;
-            }
+            	if (startupRoutine != null)
+            	{
+                	StopCoroutine(startupRoutine);
+                	startupRoutine = null;
+            	}
         }
 
         #endregion
@@ -2653,59 +2608,58 @@ namespace BDArmory.Modules
 
         void ParseBulletDragType()
         {
-            bulletDragTypeName = bulletDragTypeName.ToLower();
+            	bulletDragTypeName = bulletDragTypeName.ToLower();
 
-            switch (bulletDragTypeName)
-            {
-                case "none":
-                    bulletDragType = BulletDragTypes.None;
-                    break;
+            	switch (bulletDragTypeName)
+            	{
+                	case "none":
+                    		bulletDragType = BulletDragTypes.None;
+                    		break;
 
-                case "numericalintegration":
-                    bulletDragType = BulletDragTypes.NumericalIntegration;
-                    break;
+                	case "numericalintegration":
+                    		bulletDragType = BulletDragTypes.NumericalIntegration;
+                    		break;
 
-                case "analyticestimate":
-                    bulletDragType = BulletDragTypes.AnalyticEstimate;
-                    break;
-            }
+                	case "analyticestimate":
+                    		bulletDragType = BulletDragTypes.AnalyticEstimate;
+                    		break;
+            	}
         }
         
         void SetupBulletPool()
         {
-            GameObject templateBullet = new GameObject("Bullet");                                 
-            templateBullet.AddComponent<PooledBullet>();
-            templateBullet.SetActive(false);
-            bulletPool = ObjectPool.CreateObjectPool(templateBullet, 100, true, true);
+            	GameObject templateBullet = new GameObject("Bullet");                                 
+            	templateBullet.AddComponent<PooledBullet>();
+            	templateBullet.SetActive(false);
+            	bulletPool = ObjectPool.CreateObjectPool(templateBullet, 100, true, true);
         }
 
         void SetupShellPool()
         {
-            GameObject templateShell =
+           	GameObject templateShell =
                 (GameObject)Instantiate(GameDatabase.Instance.GetModel("BDArmory/Models/shell/model"));
-            templateShell.SetActive(false);
-            templateShell.AddComponent<ShellCasing>();
-            shellPool = ObjectPool.CreateObjectPool(templateShell, 50, true, true);
+            	templateShell.SetActive(false);
+            	templateShell.AddComponent<ShellCasing>();
+            	shellPool = ObjectPool.CreateObjectPool(templateShell, 50, true, true);
         }
 
         void SetupBullet()
         {
-            bulletInfo = BulletInfo.bullets[bulletType];
-            if (bulletType != "def")
-            {
-                //use values from bullets.cfg if not the Part Module defaults are used
-                caliber = bulletInfo.caliber;
-                bulletVelocity = bulletInfo.bulletVelocity;
-                bulletMass = bulletInfo.bulletMass;
-                bulletDragTypeName = bulletInfo.bulletDragTypeName;
-                cannonShellHeat = bulletInfo.blastHeat;
-                cannonShellPower = bulletInfo.blastPower;
-                cannonShellRadius = bulletInfo.blastRadius;
-		detonationRange = bulletInfo.tntMass;
-		detonationRange = (float)((14.8f * Math.Pow(detonationRange, 1 / 3f))*(2/3));
-
+            	bulletInfo = BulletInfo.bullets[bulletType];
+            	if (bulletType != "def")
+            	{
+                	//use values from bullets.cfg if not the Part Module defaults are used
+                	caliber = bulletInfo.caliber;
+	                bulletVelocity = bulletInfo.bulletVelocity;
+	                bulletMass = bulletInfo.bulletMass;
+        	        bulletDragTypeName = bulletInfo.bulletDragTypeName;
+                	cannonShellHeat = bulletInfo.blastHeat;
+	                cannonShellPower = bulletInfo.blastPower;
+        	        cannonShellRadius = bulletInfo.blastRadius;
+			detonationRange = bulletInfo.tntMass;
+			detonationRange = (float)((14.8f * Math.Pow(detonationRange, 1 / 3f))*(2/3));
 		}
-            ParseBulletDragType();
+            	ParseBulletDragType();
 		if (eWeaponType == WeaponTypes.Rocket)
 		{
 			detonationRange = blastForce;
@@ -2718,25 +2672,25 @@ namespace BDArmory.Modules
 
         public override string GetInfo()
         {
-            BulletInfo binfo = BulletInfo.bullets[bulletType];
-            StringBuilder output = new StringBuilder();
-            output.Append(Environment.NewLine);
-            output.AppendLine($"Weapon Type: {weaponType}");
+            	BulletInfo binfo = BulletInfo.bullets[bulletType];
+            	StringBuilder output = new StringBuilder();
+            	output.Append(Environment.NewLine);
+            	output.AppendLine($"Weapon Type: {weaponType}");
 
-            if (weaponType == "laser")
-            {
-                output.AppendLine($"Laser damage: {laserDamage}");
-            }
+            	if (weaponType == "laser")
+           	{
+                	output.AppendLine($"Laser damage: {laserDamage}");
+            	}
 		else
-            {
-                output.AppendLine($"Rounds Per Minute: {roundsPerMinute * (fireTransforms?.Length ?? 1)}");
-                output.AppendLine($"Ammunition: {ammoName}");
-		if (weaponType == "ballistic")
-		{
-			output.AppendLine($"Bullet type: {bulletType}");
-			output.AppendLine($"Bullet mass: {Math.Round(binfo.bulletMass, 2)} kg");
-			output.AppendLine($"Muzzle velocity: {Math.Round(binfo.bulletVelocity, 2)} m/s");
-		}
+            	{
+                	output.AppendLine($"Rounds Per Minute: {roundsPerMinute * (fireTransforms?.Length ?? 1)}");
+                	output.AppendLine($"Ammunition: {ammoName}");
+			if (weaponType == "ballistic")
+			{
+				output.AppendLine($"Bullet type: {bulletType}");
+				output.AppendLine($"Bullet mass: {Math.Round(binfo.bulletMass, 2)} kg");
+				output.AppendLine($"Muzzle velocity: {Math.Round(binfo.bulletVelocity, 2)} m/s");
+			}
 			output.AppendLine($"Max Range: {maxEffectiveDistance} m");
 			if (weaponType == "rocket")
 			{
@@ -2751,28 +2705,28 @@ namespace BDArmory.Modules
 				}
 			}
 			if (weaponType == "ballistic")
-                {
-                    output.AppendLine($"Explosive: {binfo.explosive}");
-                    if (binfo.explosive)
-                    {
-                        output.AppendLine($"Blast:");
-                        output.AppendLine($"- tnt mass:  {Math.Round((binfo.tntMass > 0 ? binfo.tntMass : binfo.blastPower),2)} kg");
-                        output.AppendLine($"- radius:  {Math.Round(BlastPhysicsUtils.CalculateBlastRange(binfo.tntMass), 2)} m");
-                        output.AppendLine($"Air detonation: {airDetonation}");
-                        if (airDetonation)
-                        {
-                            output.AppendLine($"- auto timing: {airDetonationTiming}");
-                            output.AppendLine($"- max range: {maxAirDetonationRange} m");
-                        }
-				output.AppendLine($"Proximity Fuzed: {proximityDetonation}");
-				if (proximityDetonation)
-				{
-					output.AppendLine($"- fuze radius: {detonationRange} m");
+                	{
+                    		output.AppendLine($"Explosive: {binfo.explosive}");
+                    		if (binfo.explosive)
+                    		{
+                        		output.AppendLine($"Blast:");
+                        		output.AppendLine($"- tnt mass:  {Math.Round((binfo.tntMass > 0 ? binfo.tntMass : binfo.blastPower),2)} kg");
+                        		output.AppendLine($"- radius:  {Math.Round(BlastPhysicsUtils.CalculateBlastRange(binfo.tntMass), 2)} m");
+                        		output.AppendLine($"Air detonation: {airDetonation}");
+                        		if (airDetonation)
+                        		{
+                            			output.AppendLine($"- auto timing: {airDetonationTiming}");
+                            			output.AppendLine($"- max range: {maxAirDetonationRange} m");
+                        		}
+					output.AppendLine($"Proximity Fuzed: {proximityDetonation}");
+					if (proximityDetonation)
+					{
+						output.AppendLine($"- fuze radius: {detonationRange} m");
+					}
 				}
-			}
-                }
-            }
-            return output.ToString();
+                	}
+            	}
+            	return output.ToString();
         }
 	#endregion
 	}

--- a/BDArmory/Modules/RocketLauncher.cs
+++ b/BDArmory/Modules/RocketLauncher.cs
@@ -8,1083 +8,338 @@ using BDArmory.Core.Utils;
 using BDArmory.FX;
 using BDArmory.Misc;
 using BDArmory.UI;
+using KSP.UI.Screens;
 using UniLinq;
 using UnityEngine;
 
 namespace BDArmory.Modules
 {
-    public class RocketLauncher : EngageableWeapon, IBDWeapon
-    {
-        public bool hasRocket = true;
-
-        [KSPField] public string shortName = string.Empty;
-
-        [KSPField(isPersistant = false)] public string rocketType;
-
-        [KSPField(isPersistant = false)] public string rocketModelPath;
-
-        [KSPField(isPersistant = false)] public float rocketMass;
-
-        [KSPField(isPersistant = false)] public float thrust;
-
-        [KSPField(isPersistant = false)] public float thrustTime;
-
-        [KSPField(isPersistant = false)] public float blastRadius;
-
-        [KSPField(isPersistant = false)] public float blastForce;
-
-        [KSPField] public float blastHeat = -1;
-
-        [KSPField(isPersistant = false)] public bool descendingOrder = true;
-
-        [KSPField(isPersistant = false)] public string explModelPath = "BDArmory/Models/explosion/explosion";
-
-        [KSPField(isPersistant = false)] public string explSoundPath = "BDArmory/Sounds/explode1";
-
-        [KSPField] public float thrustDeviation = 0.10f;
-
-        [KSPField] public float maxTargetingRange = 8000;
-        float currentTgtRange = 8000;
-        float predictedFlightTime = 1;
-
-        public bool drawAimer;
-
-        Vector3 rocketPrediction = Vector3.zero;
-        Texture2D aimerTexture;
-
-        Transform[] rockets;
-
-        public AudioSource sfAudioSource;
-
-        //animation
-        [KSPField] public string deployAnimationName;
-        [KSPField] public float deployAnimationSpeed = 1;
-        AnimationState deployAnimState;
-        bool hasDeployAnimation;
-        public bool deployed;
-        Coroutine deployAnimRoutine;
-
-        public bool readyToFire = true;
-
-        public Vessel legacyGuardTarget = null;
-        public float lastAutoFiredTime;
-        public float autoRippleRate = 0;
-        public float autoFireStartTime = 0;
-        public float autoFireDuration = 0;
-
-        //turret
-        [KSPField] public int turretID = 0;
-        public ModuleTurret turret;
-        Vector3 trajectoryOffset = Vector3.zero;
-        public MissileFire weaponManager;
-        bool targetInTurretView = true;
-
-        public float yawRange
-        {
-            get { return turret ? turret.yawRange : 0; }
-        }
-
-        public float maxPitch
-        {
-            get { return turret ? turret.maxPitch : 0; }
-        }
-
-        public float minPitch
-        {
-            get { return turret ? turret.minPitch : 0; }
-        }
-
-        Vector3 targetPosition;
-        public Vector3? FiringSolutionVector => targetPosition.IsZero() ? (Vector3?)null : (targetPosition - rockets[0].parent.transform.position).normalized;
-
-        double lastRocketsLeft;
-
-        //weapon interface
-        public Part GetPart()
-        {
-            return part;
-        }
-
-        public string GetShortName()
-        {
-            return shortName;
-        }
-
-        public WeaponClasses GetWeaponClass()
-        {
-            return WeaponClasses.Rocket;
-        }
-
-        public string GetSubLabel()
-        {
-            return string.Empty;
-        }
-
-        public string GetMissileType()
-        {
-            return string.Empty;
-        }
-
-
-        [KSPAction("Fire")]
-        public void AGFire(KSPActionParam param)
-        {
-            FireRocket();
-        }
-
-        [KSPEvent(guiActive = true, guiName = "Fire", active = true)]
-        public void GuiFire()
-        {
-            FireRocket();
-        }
-
-        [KSPEvent(guiActive = true, guiName = "Jettison", active = true, guiActiveEditor = false)]
-        public void Jettison()
-        {
-            if (turret)
-            {
-                return;
-            }
-
-            part.decouple(0);
-            if (BDArmorySetup.Instance.ActiveWeaponManager != null)
-                BDArmorySetup.Instance.ActiveWeaponManager.UpdateList();
-        }
-
-        [KSPEvent(guiActive = false, guiName = "Toggle Turret", guiActiveEditor = false)]
-        public void ToggleTurret()
-        {
-            if (deployed)
-            {
-                DisableTurret();
-            }
-            else
-            {
-                EnableTurret();
-            }
-        }
-
-        public void EnableTurret()
-        {
-            deployed = true;
-            drawAimer = true;
-            hasReturned = false;
-
-            if (returnRoutine != null)
-            {
-                StopCoroutine(returnRoutine);
-                returnRoutine = null;
-            }
-
-            if (hasDeployAnimation)
-            {
-                if (deployAnimRoutine != null)
-                {
-                    StopCoroutine(deployAnimRoutine);
-                }
-                deployAnimRoutine = StartCoroutine(DeployAnimRoutine(true));
-            }
-            else
-            {
-                readyToFire = true;
-            }
-        }
-
-        public void DisableTurret()
-        {
-            deployed = false;
-            readyToFire = false;
-            drawAimer = false;
-            hasReturned = false;
-            targetInTurretView = false;
-
-            if (returnRoutine != null)
-            {
-                StopCoroutine(returnRoutine);
-            }
-            returnRoutine = StartCoroutine(ReturnRoutine());
-
-            if (hasDeployAnimation)
-            {
-                if (deployAnimRoutine != null)
-                {
-                    StopCoroutine(deployAnimRoutine);
-                }
-
-                deployAnimRoutine = StartCoroutine(DeployAnimRoutine(false));
-            }
-        }
-
-        bool hasReturned = true;
-        Coroutine returnRoutine;
-
-        IEnumerator ReturnRoutine()
-        {
-            if (deployed)
-            {
-                hasReturned = false;
-                yield break;
-            }
-
-            yield return new WaitForSeconds(0.25f);
-
-            while (!turret.ReturnTurret())
-            {
-                yield return new WaitForFixedUpdate();
-            }
-
-            hasReturned = true;
-        }
-
-        void SetupAudio()
-        {
-            sfAudioSource = gameObject.AddComponent<AudioSource>();
-            sfAudioSource.minDistance = 1;
-            sfAudioSource.maxDistance = 2000;
-            sfAudioSource.dopplerLevel = 0;
-            sfAudioSource.priority = 230;
-            sfAudioSource.spatialBlend = 1;
-
-            UpdateVolume();
-            BDArmorySetup.OnVolumeChange += UpdateVolume;
-        }
-
-        void UpdateVolume()
-        {
-            if (sfAudioSource)
-            {
-                sfAudioSource.volume = BDArmorySettings.BDARMORY_WEAPONS_VOLUME;
-            }
-        }
-
-
-        public override void OnStart(StartState state)
-        {
-            // extension for feature_engagementenvelope
-            InitializeEngagementRange(0, maxTargetingRange);
-
-            if (HighLogic.LoadedSceneIsFlight)
-            {
-                part.force_activate();
-
-                aimerTexture = BDArmorySetup.Instance.greenPointCircleTexture;
-                // GameDatabase.Instance.GetTexture("BDArmory/Textures/grayCircle", false);
-
-
-                MakeRocketArray();
-                UpdateRocketScales();
-
-                if (shortName == string.Empty)
-                {
-                    shortName = part.partInfo.title;
-                }
-
-                UpdateAudio();
-                BDArmorySetup.OnVolumeChange += UpdateAudio;
-            }
-
-            if (HighLogic.LoadedSceneIsFlight || HighLogic.LoadedSceneIsEditor)
-            {
-                List<ModuleTurret>.Enumerator turr = part.FindModulesImplementing<ModuleTurret>().GetEnumerator();
-                while (turr.MoveNext())
-                {
-                    if (turr.Current == null) continue;
-                    if (turr.Current.turretID != turretID) continue;
-                    turret = turr.Current;
-                    targetInTurretView = false;
-                    break;
-                }
-                turr.Dispose();
-
-                if (turret)
-                {
-                    Events["GuiFire"].guiActive = false;
-                    Events["Jettison"].guiActive = false;
-                    Actions["AGFire"].active = false;
-
-                    if (HighLogic.LoadedSceneIsFlight)
-                    {
-                        Events["ToggleTurret"].guiActive = true;
-                    }
-                }
-
-                if (!string.IsNullOrEmpty(deployAnimationName))
-                {
-                    deployAnimState = Misc.Misc.SetUpSingleAnimation(deployAnimationName, part);
-                    hasDeployAnimation = true;
-
-                    readyToFire = false;
-                }
-            }
-            SetupAudio();
-
-            blastForce = BlastPhysicsUtils.CalculateExplosiveMass(blastRadius);
-        }
-
-        IEnumerator DeployAnimRoutine(bool forward)
-        {
-            readyToFire = false;
-            BDArmorySetup.Instance.UpdateCursorState();
-
-            if (forward)
-            {
-                while (deployAnimState.normalizedTime < 1)
-                {
-                    deployAnimState.speed = deployAnimationSpeed;
-                    yield return null;
-                }
-
-                deployAnimState.normalizedTime = 1;
-            }
-            else
-            {
-                while (!hasReturned)
-                {
-                    deployAnimState.speed = 0;
-                    yield return null;
-                }
-
-                while (deployAnimState.normalizedTime > 0)
-                {
-                    deployAnimState.speed = -deployAnimationSpeed;
-                    yield return null;
-                }
-
-                deployAnimState.normalizedTime = 0;
-            }
-
-            deployAnimState.speed = 0;
-
-            readyToFire = deployed;
-            BDArmorySetup.Instance.UpdateCursorState();
-        }
-
-        void UpdateAudio()
-        {
-            if (sfAudioSource)
-            {
-                sfAudioSource.volume = BDArmorySettings.BDARMORY_WEAPONS_VOLUME;
-            }
-        }
-
-        void OnDestroy()
-        {
-            BDArmorySetup.OnVolumeChange -= UpdateAudio;
-        }
-
-
-        public override void OnFixedUpdate()
-        {
-            if (GetRocketResource().amount != lastRocketsLeft)
-            {
-                UpdateRocketScales();
-                lastRocketsLeft = GetRocketResource().amount;
-            }
-
-            if (!vessel.IsControllable)
-            {
-                return;
-            }
-
-            SimulateTrajectory();
-
-            currentTgtRange = maxTargetingRange;
-
-            if (deployed && readyToFire && (turret || weaponManager?.AI?.pilotEnabled == true))
-            {
-                Aim();
-            }
-            else
-            {
-                targetPosition = Vector3.zero;
-            }
-        }
-
-        public override void OnUpdate()
-        {
-            if (HighLogic.LoadedSceneIsFlight)
-            {
-                if (readyToFire && deployed)
-                {
-                    if (returnRoutine != null)
-                    {
-                        StopCoroutine(returnRoutine);
-                        returnRoutine = null;
-                    }
-
-                    if (weaponManager && weaponManager.guardMode && weaponManager.selectedWeaponString == GetShortName())
-                    {
-                        if (Time.time - autoFireStartTime < autoFireDuration)
-                        {
-                            float fireInterval = 0.5f;
-                            if (autoRippleRate > 0) fireInterval = 60f/autoRippleRate;
-                            if (Time.time - lastAutoFiredTime > fireInterval)
-                            {
-                                FireRocket();
-                                lastAutoFiredTime = Time.time;
-                            }
-                        }
-                    }
-                    else if ((!weaponManager ||
-                              (weaponManager.selectedWeaponString == GetShortName() && !weaponManager.guardMode)))
-                    {
-                        if (BDInputUtils.GetKeyDown(BDInputSettingsFields.WEAP_FIRE_KEY) &&
-                            (vessel.isActiveVessel || BDArmorySettings.REMOTE_SHOOTING))
-                        {
-                            FireRocket();
-                        }
-                    }
-                }
-            }
-        }
-
-        bool mouseAiming;
-
-        void Aim()
-        {
-            mouseAiming = false;
-            if (weaponManager && (weaponManager.slavingTurrets || weaponManager.guardMode || weaponManager.AI?.pilotEnabled == true))
-            {
-                SlavedAim();
-            }
-            else
-            {
-                if (vessel.isActiveVessel || BDArmorySettings.REMOTE_SHOOTING)
-                {
-                    MouseAim();
-                }
-            }
-        }
-
-        void SlavedAim()
-        {
-            Vector3 targetVel;
-            Vector3 targetAccel;
-            if (weaponManager.slavingTurrets)
-            {
-                targetPosition = weaponManager.slavedPosition;
-                targetVel = weaponManager.slavedVelocity;
-                targetAccel = weaponManager.slavedAcceleration;
-
-                //targetPosition -= vessel.Velocity * predictedFlightTime;
-            }
-            else if (legacyGuardTarget)
-            {
-                targetPosition = legacyGuardTarget.CoM;
-                targetVel = legacyGuardTarget.Velocity();
-                targetAccel = legacyGuardTarget.acceleration;
-            }
-            else
-            {
-                targetInTurretView = false;
-                return;
-            }
-
-            currentTgtRange = Vector3.Distance(targetPosition, rockets[0].parent.transform.position);
-
-
-            targetPosition += trajectoryOffset;
-            targetPosition += targetVel*predictedFlightTime;
-            targetPosition += 0.5f*targetAccel*predictedFlightTime*predictedFlightTime;
-
-            turret.AimToTarget(targetPosition);
-            targetInTurretView = turret.TargetInRange(targetPosition, 2, maxTargetingRange);
-        }
-
-        void MouseAim()
-        {
-            mouseAiming = true;
-            Vector3 targetPosition;
-            //	float maxTargetingRange = 8000;
-
-            float targetDistance;
-
-            //MouseControl
-            Vector3 mouseAim = new Vector3(Input.mousePosition.x/Screen.width, Input.mousePosition.y/Screen.height, 0);
-            Ray ray = FlightCamera.fetch.mainCamera.ViewportPointToRay(mouseAim);
-            RaycastHit hit;
-            if (Physics.Raycast(ray, out hit, maxTargetingRange, 557057))
-            {
-                targetPosition = hit.point;
-
-                //aim through self vessel if occluding mouseray
-                Part p = hit.collider.gameObject.GetComponentInParent<Part>();
-                if (p && p.vessel && p.vessel == vessel)
-                {
-                    targetPosition = ray.direction*maxTargetingRange + FlightCamera.fetch.mainCamera.transform.position;
-                }
-
-                targetDistance = Vector3.Distance(hit.point, rockets[0].parent.position);
-            }
-            else
-            {
-                targetPosition = (ray.direction*(maxTargetingRange + (FlightCamera.fetch.Distance*0.75f))) +
-                                 FlightCamera.fetch.mainCamera.transform.position;
-                targetDistance = maxTargetingRange;
-            }
-
-            currentTgtRange = targetDistance;
-
-            targetPosition += trajectoryOffset;
-
-
-            turret.AimToTarget(targetPosition);
-            targetInTurretView = turret.TargetInRange(targetPosition, 2, maxTargetingRange);
-        }
-
-        public void FireRocket()
-        {
-            if (!readyToFire) return;
-            if (!targetInTurretView) return;
-
-            PartResource rocketResource = GetRocketResource();
-
-            if (rocketResource == null)
-            {
-                Debug.Log(part.name + " doesn't carry the rocket resource it was meant to");
-                return;
-            }
-
-            int rocketsLeft = (int)Math.Floor(rocketResource.amount);
-
-            if (BDArmorySettings.INFINITE_AMMO && rocketsLeft < 1)
-                rocketsLeft = 1;
-
-            if (rocketsLeft >= 1)
-            {
-                Transform currentRocketTfm = rockets[rocketsLeft - 1];
-
-                GameObject rocketObj = GameDatabase.Instance.GetModel(rocketModelPath);
-                rocketObj =
-                    (GameObject) Instantiate(rocketObj, currentRocketTfm.position, currentRocketTfm.parent.rotation);
-                rocketObj.transform.rotation = currentRocketTfm.parent.rotation;
-                rocketObj.transform.localScale = part.rescaleFactor*Vector3.one;
-                currentRocketTfm.localScale = Vector3.zero;
-                Rocket rocket = rocketObj.AddComponent<Rocket>();
-                rocket.explModelPath = explModelPath;
-                rocket.explSoundPath = explSoundPath;
-                rocket.spawnTransform = currentRocketTfm;
-                rocket.mass = rocketMass;
-                rocket.blastForce = blastForce;
-                rocket.blastHeat = blastHeat;
-                rocket.blastRadius = blastRadius;
-                rocket.thrust = thrust;
-                rocket.thrustTime = thrustTime;
-                rocket.randomThrustDeviation = thrustDeviation;
-
-                rocket.sourceVessel = vessel;
-                rocketObj.SetActive(true);
-                rocketObj.transform.SetParent(currentRocketTfm.parent);
-                rocket.parentRB = part.rb;
-
-                sfAudioSource.PlayOneShot(GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/launch"));
-                if (!BDArmorySettings.INFINITE_AMMO)
-                    rocketResource.amount--;
-
-                lastRocketsLeft = rocketResource.amount;
-            }
-        }
-
-
-        void SimulateTrajectory()
-        {
-            if ((BDArmorySettings.AIM_ASSIST && BDArmorySettings.DRAW_AIMERS && drawAimer && vessel.isActiveVessel) ||
-                (weaponManager && weaponManager.guardMode && weaponManager.selectedWeaponString == GetShortName()))
-            {
-                float simTime = 0;
-                Transform fireTransform = rockets[0].parent;
-                Vector3 pointingDirection = fireTransform.forward;
-                Vector3 simVelocity = part.rb.velocity;
-                Vector3 simCurrPos = fireTransform.position + (part.rb.velocity*Time.fixedDeltaTime);
-                Vector3 simPrevPos = fireTransform.position + (part.rb.velocity*Time.fixedDeltaTime);
-                Vector3 simStartPos = fireTransform.position + (part.rb.velocity*Time.fixedDeltaTime);
-                bool simulating = true;
-                float simDeltaTime = 0.02f;
-                List<Vector3> pointPositions = new List<Vector3>();
-                pointPositions.Add(simCurrPos);
-
-                bool slaved = turret && weaponManager && (weaponManager.slavingTurrets || weaponManager.guardMode);
-                float atmosMultiplier =
-                    Mathf.Clamp01(2.5f*
-                                  (float)
-                                  FlightGlobals.getAtmDensity(vessel.staticPressurekPa, vessel.externalTemperature,
-                                      vessel.mainBody));
-                while (simulating)
-                {
-                    RaycastHit hit;
-
-                    if (simTime > thrustTime)
-                    {
-                        simDeltaTime = 0.1f;
-                    }
-
-                    if (simTime > 0.04f)
-                    {
-                        simDeltaTime = 0.02f;
-                        if (simTime < thrustTime)
-                        {
-                            simVelocity += thrust/rocketMass*simDeltaTime*pointingDirection;
-                        }
-
-                        //rotation (aero stabilize)
-                        pointingDirection = Vector3.RotateTowards(pointingDirection,
-                            simVelocity + Krakensbane.GetFrameVelocity(),
-                            atmosMultiplier*(0.5f*(simTime))*50*simDeltaTime*Mathf.Deg2Rad, 0);
-                    }
-
-                    //gravity
-                    simVelocity += FlightGlobals.getGeeForceAtPosition(simCurrPos)*simDeltaTime;
-
-                    simCurrPos += simVelocity*simDeltaTime;
-                    pointPositions.Add(simCurrPos);
-                    if (!mouseAiming && !slaved)
-                    {
-                        if (simTime > 0.1f && Physics.Raycast(simPrevPos, simCurrPos - simPrevPos, out hit,
-                                Vector3.Distance(simPrevPos, simCurrPos), 9076737))
-                        {
-                            rocketPrediction = hit.point;
-                            simulating = false;
-                            break;
-                        }
-                        else if (FlightGlobals.getAltitudeAtPos(simCurrPos) < 0)
-                        {
-                            rocketPrediction = simCurrPos;
-                            simulating = false;
-                            break;
-                        }
-                    }
-
-
-                    simPrevPos = simCurrPos;
-
-                    if ((simStartPos - simCurrPos).sqrMagnitude > currentTgtRange*currentTgtRange)
-                    {
-                        rocketPrediction = simStartPos + (simCurrPos - simStartPos).normalized*currentTgtRange;
-                        //rocketPrediction = simCurrPos;
-                        simulating = false;
-                    }
-                    simTime += simDeltaTime;
-                }
-
-                Vector3 pointingPos = fireTransform.position + (fireTransform.forward*currentTgtRange);
-                trajectoryOffset = pointingPos - rocketPrediction;
-                predictedFlightTime = simTime;
-
-                if (BDArmorySettings.DRAW_DEBUG_LINES && BDArmorySettings.DRAW_AIMERS)
-                {
-                    Vector3[] pointsArray = pointPositions.ToArray();
-                    if (gameObject.GetComponent<LineRenderer>() == null)
-                    {
-                        LineRenderer lr = gameObject.AddComponent<LineRenderer>();
-                        lr.startWidth = .1f;
-                        lr.endWidth = .1f;
-                        lr.positionCount = pointsArray.Length;
-                        for (int i = 0; i < pointsArray.Length; i++)
-                        {
-                            lr.SetPosition(i, pointsArray[i]);
-                        }
-                    }
-                    else
-                    {
-                        LineRenderer lr = gameObject.GetComponent<LineRenderer>();
-                        lr.enabled = true;
-                        lr.positionCount = pointsArray.Length;
-                        for (int i = 0; i < pointsArray.Length; i++)
-                        {
-                            lr.SetPosition(i, pointsArray[i]);
-                        }
-                    }
-                }
-                else
-                {
-                    if (gameObject.GetComponent<LineRenderer>() != null)
-                    {
-                        gameObject.GetComponent<LineRenderer>().enabled = false;
-                    }
-                }
-            }
-
-            //for straight aimer
-            else if (BDArmorySettings.DRAW_AIMERS && drawAimer && vessel.isActiveVessel)
-            {
-                RaycastHit hit;
-                float distance = 2500;
-                if (Physics.Raycast(transform.position, transform.forward, out hit, distance, 9076737))
-                {
-                    rocketPrediction = hit.point;
-                }
-                else
-                {
-                    rocketPrediction = transform.position + (transform.forward*distance);
-                }
-            }
-        }
-
-        void OnGUI()
-        {
-            if (drawAimer && vessel.isActiveVessel && BDArmorySettings.DRAW_AIMERS && !MapView.MapIsEnabled)
-            {
-                float size = 30;
-
-                Vector3 aimPosition = FlightCamera.fetch.mainCamera.WorldToViewportPoint(rocketPrediction);
-
-                Rect drawRect = new Rect(aimPosition.x*Screen.width - (0.5f*size),
-                    (1 - aimPosition.y)*Screen.height - (0.5f*size), size, size);
-                float cameraAngle = Vector3.Angle(FlightCamera.fetch.GetCameraTransform().forward,
-                    rocketPrediction - FlightCamera.fetch.mainCamera.transform.position);
-                if (cameraAngle < 90) GUI.DrawTexture(drawRect, aimerTexture);
-            }
-        }
-
-        void MakeRocketArray()
-        {
-            Transform rocketsTransform = part.FindModelTransform("rockets");
-            int numOfRockets = rocketsTransform.childCount;
-            rockets = new Transform[numOfRockets];
-
-            for (int i = 0; i < numOfRockets; i++)
-            {
-                string rocketName = rocketsTransform.GetChild(i).name;
-                int rocketIndex = int.Parse(rocketName.Substring(7)) - 1;
-                rockets[rocketIndex] = rocketsTransform.GetChild(i);
-            }
-
-            if (!descendingOrder) Array.Reverse(rockets);
-        }
-
-
-        public PartResource GetRocketResource()
-        {
-            IEnumerator<PartResource> res = part.Resources.GetEnumerator();
-            while (res.MoveNext())
-            {
-                if (res.Current == null) continue;
-                if (res.Current.resourceName == rocketType) return res.Current;
-            }
-            res.Dispose();
-            return null;
-        }
-
-        void UpdateRocketScales()
-        {
-            PartResource rocketResource = GetRocketResource();
-            double rocketsLeft = Math.Floor(rocketResource.amount);
-            double rocketsMax = rocketResource.maxAmount;
-            for (int i = 0; i < rocketsMax; i++)
-            {
-                if (i < rocketsLeft) rockets[i].localScale = Vector3.one;
-                else rockets[i].localScale = Vector3.zero;
-            }
-        }
-
-        // RMB info in editor
-        public override string GetInfo()
-        {
-            StringBuilder output = new StringBuilder();
-            output.Append(Environment.NewLine);
-            output.AppendLine("Weapon Type: Rocket Launcher");
-            output.AppendLine($"Rocket Type: {rocketType}");
-            output.AppendLine($"Max Range: {maxTargetingRange} m");
-
-            output.AppendLine($"Blast:");
-            output.AppendLine($"- radius: {blastRadius}");
-            output.AppendLine($"- power: {blastForce}");
-            output.AppendLine($"- heat: {blastHeat}");
-
-            return output.ToString();
-        }
-    }
-
-
-    public class Rocket : MonoBehaviour
-    {
-        public Transform spawnTransform;
-        public Vessel sourceVessel;
-        public float mass;
-        public float thrust;
-        public float thrustTime;
-        public float blastRadius;
-        public float blastForce;
-        public float blastHeat;
-        public string explModelPath;
-        public string explSoundPath;
-
-        public float randomThrustDeviation = 0.05f;
-
-        public Rigidbody parentRB;
-
-        float startTime;
-        public AudioSource audioSource;
-
-        Vector3 prevPosition;
-        Vector3 currPosition;
-
-        float stayTime = 0.04f;
-        float lifeTime = 10;
-
-        //bool isThrusting = true;
-
-        Rigidbody rb;
-
-
-        KSPParticleEmitter[] pEmitters;
-
-        float randThrustSeed;
-
-        void Start()
-        {
-            BDArmorySetup.numberOfParticleEmitters++;
-
-            rb = gameObject.AddComponent<Rigidbody>();
-            pEmitters = gameObject.GetComponentsInChildren<KSPParticleEmitter>();
-
-            IEnumerator<KSPParticleEmitter> pe = pEmitters.AsEnumerable().GetEnumerator();
-            while (pe.MoveNext())
-            {
-                if (pe.Current == null) continue;
-                if (FlightGlobals.getStaticPressure(transform.position) == 0 && pe.Current.useWorldSpace)
-                {
-                    pe.Current.emit = false;
-                }
-                else if (pe.Current.useWorldSpace)
-                {
-                    BDAGaplessParticleEmitter gpe = pe.Current.gameObject.AddComponent<BDAGaplessParticleEmitter>();
-                    gpe.rb = rb;
-                    gpe.emit = true;
-                }
-                else
-                {
-                    EffectBehaviour.AddParticleEmitter(pe.Current);
-                }
-            }
-            pe.Dispose();
-
-            prevPosition = transform.position;
-            currPosition = transform.position;
-            startTime = Time.time;
-
-            rb.mass = mass;
-            rb.isKinematic = true;
-            //rigidbody.velocity = startVelocity;
-            if (!FlightGlobals.RefFrameIsRotating) rb.useGravity = false;
-
-            rb.useGravity = false;
-
-            randThrustSeed = UnityEngine.Random.Range(0f, 100f);
-
-            SetupAudio();
-        }
-
-        void FixedUpdate()
-        {
-            //floating origin and velocity offloading corrections
-            if (!FloatingOrigin.Offset.IsZero() || !Krakensbane.GetFrameVelocity().IsZero())
-            {
-                transform.position -= FloatingOrigin.OffsetNonKrakensbane;
-                prevPosition -= FloatingOrigin.OffsetNonKrakensbane;
-            }
-
-
-            if (Time.time - startTime < stayTime && transform.parent != null)
-            {
-                transform.rotation = transform.parent.rotation;
-                transform.position = spawnTransform.position;
-                //+(transform.parent.rigidbody.velocity*Time.fixedDeltaTime);
-            }
-            else
-            {
-                if (transform.parent != null && parentRB)
-                {
-                    transform.parent = null;
-                    rb.isKinematic = false;
-                    rb.velocity = parentRB.velocity + Krakensbane.GetFrameVelocityV3f();
-                }
-            }
-
-            if (rb && !rb.isKinematic)
-            {
-                //physics
-                if (FlightGlobals.RefFrameIsRotating)
-                {
-                    rb.velocity += FlightGlobals.getGeeForceAtPosition(transform.position)*Time.fixedDeltaTime;
-                }
-
-                //guidance and attitude stabilisation scales to atmospheric density.
-                float atmosMultiplier =
-                    Mathf.Clamp01(2.5f*
-                                  (float)
-                                  FlightGlobals.getAtmDensity(FlightGlobals.getStaticPressure(transform.position),
-                                      FlightGlobals.getExternalTemperature(), FlightGlobals.currentMainBody));
-
-                //model transform. always points prograde
-                transform.rotation = Quaternion.RotateTowards(transform.rotation,
-                    Quaternion.LookRotation(rb.velocity + Krakensbane.GetFrameVelocity(), transform.up),
-                    atmosMultiplier*(0.5f*(Time.time - startTime))*50*Time.fixedDeltaTime);
-
-
-                if (Time.time - startTime < thrustTime && Time.time - startTime > stayTime)
-                {
-                    float random = randomThrustDeviation*(1 - (Mathf.PerlinNoise(4*Time.time, randThrustSeed)*2));
-                    float random2 = randomThrustDeviation*(1 - (Mathf.PerlinNoise(randThrustSeed, 4*Time.time)*2));
-                    rb.AddRelativeForce(new Vector3(random, random2, thrust));
-                }
-            }
-
-
-            if (Time.time - startTime > thrustTime)
-            {
-                //isThrusting = false;
-                IEnumerator<KSPParticleEmitter> pEmitter = pEmitters.AsEnumerable().GetEnumerator();
-                while (pEmitter.MoveNext())
-                {
-                    if (pEmitter.Current == null) continue;
-                    if (pEmitter.Current.useWorldSpace)
-                    {
-                        pEmitter.Current.minSize = Mathf.MoveTowards(pEmitter.Current.minSize, 0.1f, 0.05f);
-                        pEmitter.Current.maxSize = Mathf.MoveTowards(pEmitter.Current.maxSize, 0.2f, 0.05f);
-                    }
-                    else
-                    {
-                        pEmitter.Current.minSize = Mathf.MoveTowards(pEmitter.Current.minSize, 0, 0.1f);
-                        pEmitter.Current.maxSize = Mathf.MoveTowards(pEmitter.Current.maxSize, 0, 0.1f);
-                        if (pEmitter.Current.maxSize == 0)
-                        {
-                            pEmitter.Current.emit = false;
-                        }
-                    }
-                }
-                pEmitter.Dispose();
-            }
-
-            if (Time.time - startTime > 0.1f + stayTime)
-            {
-                currPosition = transform.position;
-                float dist = (currPosition - prevPosition).magnitude;
-                Ray ray = new Ray(prevPosition, currPosition - prevPosition);
-                RaycastHit hit;
-                KerbalEVA hitEVA = null;
-                //if (Physics.Raycast(ray, out hit, dist, 2228224))
-                //{
-                //    try
-                //    {
-                //        hitEVA = hit.collider.gameObject.GetComponentUpwards<KerbalEVA>();
-                //        if (hitEVA != null)
-                //            Debug.Log("[BDArmory]:Hit on kerbal confirmed!");
-                //    }
-                //    catch (NullReferenceException)
-                //    {
-                //        Debug.Log("[BDArmory]:Whoops ran amok of the exception handler");
-                //    }
-
-                //    if (hitEVA && hitEVA.part.vessel != sourceVessel)
-                //    {
-                //        Detonate(hit.point);
-                //    }
-                //}
-
-                if (!hitEVA)
-                {
-                    if (Physics.Raycast(ray, out hit, dist, 9076737))
-                    {
-                        Part hitPart = null;
-                        try
-                        {
-                            KerbalEVA eva = hit.collider.gameObject.GetComponentUpwards<KerbalEVA>();
-                            hitPart = eva ? eva.part : hit.collider.gameObject.GetComponentInParent<Part>();
-                        }
-                        catch (NullReferenceException)
-                        {
-                        }
-
-
-                        if (hitPart == null || (hitPart != null && hitPart.vessel != sourceVessel))
-                        {
-                            Detonate(hit.point);
-                        }
-                    }
-                    else if (FlightGlobals.getAltitudeAtPos(transform.position) < 0)
-                    {
-                        Detonate(transform.position);
-                    }
-                }
-            }
-            else if (FlightGlobals.getAltitudeAtPos(currPosition) <= 0)
-            {
-                Detonate(currPosition);
-            }
-            prevPosition = currPosition;
-
-            if (Time.time - startTime > lifeTime)
-            {
-                Detonate(transform.position);
-            }
-        }
-
-        void Update()
-        {
-            if (HighLogic.LoadedSceneIsFlight)
-            {
-                if (BDArmorySetup.GameIsPaused)
-                {
-                    if (audioSource.isPlaying)
-                    {
-                        audioSource.Stop();
-                    }
-                }
-                else
-                {
-                    if (!audioSource.isPlaying)
-                    {
-                        audioSource.Play();
-                    }
-                }
-            }
-        }
-
-        void Detonate(Vector3 pos)
-        {
-            BDArmorySetup.numberOfParticleEmitters--;
-
-            ExplosionFx.CreateExplosion(pos, BlastPhysicsUtils.CalculateExplosiveMass(blastRadius),
-                explModelPath, explSoundPath, true);
-
-            IEnumerator<KSPParticleEmitter> emitter = pEmitters.AsEnumerable().GetEnumerator();
-            while (emitter.MoveNext())
-            {
-                if (emitter.Current == null) continue;
-                if (!emitter.Current.useWorldSpace) continue;
-                emitter.Current.gameObject.AddComponent<BDAParticleSelfDestruct>();
-                emitter.Current.transform.parent = null;
-            }
-            emitter.Dispose();
-            Destroy(gameObject); //destroy rocket on collision
-        }
-
-
-        void SetupAudio()
-        {
-            audioSource = gameObject.AddComponent<AudioSource>();
-            audioSource.loop = true;
-            audioSource.minDistance = 1;
-            audioSource.maxDistance = 2000;
-            audioSource.dopplerLevel = 0.5f;
-            audioSource.volume = 0.9f*BDArmorySettings.BDARMORY_WEAPONS_VOLUME;
-            audioSource.pitch = 1f;
-            audioSource.priority = 255;
-            audioSource.spatialBlend = 1;
-
-            audioSource.clip = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/rocketLoop");
-
-            UpdateVolume();
-            BDArmorySetup.OnVolumeChange += UpdateVolume;
-        }
-
-        void UpdateVolume()
-        {
-            if (audioSource)
-            {
-                audioSource.volume = BDArmorySettings.BDARMORY_WEAPONS_VOLUME;
-            }
-        }
-    }
+	public class RocketLauncher : ModuleWeapon
+	{
+    //the entirety of RocketLauncher (save for FireRocket(), MakeRocketArray(), UpdateRocketscales(), and RocketResource()) is duplicate code
+    //to ModuleWeapon. RocketLauncher left as empty childclass for legacy compatibility
+	}
+
+
+	public class Rocket : MonoBehaviour
+	{
+		public Transform spawnTransform;
+		public Vessel sourceVessel;
+		public float mass;
+		public float thrust;
+		public float thrustTime;
+		public float blastRadius;
+		public float blastForce;
+		public float blastHeat;
+		public bool proximityDetonation; // adds proxy detonation option for, say, AA rockets
+		public float detonationRange;
+		public float engageRangeMax;
+		public string explModelPath;
+		public string explSoundPath;
+
+		public float randomThrustDeviation = 0.05f;
+
+		public Rigidbody parentRB;
+
+		float startTime;
+		public AudioSource audioSource;
+
+		Vector3 prevPosition;
+		Vector3 currPosition;
+		Vector3 startPosition;
+
+		float stayTime = 0.04f;
+		float lifeTime = 10;
+
+		//bool isThrusting = true;
+
+		Rigidbody rb;
+
+
+		KSPParticleEmitter[] pEmitters;
+
+		float randThrustSeed;
+
+		void Start()
+		{
+			BDArmorySetup.numberOfParticleEmitters++;
+
+			rb = gameObject.AddComponent<Rigidbody>();
+			pEmitters = gameObject.GetComponentsInChildren<KSPParticleEmitter>();
+
+			IEnumerator<KSPParticleEmitter> pe = pEmitters.AsEnumerable().GetEnumerator();
+			while (pe.MoveNext())
+			{
+				if (pe.Current == null) continue;
+				if (FlightGlobals.getStaticPressure(transform.position) == 0 && pe.Current.useWorldSpace)
+				{
+					pe.Current.emit = false;
+				}
+				else if (pe.Current.useWorldSpace)
+				{
+					BDAGaplessParticleEmitter gpe = pe.Current.gameObject.AddComponent<BDAGaplessParticleEmitter>();
+					gpe.rb = rb;
+					gpe.emit = true;
+				}
+				else
+				{
+					EffectBehaviour.AddParticleEmitter(pe.Current);
+				}
+			}
+			pe.Dispose();
+
+			prevPosition = transform.position;
+			currPosition = transform.position;
+			startPosition = transform.position;
+			startTime = Time.time;
+
+			rb.mass = mass;
+			rb.isKinematic = true;
+			//rigidbody.velocity = startVelocity;
+			if (!FlightGlobals.RefFrameIsRotating) rb.useGravity = false;
+
+			rb.useGravity = false;
+
+			randThrustSeed = UnityEngine.Random.Range(0f, 100f);
+
+			SetupAudio();
+		}
+
+		void FixedUpdate()
+		{
+			//floating origin and velocity offloading corrections
+			if (!FloatingOrigin.Offset.IsZero() || !Krakensbane.GetFrameVelocity().IsZero())
+			{
+				transform.position -= FloatingOrigin.OffsetNonKrakensbane;
+				prevPosition -= FloatingOrigin.OffsetNonKrakensbane;
+			}
+			float distanceFromStart = Vector3.Distance(transform.position, startPosition);
+
+			if (Time.time - startTime < stayTime && transform.parent != null)
+			{
+				transform.rotation = transform.parent.rotation;
+				transform.position = spawnTransform.position;
+				//+(transform.parent.rigidbody.velocity*Time.fixedDeltaTime);
+			}
+			else
+			{
+				if (transform.parent != null && parentRB)
+				{
+					transform.parent = null;
+					rb.isKinematic = false;
+					rb.velocity = parentRB.velocity + Krakensbane.GetFrameVelocityV3f();
+				}
+			}
+
+			if (rb && !rb.isKinematic)
+			{
+				//physics
+				if (FlightGlobals.RefFrameIsRotating)
+				{
+					rb.velocity += FlightGlobals.getGeeForceAtPosition(transform.position) * Time.fixedDeltaTime;
+				}
+
+				//guidance and attitude stabilisation scales to atmospheric density.
+				float atmosMultiplier =
+					Mathf.Clamp01(2.5f *
+								  (float)
+								  FlightGlobals.getAtmDensity(FlightGlobals.getStaticPressure(transform.position),
+									  FlightGlobals.getExternalTemperature(), FlightGlobals.currentMainBody));
+
+				//model transform. always points prograde
+				transform.rotation = Quaternion.RotateTowards(transform.rotation,
+					Quaternion.LookRotation(rb.velocity + Krakensbane.GetFrameVelocity(), transform.up),
+					atmosMultiplier * (0.5f * (Time.time - startTime)) * 50 * Time.fixedDeltaTime);
+
+
+				if (Time.time - startTime < thrustTime && Time.time - startTime > stayTime)
+				{
+					float random = randomThrustDeviation * (1 - (Mathf.PerlinNoise(4 * Time.time, randThrustSeed) * 2));
+					float random2 = randomThrustDeviation * (1 - (Mathf.PerlinNoise(randThrustSeed, 4 * Time.time) * 2));
+					rb.AddRelativeForce(new Vector3(random, random2, thrust));
+				}
+			}
+
+
+			if (Time.time - startTime > thrustTime)
+			{
+				//isThrusting = false;
+				IEnumerator<KSPParticleEmitter> pEmitter = pEmitters.AsEnumerable().GetEnumerator();
+				while (pEmitter.MoveNext())
+				{
+					if (pEmitter.Current == null) continue;
+					if (pEmitter.Current.useWorldSpace)
+					{
+						pEmitter.Current.minSize = Mathf.MoveTowards(pEmitter.Current.minSize, 0.1f, 0.05f);
+						pEmitter.Current.maxSize = Mathf.MoveTowards(pEmitter.Current.maxSize, 0.2f, 0.05f);
+					}
+					else
+					{
+						pEmitter.Current.minSize = Mathf.MoveTowards(pEmitter.Current.minSize, 0, 0.1f);
+						pEmitter.Current.maxSize = Mathf.MoveTowards(pEmitter.Current.maxSize, 0, 0.1f);
+						if (pEmitter.Current.maxSize == 0)
+						{
+							pEmitter.Current.emit = false;
+						}
+					}
+				}
+				pEmitter.Dispose();
+			}
+
+			if (Time.time - startTime > 0.1f + stayTime)
+			{
+				currPosition = transform.position;
+				float dist = (currPosition - prevPosition).magnitude;
+				Ray ray = new Ray(prevPosition, currPosition - prevPosition);
+				RaycastHit hit;
+				KerbalEVA hitEVA = null;
+				//if (Physics.Raycast(ray, out hit, dist, 2228224))
+				//{
+				//    try
+				//    {
+				//        hitEVA = hit.collider.gameObject.GetComponentUpwards<KerbalEVA>();
+				//        if (hitEVA != null)
+				//            Debug.Log("[BDArmory]:Hit on kerbal confirmed!");
+				//    }
+				//    catch (NullReferenceException)
+				//    {
+				//        Debug.Log("[BDArmory]:Whoops ran amok of the exception handler");
+				//    }
+
+				//    if (hitEVA && hitEVA.part.vessel != sourceVessel)
+				//    {
+				//        Detonate(hit.point);
+				//    }
+				//}
+
+				if (!hitEVA)
+				{
+					if (Physics.Raycast(ray, out hit, dist, 9076737))
+					{
+						Part hitPart = null;
+						try
+						{
+							KerbalEVA eva = hit.collider.gameObject.GetComponentUpwards<KerbalEVA>();
+							hitPart = eva ? eva.part : hit.collider.gameObject.GetComponentInParent<Part>();
+						}
+						catch (NullReferenceException)
+						{
+						}
+
+
+						if (hitPart == null || (hitPart != null && hitPart.vessel != sourceVessel))
+						{
+							Detonate(hit.point);
+						}
+					}
+					else if (FlightGlobals.getAltitudeAtPos(transform.position) < 0)
+					{
+						Detonate(transform.position);
+					}
+				}
+				if (proximityDetonation && (distanceFromStart >= (detonationRange*10))) //flak rocket functionality
+				{
+					using (var hitsEnu = Physics.OverlapSphere(transform.position, detonationRange, 557057).AsEnumerable().GetEnumerator())
+					{
+						while (hitsEnu.MoveNext())
+						{
+							if (hitsEnu.Current == null) continue;
+
+							try
+							{
+								Part partHit = hitsEnu.Current.GetComponentInParent<Part>();
+								if (partHit?.vessel == sourceVessel) continue;
+
+								Detonate(transform.position);
+							}
+							catch
+							{
+								// ignored
+							}
+						}
+					}
+				}
+			}
+			else if (FlightGlobals.getAltitudeAtPos(currPosition) <= 0)
+			{
+				Detonate(currPosition);
+			}
+			prevPosition = currPosition;
+
+			if (Time.time - startTime > lifeTime) // life's 10s, quite a long time for faster rockets
+			{
+				Detonate(transform.position);
+			}
+			if (distanceFromStart >= 8000)//rockets are performance intensive, lets cull those that have flown too far away
+			{
+				Detonate(transform.position);
+			}
+		}
+
+		void Update()
+		{
+			if (HighLogic.LoadedSceneIsFlight)
+			{
+				if (BDArmorySetup.GameIsPaused)
+				{
+					if (audioSource.isPlaying)
+					{
+						audioSource.Stop();
+					}
+				}
+				else
+				{
+					if (!audioSource.isPlaying)
+					{
+						audioSource.Play();
+					}
+				}
+			}
+		}
+		void Detonate(Vector3 pos)
+		{
+			BDArmorySetup.numberOfParticleEmitters--;
+
+			ExplosionFx.CreateExplosion(pos, BlastPhysicsUtils.CalculateExplosiveMass(blastRadius),
+				explModelPath, explSoundPath, true);
+
+			IEnumerator<KSPParticleEmitter> emitter = pEmitters.AsEnumerable().GetEnumerator();
+			while (emitter.MoveNext())
+			{
+				if (emitter.Current == null) continue;
+				if (!emitter.Current.useWorldSpace) continue;
+				emitter.Current.gameObject.AddComponent<BDAParticleSelfDestruct>();
+				emitter.Current.transform.parent = null;
+			}
+			emitter.Dispose();
+			Destroy(gameObject); //destroy rocket on collision
+		}
+
+
+		void SetupAudio()
+		{
+			audioSource = gameObject.AddComponent<AudioSource>();
+			audioSource.loop = true;
+			audioSource.minDistance = 1;
+			audioSource.maxDistance = 2000;
+			audioSource.dopplerLevel = 0.5f;
+			audioSource.volume = 0.9f * BDArmorySettings.BDARMORY_WEAPONS_VOLUME;
+			audioSource.pitch = 1f;
+			audioSource.priority = 255;
+			audioSource.spatialBlend = 1;
+
+			audioSource.clip = GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/rocketLoop");
+
+			UpdateVolume();
+			BDArmorySetup.OnVolumeChange += UpdateVolume;
+		}
+
+		void UpdateVolume()
+		{
+			if (audioSource)
+			{
+				audioSource.volume = BDArmorySettings.BDARMORY_WEAPONS_VOLUME;
+			}
+		}
+	}
 }

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -502,24 +502,13 @@ namespace BDArmory.UI
                     !ActiveWeaponManager.guardMode)
                 {
                     if (ActiveWeaponManager.selectedWeapon.GetWeaponClass() == WeaponClasses.Gun ||
-                        ActiveWeaponManager.selectedWeapon.GetWeaponClass() == WeaponClasses.DefenseLaser)
+                        ActiveWeaponManager.selectedWeapon.GetWeaponClass() == WeaponClasses.DefenseLaser ||
+						 ActiveWeaponManager.selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket)
                     {
                         ModuleWeapon mw =
                             ActiveWeaponManager.selectedWeapon.GetPart().FindModuleImplementing<ModuleWeapon>();
                         if (mw.weaponState == ModuleWeapon.WeaponStates.Enabled && mw.maxPitch > 1 && !mw.slaved &&
                             !mw.aiControlled)
-                        {
-                            //Screen.showCursor = false;
-                            Cursor.visible = false;
-                            drawCursor = true;
-                            return;
-                        }
-                    }
-                    else if (ActiveWeaponManager.selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket)
-                    {
-                        RocketLauncher rl =
-                            ActiveWeaponManager.selectedWeapon.GetPart().FindModuleImplementing<RocketLauncher>();
-                        if (rl.readyToFire && rl.turret)
                         {
                             //Screen.showCursor = false;
                             Cursor.visible = false;
@@ -746,7 +735,8 @@ namespace BDArmory.UI
                 //if weapon can ripple, show option and slider.
                 if (ActiveWeaponManager.hasLoadedRippleData && ActiveWeaponManager.canRipple)
                 {
-                    if (ActiveWeaponManager.selectedWeapon.GetWeaponClass() == WeaponClasses.Gun)
+                    if (ActiveWeaponManager.selectedWeapon.GetWeaponClass() == WeaponClasses.Gun 
+                    || ActiveWeaponManager.selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket)
                     {
                         string rippleText = ActiveWeaponManager.rippleFire
                             ? "Barrage: " + ActiveWeaponManager.gunRippleRpm.ToString("0") + " RPM"


### PR DESCRIPTION
A rework of ModuleWeapon and RocketLauncher.cs removing duplicate code and incorporating rocket launcher functionality into ModuleWeapon*, with the necessary edits to ModuleSurfaceAi, BDArmorySetup to get them to recognize the new rocketlauncher code, extensive edits** to MissileFire stripping out now-obsolete rocket code while simultaneously enabling proper Rocketlauncher ripple/salvo functionality, AI rocket selection functionality, and adding SmartPickWeapon_ rocket selection, and a MM patch to convert legacy Rocketlaunchers to the new code.
*Rockets can now be included in weapon groups, can be set to have proximity warheads, and can be fired from non-configured rocketpod models/use ammobox sourced ammunition (i.e. you wanted the Browning AN/M2 to fire gyrojet ammo, now you can)
**sloppy of me, but the edits also include PR#649's ammoController() since that was the source file I was pulling from. there was also some non-rocket SmartpickWeapon improvement code included.