### PR TITLE
Fixed CoMOffset on Saturn engine

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/Parts/SaturnAL31/SaturnAL31.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/SaturnAL31/SaturnAL31.cfg
@@ -9,7 +9,7 @@
 	}
 	rescaleFactor = 1
 	node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0
-	//CoMOffset = 0.0, 1.5, 0.0
+	CoMOffset = 0.0, 1.2, 0.0
 	TechRequired = supersonicFlight
 	entryCost = 9000
 	cost = 2000


### PR DESCRIPTION
Mistakenly left the CoMOffset commented out.
The new CoMOffset will make it so that if you go from the Squad Panther engine to the Saturn, it should not change your COM much at all.