### PR TITLE
Weapons respect engagement range

### DIFF
--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -769,7 +769,7 @@ namespace BDArmory.Modules
                         (yawRange == 0 || (maxPitch - minPitch) == 0 ||
                          turret.TargetInRange(finalAimTarget, 10, float.MaxValue)))
                     {
-                        if (useRippleFire && (pointingAtSelf || isOverheated))
+                        if (useRippleFire && ((pointingAtSelf || isOverheated) || (aiControlled && engageRangeMax < targetLeadDistance))) // only fire if weapon within weapon's max range
                         {
                             StartCoroutine(IncrementRippleIndex(0));
                             finalFire = false;


### PR DESCRIPTION
Fix for multiple weapons of one type with different max ranges to respect individual weapon's range settings, rather than all firing as soon as one of them comes in range