### PR TITLE
Turret rotation fix

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,4 +1,8 @@
-﻿v1.3.1
+﻿v1.3.2
+* FIXES
+	* Turrets with constrained yaw should freak out less when aiming behind them.
+
+v1.3.1
 * FIXES
 	* All parts have bulkheadProfiles - should stop bulkhead filter NREs.
 	* Rocket pods no longer fire StackOverflows.

--- a/BDArmory/Misc/VectorUtils.cs
+++ b/BDArmory/Misc/VectorUtils.cs
@@ -27,6 +27,14 @@ namespace BDArmory.Misc
             float finalAngle = sign * angle;
             return finalAngle;
         }
+        
+        /// <summary>
+        /// Convert an angle to be between -180 and 180.
+        /// </summary>
+        public static float ToAngle(this float angle)
+        {
+            return ((angle + 180) % 360) - 180;
+        }
 
         //from howlingmoonsoftware.com
         //calculates how long it will take for a target to be where it will be when a bullet fired now can reach it.

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -4217,14 +4217,6 @@ namespace BDArmory.Modules
                 }
                 return false;
             }
-            if (turret.yawRange == 360)
-            {
-                if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                {
-                    Debug.Log("[BDArmory]: Checking turret range - turret has full swivel");
-                }
-                return true;
-            }
 
             Transform turretTransform = turret.yawTransform.parent;
             Vector3 direction = guardTarget.transform.position - turretTransform.position;
@@ -4232,13 +4224,8 @@ namespace BDArmory.Modules
             Vector3 directionPitch = Vector3.ProjectOnPlane(direction, turretTransform.right);
 
             float angleYaw = Vector3.Angle(turretTransform.forward, directionYaw);
-            //float anglePitch = Vector3.Angle(-turret.transform.forward, directionPitch);
-            float signedAnglePitch = Misc.Misc.SignedAngle(turretTransform.forward, directionPitch, turretTransform.up);
-            if (Mathf.Abs(signedAnglePitch) > 90)
-            {
-                signedAnglePitch -= Mathf.Sign(signedAnglePitch) * 180;
-            }
-            bool withinPitchRange = (signedAnglePitch >= turret.minPitch && signedAnglePitch <= turret.maxPitch + tolerance);
+            float signedAnglePitch = 90 - Vector3.Angle(turretTransform.up, directionPitch);
+            bool withinPitchRange = (signedAnglePitch >= turret.minPitch - tolerance && signedAnglePitch <= turret.maxPitch + tolerance);
 
             if (angleYaw < (turret.yawRange / 2) + tolerance && withinPitchRange)
             {

--- a/BDArmory/Modules/ModuleTurret.cs
+++ b/BDArmory/Modules/ModuleTurret.cs
@@ -180,7 +180,10 @@ namespace BDArmory.Modules
                 yawComponent,
                 Vector3.Cross(yawNormal, referenceTransform.forward));
             float yawOffset = Mathf.Abs(yawError);
-            float targetYawAngle = Mathf.Clamp((currentYaw + yawError).ToAngle(), -yawRange / 2, yawRange / 2); // clamped target yaw
+            float targetYawAngle = (currentYaw + yawError).ToAngle();
+            // clamp target yaw in a non-wobbly way
+            if (Mathf.Abs(targetYawAngle) > yawRange / 2)
+                targetYawAngle = yawRange / 2 * Math.Sign(Vector3.Dot(yawTransform.parent.right, targetDirection + referenceTransform.position - yawTransform.position));
 
             float pitchError = (float)Vector3d.Angle(pitchComponent, yawNormal) - (float)Vector3d.Angle(referenceTransform.forward, yawNormal);
             float currentPitch = -pitchTransform.localEulerAngles.x.ToAngle(); // from current rotation transform

--- a/BDArmory/Modules/ModuleTurret.cs
+++ b/BDArmory/Modules/ModuleTurret.cs
@@ -1,3 +1,4 @@
+using System;
 using BDArmory.Core;
 using BDArmory.Misc;
 using BDArmory.UI;
@@ -173,16 +174,16 @@ namespace BDArmory.Modules
             Vector3 pitchNormal = Vector3.Cross(yawComponent, yawNormal);
             Vector3 pitchComponent = Vector3.ProjectOnPlane(targetDirection, pitchNormal);
 
-            float currentYaw = yawTransform.localEulerAngles.y;
+            float currentYaw = yawTransform.localEulerAngles.y.ToAngle();
             float yawError = VectorUtils.SignedAngleDP(
                 Vector3.ProjectOnPlane(referenceTransform.forward, yawNormal),
                 yawComponent,
                 Vector3.Cross(yawNormal, referenceTransform.forward));
             float yawOffset = Mathf.Abs(yawError);
-            float targetYawAngle = Mathf.Clamp((currentYaw + yawError + 180f) % 360f - 180f, -yawRange / 2, yawRange / 2); // clamped target yaw
+            float targetYawAngle = Mathf.Clamp((currentYaw + yawError).ToAngle(), -yawRange / 2, yawRange / 2); // clamped target yaw
 
             float pitchError = (float)Vector3d.Angle(pitchComponent, yawNormal) - (float)Vector3d.Angle(referenceTransform.forward, yawNormal);
-            float currentPitch = -((pitchTransform.localEulerAngles.x + 180f) % 360f - 180f); // from current rotation transform
+            float currentPitch = -pitchTransform.localEulerAngles.x.ToAngle(); // from current rotation transform
             float targetPitchAngle = currentPitch - pitchError;
             float pitchOffset = Mathf.Abs(targetPitchAngle - currentPitch);
             targetPitchAngle = Mathf.Clamp(targetPitchAngle, minPitch, maxPitch); // clamp pitch
@@ -206,9 +207,9 @@ namespace BDArmory.Modules
             yawSpeed *= linYawMult;
             pitchSpeed *= linPitchMult;
 
-            if (yawRange < 360 && Mathf.Abs(targetYawAngle) > 90 && Mathf.Sign(currentYaw) != Mathf.Sign(targetYawAngle))
+            if (yawRange < 360 && Mathf.Abs(currentYaw - targetYawAngle) >= 180)
             {
-                targetYawAngle = 5 * Mathf.Sign(targetYawAngle);
+                targetYawAngle = currentYaw - (Math.Sign(currentYaw) * 179);
             }
 
             if (yaw)


### PR DESCRIPTION
Should mostly fix #614 

Turrets may still freak out for targets behind the turret and between the end of the barrel and turret center, but that is such and edge case that we may allow it to persist.

Also fix calculation of gimbal in-range targets.