### PR TITLE
Localization fixes

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/Localization/BDArmory.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/BDArmory.cfg
@@ -10,15 +10,34 @@ Localization
 		#autoLOC_bda_1000005 = MISSILE
 		#autoLOC_bda_1000006 = DETECTION
 		#autoLOC_bda_1000007 = UNKNOWN
-		#autoLOC_bda_1000008 = Radar Type: {0}
-		#autoLOC_bda_1000009 = Range: {0} meters
-		#autoLOC_bda_1000010 = RWR Threat Type: {0}
-		#autoLOC_bda_1000011 = Can Scan: {0}
-		#autoLOC_bda_1000012 = Track-While-Scan: {0}
-		#autoLOC_bda_1000013 = Can Lock: {0}
-		#autoLOC_bda_1000014 = Can Receive Data: {0}
-		#autoLOC_bda_1000015 = Simultaneous Locks: {0}
+		#autoLOC_bda_1000008 = Radar Type: <<1>>
+		#autoLOC_bda_1000009 = Range: <<1>> meters
+		#autoLOC_bda_1000010 = RWR Threat Type: <<1>>
+		#autoLOC_bda_1000011 = Can Scan: <<1>>
+		#autoLOC_bda_1000012 = Track-While-Scan: <<1>>
+		#autoLOC_bda_1000013 = Can Lock: <<1>>
+		#autoLOC_bda_1000014 = Can Receive Data: <<1>>
+		#autoLOC_bda_1000015 = Simultaneous Locks: <<1>>
 		#autoLOC_bda_1000016 = Radar Requires EC
+		#autoLOC_bda_1000017 = SONAR
+		#autoLOC_bda_1000018 = datalink only
+		#autoLOC_bda_1000019 = omnidirectional
+		#autoLOC_bda_1000020 = boresight
+		#autoLOC_bda_1000021 = EC/sec: <<1>>
+		#autoLOC_bda_1000022 = Field of view: <<1>>°
+		#autoLOC_bda_1000023 = RWR Threat Type: <<1>>
+		#autoLOC_bda_1000024 = Capabilities:
+		#autoLOC_bda_1000025 = - Scanning: <<1>>
+		#autoLOC_bda_1000026 = - Track-While-Scan: <<1>>
+		#autoLOC_bda_1000027 = - Locking: <<1>>
+		#autoLOC_bda_1000028 = - Max Locks: <<1>>
+		#autoLOC_bda_1000029 = - Receive Data: <<1>>
+		#autoLOC_bda_1000030 = Performance:
+		#autoLOC_bda_1000031 = - Detection: <<1>> m^2 @ <<2>> km
+		#autoLOC_bda_1000032 = - Detection: (none)
+		#autoLOC_bda_1000033 = - Lock/Track: <<1>> m^2 @ <<2>> km
+		#autoLOC_bda_1000034 = - Lock/Track: (none)
+		#autoLOC_bda_1000035 = - Ground clutter factor: <<1>>
 	}
 	es-es
 	{
@@ -30,14 +49,14 @@ Localization
 		#autoLOC_bda_1000005 = MISIL
 		#autoLOC_bda_1000006 = DETECCIÓN
 		#autoLOC_bda_1000007 = DESCONOCIDO
-		#autoLOC_bda_1000008 = Tipo de radar: {0}
-		#autoLOC_bda_1000009 = Distancia: {0} metros
-		#autoLOC_bda_1000010 = RAR Tipo de amenaza: {0}
-		#autoLOC_bda_1000011 = Puede Escanear: {0}
-		#autoLOC_bda_1000012 = Seguir-Mientra-Escanea: {0}
-		#autoLOC_bda_1000013 = Puede Bloquear: {0}
-		#autoLOC_bda_1000014 = Puede recibir datos: {0}
-		#autoLOC_bda_1000015 = Bloqueos Simultáneos: {0}
+		#autoLOC_bda_1000008 = Tipo de radar: <<1>>
+		#autoLOC_bda_1000009 = Distancia: <<1>> metros
+		#autoLOC_bda_1000010 = RAR Tipo de amenaza: <<1>>
+		#autoLOC_bda_1000011 = Puede Escanear: <<1>>
+		#autoLOC_bda_1000012 = Seguir-Mientra-Escanea: <<1>>
+		#autoLOC_bda_1000013 = Puede Bloquear: <<1>>
+		#autoLOC_bda_1000014 = Puede recibir datos: <<1>>
+		#autoLOC_bda_1000015 = Bloqueos Simultáneos: <<1>>
 		#autoLOC_bda_1000016 = Radar requiere CE
 	}
 	ja
@@ -50,14 +69,14 @@ Localization
 		#autoLOC_bda_1000005 = MISSILE
 		#autoLOC_bda_1000006 = DETECTION
 		#autoLOC_bda_1000007 = UNKNOWN
-		#autoLOC_bda_1000008 = Radar Type: {0}
-		#autoLOC_bda_1000009 = Range: {0} meters
-		#autoLOC_bda_1000010 = RWR Threat Type: {0}
-		#autoLOC_bda_1000011 = Can Scan: {0}
-		#autoLOC_bda_1000012 = Track-While-Scan: {0}
-		#autoLOC_bda_1000013 = Can Lock: {0}
-		#autoLOC_bda_1000014 = Can Receive Data: {0}
-		#autoLOC_bda_1000015 = Simultaneous Locks: {0}
+		#autoLOC_bda_1000008 = Radar Type: <<1>>
+		#autoLOC_bda_1000009 = Range: <<1>> meters
+		#autoLOC_bda_1000010 = RWR Threat Type: <<1>>
+		#autoLOC_bda_1000011 = Can Scan: <<1>>
+		#autoLOC_bda_1000012 = Track-While-Scan: <<1>>
+		#autoLOC_bda_1000013 = Can Lock: <<1>>
+		#autoLOC_bda_1000014 = Can Receive Data: <<1>>
+		#autoLOC_bda_1000015 = Simultaneous Locks: <<1>>
 		#autoLOC_bda_1000016 = Radar Requires EC
 	}
 	ru
@@ -70,14 +89,14 @@ Localization
 		#autoLOC_bda_1000005 = MISSILE
 		#autoLOC_bda_1000006 = DETECTION
 		#autoLOC_bda_1000007 = UNKNOWN
-		#autoLOC_bda_1000008 = Radar Type: {0}
-		#autoLOC_bda_1000009 = Range: {0} meters
-		#autoLOC_bda_1000010 = RWR Threat Type: {0}
-		#autoLOC_bda_1000011 = Can Scan: {0}
-		#autoLOC_bda_1000012 = Track-While-Scan: {0}
-		#autoLOC_bda_1000013 = Can Lock: {0}
-		#autoLOC_bda_1000014 = Can Receive Data: {0}
-		#autoLOC_bda_1000015 = Simultaneous Locks: {0}
+		#autoLOC_bda_1000008 = Radar Type: <<1>>
+		#autoLOC_bda_1000009 = Range: <<1>> meters
+		#autoLOC_bda_1000010 = RWR Threat Type: <<1>>
+		#autoLOC_bda_1000011 = Can Scan: <<1>>
+		#autoLOC_bda_1000012 = Track-While-Scan: <<1>>
+		#autoLOC_bda_1000013 = Can Lock: <<1>>
+		#autoLOC_bda_1000014 = Can Receive Data: <<1>>
+		#autoLOC_bda_1000015 = Simultaneous Locks: <<1>>
 		#autoLOC_bda_1000016 = Radar Requires EC
 	}
 	zh-cn
@@ -90,14 +109,14 @@ Localization
 		#autoLOC_bda_1000005 = 导弹
 		#autoLOC_bda_1000006 = 探测
 		#autoLOC_bda_1000007 = 未知
-		#autoLOC_bda_1000008 = 雷达类型: {0}
-		#autoLOC_bda_1000009 = 探测距离: {0} m
-		#autoLOC_bda_1000010 = 雷达特征信号类型: {0}
-		#autoLOC_bda_1000011 = 允许扫描: {0}
-		#autoLOC_bda_1000012 = 边扫描边跟踪: {0}
-		#autoLOC_bda_1000013 = 允许锁定目标: {0}
-		#autoLOC_bda_1000014 = 允许接受下行数据: {0}
-		#autoLOC_bda_1000015 = 允许锁定多个目标: {0}
+		#autoLOC_bda_1000008 = 雷达类型: <<1>>
+		#autoLOC_bda_1000009 = 探测距离: <<1>> m
+		#autoLOC_bda_1000010 = 雷达特征信号类型: <<1>>
+		#autoLOC_bda_1000011 = 允许扫描: <<1>>
+		#autoLOC_bda_1000012 = 边扫描边跟踪: <<1>>
+		#autoLOC_bda_1000013 = 允许锁定目标: <<1>>
+		#autoLOC_bda_1000014 = 允许接受下行数据: <<1>>
+		#autoLOC_bda_1000015 = 允许锁定多个目标: <<1>>
 		#autoLOC_bda_1000016 = 雷达需要消耗电量
 	}
 }

--- a/BDArmory/Modules/ModuleRadar.cs
+++ b/BDArmory/Modules/ModuleRadar.cs
@@ -8,6 +8,7 @@ using BDArmory.Radar;
 using BDArmory.Targeting;
 using BDArmory.UI;
 using UnityEngine;
+using KSP.Localization;
 
 namespace BDArmory.Modules
 {
@@ -283,7 +284,7 @@ namespace BDArmory.Modules
 
         void UpdateToggleGuiName()
         {
-            Events["Toggle"].guiName = radarEnabled ? "Disable Radar" : "Enable Radar";
+            Events["Toggle"].guiName = radarEnabled ? Localizer.Format("#autoLOC_bda_1000000") : Localizer.Format("#autoLOC_bda_1000001");		// #autoLOC_bda_1000000 = Disable Radar		// #autoLOC_bda_1000001 = Enable Radar
         }
 
         public void EnsureVesselRadarData()
@@ -1059,25 +1060,25 @@ namespace BDArmory.Modules
             switch (i)
             {
                 case 0:
-                    return "SAM";
+                    return Localizer.Format("#autoLOC_bda_1000002");		// #autoLOC_bda_1000002 = SAM
 
                 case 1:
-                    return "FIGHTER";
+                    return Localizer.Format("#autoLOC_bda_1000003");		// #autoLOC_bda_1000003 = FIGHTER
 
                 case 2:
-                    return "AWACS";
+                    return Localizer.Format("#autoLOC_bda_1000004");		// #autoLOC_bda_1000004 = AWACS
 
                 case 3:
                 case 4:
-                    return "MISSILE";
+                    return Localizer.Format("#autoLOC_bda_1000005");		// #autoLOC_bda_1000005 = MISSILE
 
                 case 5:
-                    return "DETECTION";
+                    return Localizer.Format("#autoLOC_bda_1000006");		// #autoLOC_bda_1000006 = DETECTION
 
                 case 6:
-                    return "SONAR";
+                    return Localizer.Format("#autoLOC_bda_1000017");		// #autoLOC_bda_1000017 = SONAR
             }
-            return "UNKNOWN";
+            return Localizer.Format("#autoLOC_bda_1000007");		// #autoLOC_bda_1000007 = UNKNOWN
             //{SAM = 0, Fighter = 1, AWACS = 2, MissileLaunch = 3, MissileLock = 4, Detection = 5, Sonar = 6}
         }
 
@@ -1088,37 +1089,37 @@ namespace BDArmory.Modules
 
             StringBuilder output = new StringBuilder();
             output.Append(Environment.NewLine);
-            output.AppendLine($"Radar Type: {(isLinkOnly ? "datalink only" : omnidirectional ? "omnidirectional" : "boresight")}");
+            output.AppendLine(Localizer.Format("#autoLOC_bda_1000008", (isLinkOnly ? Localizer.Format("#autoLOC_bda_1000018") : omnidirectional ? Localizer.Format("#autoLOC_bda_1000019") : Localizer.Format("#autoLOC_bda_1000020"))));
 
-            output.AppendLine($"EC/sec: {resourceDrain}");
+            output.AppendLine(Localizer.Format("#autoLOC_bda_1000021", resourceDrain));
             if (!isLinkOnly)
             {
-                output.AppendLine($"Field of view: {directionalFieldOfView}°");
-                output.AppendLine($"RWR Threat Type: {getRWRType(rwrThreatType)}");
+                output.AppendLine(Localizer.Format("#autoLOC_bda_1000022", directionalFieldOfView));
+                output.AppendLine(Localizer.Format("#autoLOC_bda_1000023", getRWRType(rwrThreatType)));
 
                 output.Append(Environment.NewLine);
-                output.AppendLine($"Capabilities:");
-                output.AppendLine($"- Scanning: {canScan}");
-                output.AppendLine($"- Track-While-Scan: {canTrackWhileScan}");
-                output.AppendLine($"- Locking: {canLock}");
+                output.AppendLine(Localizer.Format("#autoLOC_bda_1000024"));
+                output.AppendLine(Localizer.Format("#autoLOC_bda_1000025", canScan));
+                output.AppendLine(Localizer.Format("#autoLOC_bda_1000026", canTrackWhileScan));
+                output.AppendLine(Localizer.Format("#autoLOC_bda_1000027", canLock));
                 if (canLock)
                 {
-                    output.AppendLine($"- Max Locks: {maxLocks}");
+                    output.AppendLine(Localizer.Format("#autoLOC_bda_1000028", maxLocks));
                 }
-                output.AppendLine($"- Receive Data: {canRecieveRadarData}");
+                output.AppendLine(Localizer.Format("#autoLOC_bda_1000029", canRecieveRadarData));
 
                 output.Append(Environment.NewLine);
-                output.AppendLine($"Performance:");
+                output.AppendLine(Localizer.Format("#autoLOC_bda_1000030"));
 
                 if (canScan)
-                    output.AppendLine($"- Detection: {radarDetectionCurve.Evaluate(radarMaxDistanceDetect)} m^2 @ {radarMaxDistanceDetect} km");
+                    output.AppendLine(Localizer.Format("#autoLOC_bda_1000031", radarDetectionCurve.Evaluate(radarMaxDistanceDetect), radarMaxDistanceDetect));
                 else
-                    output.AppendLine($"- Detection: (none)");
+                    output.AppendLine(Localizer.Format("#autoLOC_bda_1000032"));
                 if (canLock)
-                    output.AppendLine($"- Lock/Track: {radarLockTrackCurve.Evaluate(radarMaxDistanceLockTrack)} m^2 @ {radarMaxDistanceLockTrack} km");
+                    output.AppendLine(Localizer.Format("#autoLOC_bda_1000033", radarLockTrackCurve.Evaluate(radarMaxDistanceLockTrack), radarMaxDistanceLockTrack));
                 else
-                    output.AppendLine($"- Lock/Track: (none)");
-                output.AppendLine($"- Ground clutter factor: {radarGroundClutterFactor}");
+                    output.AppendLine(Localizer.Format("#autoLOC_bda_1000034"));
+                output.AppendLine(Localizer.Format("#autoLOC_bda_1000035", radarGroundClutterFactor));
             }
 
             return output.ToString();
@@ -1135,7 +1136,7 @@ namespace BDArmory.Modules
             double chargeAvailable = part.RequestResource("ElectricCharge", drainAmount, ResourceFlowMode.ALL_VESSEL);
             if (chargeAvailable < drainAmount * 0.95f)
             {
-                ScreenMessages.PostScreenMessage("Radar Requires EC", 5.0f, ScreenMessageStyle.UPPER_CENTER);
+                ScreenMessages.PostScreenMessage(Localizer.Format("#autoLOC_bda_1000016"), 5.0f, ScreenMessageStyle.UPPER_CENTER);		// #autoLOC_bda_1000016 = Radar Requires EC
                 DisableRadar();
             }
         }


### PR DESCRIPTION
There is an unused localization file with some incorrect syntax. It appears that this was created in #253 along with some C# code to use it (790aae5ab70ba1a859a36e54ffb5e916b9c10c12), but the C# code was lost later in that PR and did not make it to the release. (Noticed thanks to KSP-CKAN/CKAN#2816.)

This pull request fixes the syntax in the .cfg file (the token for substituting a value is `<<1>>` instead of `{0}`, see http://lingoona.com/cgi-bin/grammar#l=en&oh=1), adds several missing strings that were added in the meantime, and re-adds the C# localization changes that use them.