### PR TITLE
fix laser distance

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/Parts/ABL/ABL.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/ABL/ABL.cfg
@@ -75,6 +75,7 @@ MODULE
 	hasFireAnimation = false
 
 	maxEffectiveDistance = 5000
+	maxTargetingRange = 5000
 	maxDeviation = 0.0125
 
 	ammoName = ElectricCharge

--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -701,6 +701,10 @@ namespace BDArmory.Modules
                 if (eWeaponType == WeaponTypes.Laser)
                 {
                     SetupLaserSpecifics();
+                    if (maxTargetingRange < maxEffectiveDistance)
+                    {
+                        maxEffectiveDistance = maxTargetingRange;
+                    }
                 }
             }
             else if (HighLogic.LoadedSceneIsEditor)
@@ -1312,7 +1316,7 @@ namespace BDArmory.Modules
                     {
                         targetDirection = targetPosition + relativeVelocity * Time.fixedDeltaTime * 2 - tf.position;
                         rayDirection = targetDirection;
-                        targetDirectionLR = targetDirection;
+                        targetDirectionLR = targetDirection.normalized;
                     }
 
                     Ray ray = new Ray(tf.position, rayDirection);

--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -1314,7 +1314,7 @@ namespace BDArmory.Modules
                     if (((visualTargetVessel != null && visualTargetVessel.loaded) || slaved)
                         && Vector3.Angle(rayDirection, targetDirection) < 1)
                     {
-                        targetDirection = targetPosition + relativeVelocity * Time.fixedDeltaTime * 2 - tf.position;
+                        targetDirection = targetPosition - tf.position;
                         rayDirection = targetDirection;
                         targetDirectionLR = targetDirection.normalized;
                     }
@@ -1348,7 +1348,7 @@ namespace BDArmory.Modules
 
                         if (Time.time - timeFired > 6 / 120 && BDArmorySettings.BULLET_HITS)
                         {
-                            BulletHitFX.CreateBulletHit(p, hit.point, hit, hit.normal, false, 0, 0);
+                            BulletHitFX.CreateBulletHit(p, laserPoint, hit, hit.normal, false, 0, 0);
                         }
                     }
                     else


### PR DESCRIPTION
- Fix laser renderer to only render out to effective distance.
- Clamp AI range to not fire beyond effective distance.
- Set ABL range to the default 5000.