### PR TITLE
New AI features; Turn Radius to replane minAltitude, ability to toggle extensions, and more

### DIFF
--- a/BDArmory.Core/Extension/PartExtensions.cs
+++ b/BDArmory.Core/Extension/PartExtensions.cs
@@ -294,7 +294,7 @@ namespace BDArmory.Core.Extension
 
             if (part.name.Contains("B9.Aero.Wing.Procedural"))
             {
-                size = size * 0.1f;
+                //size = size * 0.1f; 
             }
 
             float scaleMultiplier = 1f;
@@ -308,11 +308,16 @@ namespace BDArmory.Core.Extension
             return size * scaleMultiplier;
         }
 
-        public static bool IsAero(this Part part)
+         public static bool IsAero(this Part part)
         {
-            return part.Modules.Contains("ModuleControlSurface") ||
-                   part.Modules.Contains("ModuleLiftingSurface");
-        }
+			return part.Modules.Contains("ModuleLiftingSurface") ||
+				   part.Modules.Contains("FARWingAerodynamicModel");
+		}
+		public static bool IsCtrlSrf(this Part part)
+		{
+			return part.Modules.Contains("ModuleControlSurface") ||
+				   part.Modules.Contains("FARControllableSurface");
+		}
 
         public static string GetExplodeMode(this Part part)
         {

--- a/BDArmory.Core/Module/HitpointTracker.cs
+++ b/BDArmory.Core/Module/HitpointTracker.cs
@@ -44,7 +44,7 @@ namespace BDArmory.Core.Module
         private bool _firstSetup = true;
         private bool _updateHitpoints = false;
         private bool _forceUpdateHitpointsUI = false;
-        private const int HpRounding = 100;
+        private const int HpRounding = 50; //lets reduce this from 100 to 50 for smoother HP scaling
 
         public override void OnLoad(ConfigNode node)
         {
@@ -163,29 +163,42 @@ namespace BDArmory.Core.Module
 
             if (!part.IsMissile())
             {
-                var averageSize = part.GetAverageBoundSize();
-                var sphereRadius = averageSize * 0.5f;
-                var sphereSurface = 4 * Mathf.PI * sphereRadius * sphereRadius;
-                var structuralVolume = sphereSurface * 0.1f;
+					var averageSize = part.GetAverageBoundSize();
+					var sphereRadius = averageSize * 0.5f;
+					var sphereSurface = 4 * Mathf.PI * sphereRadius * sphereRadius;
+					var structuralVolume = sphereSurface * 0.1f;
 
-                var density = (part.mass * 1000f) / structuralVolume;
-                density = Mathf.Clamp(density, 1000, 10000);
-                //Debug.Log("[BDArmory]: Hitpoint Calc" + part.name + " | structuralVolume : " + structuralVolume);
-                //Debug.Log("[BDArmory]: Hitpoint Calc"+part.name+" | Density : " + density);
+					var density = (part.mass * 1000f) / structuralVolume;
+					density = Mathf.Clamp(density, 1000, 10000);
+					//Debug.Log("[BDArmory]: Hitpoint Calc" + part.name + " | structuralVolume : " + structuralVolume);
+					//Debug.Log("[BDArmory]: Hitpoint Calc"+part.name+" | Density : " + density);
 
-                var structuralMass = density * structuralVolume;
-                //Debug.Log("[BDArmory]: Hitpoint Calc" + part.name + " | structuralMass : " + structuralMass);
-                //3. final calculations
-                hitpoints = structuralMass * hitpointMultiplier * 0.33f;
+					var structuralMass = density * structuralVolume;
+					//Debug.Log("[BDArmory]: Hitpoint Calc" + part.name + " | structuralMass : " + structuralMass);
+					//3. final calculations
+					hitpoints = structuralMass * hitpointMultiplier * 0.33f;
 
-                if (hitpoints > 10 * part.mass * 1000f || hitpoints < 0.1f * part.mass * 1000f)
-                {
-                    Debug.Log($"[BDArmory]: HitpointTracker::Clamping hitpoints for part {part.name}");
-                    hitpoints = hitpointMultiplier * part.mass * 333f;
-                }
+				if (hitpoints > 10 * part.mass * 1000f || hitpoints < 0.1f * part.mass * 1000f)
+				{
+					Debug.Log($"[BDArmory]: HitpointTracker::Clamping hitpoints for part {part.name}");
+					hitpoints = hitpointMultiplier * part.mass * 333f;
+				}
 
+				if (part.name.Contains("B9.Aero.Wing.Procedural")) // the above works for basic cylindrical-esque parts, but not wings, esp. not proc wings
+				{
+					hitpoints = (part.mass * 1000f) * 3.5f; // since wings are basically a 2d object, lets have mass be our scalar - afterall, 2x the mass will ~= 2x the surfce area
+				}
+				if (part.IsAero())
+				{
+					hitpoints = (part.mass * 1000f) * 7f; // stock wings are half the mass of proc wings, at least in FAR. Will need to check stock aero wing masses.
+				}
+				if (part.IsCtrlSrf())
+				{
+					hitpoints = 100f+ (part.mass * 1000f) * 5f; // Crtl surfaces will have actuators of some flavor, are going to be more fragile. +100 for guaranteed min health
+				}
                 hitpoints = Mathf.Round(hitpoints / HpRounding) * HpRounding;
                 if (hitpoints <= 0) hitpoints = HpRounding;
+				if (hitpoints < 100) hitpoints = 100;
             }
             else
             {

--- a/BDArmory/BDArmory.csproj
+++ b/BDArmory/BDArmory.csproj
@@ -52,25 +52,6 @@
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\_LocalDev\KSPRefs\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\..\_LocalDev\KSPRefs\Assembly-CSharp-firstpass.dll</HintPath>
-    </Reference>
-    <Reference Include="KSPAssets">
-      <HintPath>..\..\_LocalDev\KSPRefs\KSPAssets.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\_LocalDev\KSPRefs\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\_LocalDev\KSPRefs\UnityEngine.UI.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="Misc\BDTeam.cs" />
     <Compile Include="UI\BDStagingAreaGauge.cs" />
     <Compile Include="UI\BDAEditorCategory.cs" />
@@ -184,7 +165,6 @@
     <EmbeddedResource Include="Shaders\UnlitBlack.shader" />
     <EmbeddedResource Include="Shaders\BulletShader.shader" />
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <None Include="Distribution\GameData\BDArmory\Agencies\Agents.cfg" />
     <None Include="Distribution\GameData\BDArmory\Agencies\BDA_scaled.truecolor" />
@@ -600,6 +580,29 @@
     <Content Include="Distribution\GameData\BDArmory\Textures\settingsIcon.png" />
     <Content Include="Distribution\GameData\BDArmory\Textures\targetDirectionIndicator.png" />
     <Content Include="Distribution\GameData\BDArmory\Textures\whiteSquare.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\Kerbal Space Program\KSP Compile Stuff\Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\Kerbal Space Program\KSP Compile Stuff\Assembly-CSharp-firstpass.dll</HintPath>
+    </Reference>
+    <Reference Include="KSPAssets, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\Kerbal Space Program\KSP Compile Stuff\KSPAssets.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\Kerbal Space Program\KSP Compile Stuff\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\Kerbal Space Program\KSP Compile Stuff\UnityEngine.UI.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <PropertyGroup>
     <PostBuildEvent>@echo $(Targetname)

--- a/BDArmory/Distribution/GameData/BDArmory/BDArmory.version
+++ b/BDArmory/Distribution/GameData/BDArmory/BDArmory.version
@@ -30,7 +30,7 @@
     "KSP_VERSION_MAX":
     {
         "MAJOR":1,
-        "MINOR":7,
+        "MINOR":8,
         "PATCH":999
     }
 }

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -385,6 +385,14 @@ namespace BDArmory.Modules
         public float
             gunRange = 2500f;
 
+        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = false, guiName = "Chaff Interval"),
+         UI_FloatRange(minValue = 0f, maxValue = 5f, stepIncrement = 0.05f, scene = UI_Scene.All)]
+        public float chaffInterval = 0.5f;
+
+        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = false, guiName = "Flare Interval"),
+         UI_FloatRange(minValue = 0f, maxValue = 5f, stepIncrement = 0.05f, scene = UI_Scene.All)]
+        public float flareInterval = 0.5f;
+
         public const float maxAllowableMissilesOnTarget = 18f;
 
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Missiles/Target"), UI_FloatRange(minValue = 1f, maxValue = maxAllowableMissilesOnTarget, stepIncrement = 1f, scene = UI_Scene.All)]
@@ -1805,7 +1813,7 @@ namespace BDArmory.Modules
         IEnumerator ChaffRoutine()
         {
             isChaffing = true;
-            yield return new WaitForSeconds(UnityEngine.Random.Range(0.2f, 1f));
+            yield return new WaitForSeconds(chaffInterval/2);
             List<CMDropper>.Enumerator cm = vessel.FindPartModulesImplementing<CMDropper>().GetEnumerator();
             while (cm.MoveNext())
             {
@@ -1817,7 +1825,7 @@ namespace BDArmory.Modules
             }
             cm.Dispose();
 
-            yield return new WaitForSeconds(0.6f);
+            yield return new WaitForSeconds(chaffInterval/2);
 
             isChaffing = false;
         }
@@ -1827,7 +1835,7 @@ namespace BDArmory.Modules
             if (isFlaring) yield break;
             time = Mathf.Clamp(time, 2, 8);
             isFlaring = true;
-            yield return new WaitForSeconds(UnityEngine.Random.Range(0f, 1f));
+            yield return new WaitForSeconds(flareInterval/2);
             float flareStartTime = Time.time;
             while (Time.time - flareStartTime < time)
             {
@@ -1841,7 +1849,7 @@ namespace BDArmory.Modules
                     }
                 }
                 cm.Dispose();
-                yield return new WaitForSeconds(0.6f);
+                yield return new WaitForSeconds(flareInterval/2);
             }
             isFlaring = false;
         }

--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -790,7 +790,7 @@ namespace BDArmory.Modules
                         (yawRange == 0 || (maxPitch - minPitch) == 0 ||
                          turret.TargetInRange(finalAimTarget, 10, float.MaxValue)))
                     {
-                        if (useRippleFire && ((pointingAtSelf || isOverheated) || (aiControlled && engageRangeMax < targetLeadDistance))) // only fire if weapon within weapon's max range
+                        if (useRippleFire && (pointingAtSelf || isOverheated))
                         {
                             StartCoroutine(IncrementRippleIndex(0));
                             finalFire = false;

--- a/BDArmory/Modules/RadarWarningReceiver.cs
+++ b/BDArmory/Modules/RadarWarningReceiver.cs
@@ -220,7 +220,7 @@ namespace BDArmory.Modules
                         true, (float)RWRThreatTypes.MissileLaunch)));
                 PlayWarningSound(RWRThreatTypes.MissileLaunch);
 
-                if (weaponManager && weaponManager.guardMode)
+                if (weaponManager && weaponManager.guardMode && (weaponManager.incomingMissileDistance < 4000))
                 {
                     weaponManager.FireAllCountermeasures(Random.Range(2, 4));
                     weaponManager.incomingThreatPosition = source;
@@ -254,7 +254,7 @@ namespace BDArmory.Modules
                 }
                 else if (type == RWRThreatTypes.MissileLock)
                 {
-                    if (weaponManager && weaponManager.guardMode)
+                    if (weaponManager && weaponManager.guardMode && (weaponManager.incomingMissileDistance < 4000))
                     {
                         weaponManager.FireChaff();
                         // TODO: if torpedo inbound, also fire accoustic decoys (not yet implemented...)


### PR DESCRIPTION
Added Energy and Angles fighting modes, Turn Radius as a replacement for MinAltitude(currently serve as a hard deck)(turn radius takes into account dive angle and airspeed, using a bit of code already present), slightly different minSpeed reasoning depending on angles vs energy mode, Corner Speed, the speed the AI uses for evasive manuvers, and the min speed in energy mode, unless in steerMode == SteerModes.Aiming, ability to adjust the distance the AI reacts to missiles, and the ability to 1. toggle extensions on/off, and 2. if they're on, a multiplier for the distance the AI extends.